### PR TITLE
Switch to UUID v7

### DIFF
--- a/src/macros/composer.json
+++ b/src/macros/composer.json
@@ -29,7 +29,7 @@
     "suggest": {
         "league/commonmark": "Required to use (^1.3|^2.0.2)",
         "opis/closure": "Required to use (^3.1)",
-        "ramsey/uuid": "Required to generate UUIDs (^4.0)",
+        "ramsey/uuid": "Required to generate UUIDs (^4.5)",
         "symfony/uid": "Required to generate ULIDs (^6.0).",
         "voku/portable-ascii": "Required to use (^1.4|^1.5)"
     },

--- a/src/macros/output/Hyperf/Utils/Str.php
+++ b/src/macros/output/Hyperf/Utils/Str.php
@@ -134,7 +134,7 @@ class Str
     }
 
     /**
-     * Generate a time-ordered UUID (version 4).
+     * Generate a time-ordered UUID (version 7).
      *
      * @return \Ramsey\Uuid\UuidInterface
      */
@@ -230,7 +230,7 @@ class Str
     }
 
     /**
-     * Generate a UUID (version 4).
+     * Generate a UUID (version 7).
      *
      * @return \Ramsey\Uuid\UuidInterface
      */

--- a/src/macros/src/StrMacros.php
+++ b/src/macros/src/StrMacros.php
@@ -18,10 +18,7 @@ use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
 use League\CommonMark\Extension\InlinesOnly\InlinesOnlyExtension;
 use League\CommonMark\GithubFlavoredMarkdownConverter;
 use League\CommonMark\MarkdownConverter;
-use Ramsey\Uuid\Codec\TimestampFirstCombCodec;
-use Ramsey\Uuid\Generator\CombGenerator;
 use Ramsey\Uuid\Uuid as RamseyUuid;
-use Ramsey\Uuid\UuidFactory;
 use Symfony\Component\Uid\Ulid as SymfonyUlid;
 use voku\helper\ASCII;
 
@@ -202,22 +199,7 @@ class StrMacros
     public function orderedUuid()
     {
         return function () {
-            if (UuidContainer::$uuidFactory) {
-                return call_user_func(UuidContainer::$uuidFactory);
-            }
-
-            $factory = new UuidFactory();
-
-            $factory->setRandomGenerator(new CombGenerator(
-                $factory->getRandomGenerator(),
-                $factory->getNumberConverter()
-            ));
-
-            $factory->setCodec(new TimestampFirstCombCodec(
-                $factory->getUuidBuilder()
-            ));
-
-            return $factory->uuid4();
+            return Str::uuid();
         };
     }
 
@@ -266,7 +248,7 @@ class StrMacros
     {
         return fn () => UuidContainer::$uuidFactory
             ? call_user_func(UuidContainer::$uuidFactory)
-            : RamseyUuid::uuid4();
+            : RamseyUuid::uuid7();
     }
 
     public function wordCount()

--- a/src/model-uid-addon/class_map/Hyperf/Database/Model/Concerns/HasUuids.php
+++ b/src/model-uid-addon/class_map/Hyperf/Database/Model/Concerns/HasUuids.php
@@ -21,7 +21,7 @@ trait HasUuids
      */
     public function newUniqueId()
     {
-        return (string) Str::orderedUuid();
+        return (string) Str::uuid();
     }
 
     /**

--- a/src/model-uid-addon/composer.json
+++ b/src/model-uid-addon/composer.json
@@ -12,7 +12,7 @@
         "hyperf/database": "~3.0.0",
         "hyperf/event": "~3.0.0",
         "hyperf/utils": "~3.0.0",
-        "ramsey/uuid": "^^3.0|^4.0",
+        "ramsey/uuid": "^4.5",
         "symfony/uid": "^5.0|^6.0"
     },
     "autoload": {

--- a/src/model-uid-addon/macros/str.php
+++ b/src/model-uid-addon/macros/str.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
  * @contact  huangdijia@gmail.com
  */
 use Hyperf\Utils\Str;
-use Ramsey\Uuid\Codec\TimestampFirstCombCodec;
-use Ramsey\Uuid\Generator\CombGenerator;
-use Ramsey\Uuid\UuidFactory;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Uid\Ulid;
 
 if (! Str::hasMacro('ulid')) {
@@ -20,19 +18,8 @@ if (! Str::hasMacro('ulid')) {
     });
 }
 
-if (! Str::hasMacro('orderedUuid')) {
-    Str::macro('orderedUuid', function () {
-        $factory = new UuidFactory();
-
-        $factory->setRandomGenerator(new CombGenerator(
-            $factory->getRandomGenerator(),
-            $factory->getNumberConverter()
-        ));
-
-        $factory->setCodec(new TimestampFirstCombCodec(
-            $factory->getUuidBuilder()
-        ));
-
-        return $factory->uuid4();
+if (! Str::hasMacro('uuid')) {
+    Str::macro('uuid', function () {
+        return Uuid::uuid7();
     });
 }

--- a/src/model-uid-addon/output/Hyperf/Utils/Str.php
+++ b/src/model-uid-addon/output/Hyperf/Utils/Str.php
@@ -22,11 +22,11 @@ class Str
     }
 
     /**
-     * Generate a time-ordered UUID (version 4).
+     * Generate a time-ordered UUID (version 7).
      *
      * @return \Ramsey\Uuid\UuidInterface
      */
-    public static function orderedUuid()
+    public static function uuid()
     {
     }
 }


### PR DESCRIPTION
This will switch the default generated UUID's from v4 to v7 for `Hyperf\Utils\Str` v10. Since these are now sortable by default, orderedUuid has become an alias of uuid.