### PR TITLE
fix: fix null tag variable content will cause an error in cbc ciphers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -155,6 +155,7 @@
             "FriendsOfHyperf\\Confd\\": "src/confd/src/",
             "FriendsOfHyperf\\ConfigConsul\\": "src/config-consul/src/",
             "FriendsOfHyperf\\ConsoleSpinner\\": "src/console-spinner/src/",
+            "FriendsOfHyperf\\Encryption\\": "src/encryption/src/",
             "FriendsOfHyperf\\ExceptionEvent\\": "src/exception-event/src/",
             "FriendsOfHyperf\\Facade\\": "src/facade/src/",
             "FriendsOfHyperf\\FastPaginate\\": "src/fast-paginate/src/",
@@ -181,7 +182,6 @@
             "FriendsOfHyperf\\Tinker\\": "src/tinker/src/",
             "FriendsOfHyperf\\Trigger\\": "src/trigger/src/",
             "FriendsOfHyperf\\ValidatedDTO\\": "src/validated-dto/src/",
-            "Friendsofhyperf\\Encryption\\": "src/encryption/src/",
             "Pest\\Hyperf\\": "src/pest-plugin-hyperf/src/"
         }
     },
@@ -203,6 +203,7 @@
                 "FriendsOfHyperf\\Confd\\ConfigProvider",
                 "FriendsOfHyperf\\ConfigConsul\\ConfigProvider",
                 "FriendsOfHyperf\\ConsoleSpinner\\ConfigProvider",
+                "FriendsOfHyperf\\Encryption\\ConfigProvider",
                 "FriendsOfHyperf\\ExceptionEvent\\ConfigProvider",
                 "FriendsOfHyperf\\Facade\\ConfigProvider",
                 "FriendsOfHyperf\\FastPaginate\\ConfigProvider",
@@ -227,8 +228,7 @@
                 "FriendsOfHyperf\\Support\\ConfigProvider",
                 "FriendsOfHyperf\\Tinker\\ConfigProvider",
                 "FriendsOfHyperf\\Trigger\\ConfigProvider",
-                "FriendsOfHyperf\\ValidatedDTO\\ConfigProvider",
-                "Friendsofhyperf\\Encryption\\ConfigProvider"
+                "FriendsOfHyperf\\ValidatedDTO\\ConfigProvider"
             ]
         }
     },

--- a/src/encryption/composer.json
+++ b/src/encryption/composer.json
@@ -22,7 +22,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Friendsofhyperf\\Encryption\\": "src/"
+            "FriendsOfHyperf\\Encryption\\": "src/"
         },
         "files": [
             "src/Functions.php"
@@ -44,7 +44,7 @@
     },
     "extra": {
         "hyperf": {
-            "config": "Friendsofhyperf\\Encryption\\ConfigProvider"
+            "config": "FriendsOfHyperf\\Encryption\\ConfigProvider"
         },
         "branch-alias": {
             "dev-main": "3.1-dev"

--- a/src/encryption/src/ConfigProvider.php
+++ b/src/encryption/src/ConfigProvider.php
@@ -8,9 +8,9 @@ declare(strict_types=1);
  * @document https://github.com/friendsofhyperf/components/blob/main/README.md
  * @contact  huangdijia@gmail.com
  */
-namespace Friendsofhyperf\Encryption;
+namespace FriendsOfHyperf\Encryption;
 
-use Friendsofhyperf\Encryption\Listener\BootEncryptionListener;
+use FriendsOfHyperf\Encryption\Listener\BootEncryptionListener;
 
 class ConfigProvider
 {

--- a/src/encryption/src/Contract/DecryptException.php
+++ b/src/encryption/src/Contract/DecryptException.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @document https://github.com/friendsofhyperf/components/blob/main/README.md
  * @contact  huangdijia@gmail.com
  */
-namespace Friendsofhyperf\Encryption\Contract;
+namespace FriendsOfHyperf\Encryption\Contract;
 
 use RuntimeException;
 

--- a/src/encryption/src/Contract/EncryptException.php
+++ b/src/encryption/src/Contract/EncryptException.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @document https://github.com/friendsofhyperf/components/blob/main/README.md
  * @contact  huangdijia@gmail.com
  */
-namespace Friendsofhyperf\Encryption\Contract;
+namespace FriendsOfHyperf\Encryption\Contract;
 
 use RuntimeException;
 

--- a/src/encryption/src/Contract/Encrypter.php
+++ b/src/encryption/src/Contract/Encrypter.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @document https://github.com/friendsofhyperf/components/blob/main/README.md
  * @contact  huangdijia@gmail.com
  */
-namespace Friendsofhyperf\Encryption\Contract;
+namespace FriendsOfHyperf\Encryption\Contract;
 
 interface Encrypter
 {
@@ -16,7 +16,7 @@ interface Encrypter
      * Encrypt the given value.
      *
      * @param mixed $value
-     * @throws \Friendsofhyperf\Encryption\Contract\EncryptException
+     * @throws \FriendsOfHyperf\Encryption\Contract\EncryptException
      */
     public function encrypt($value, bool $serialize = true): string;
 
@@ -24,7 +24,7 @@ interface Encrypter
      * Decrypt the given value.
      *
      * @return mixed
-     * @throws \Friendsofhyperf\Encryption\Contract\DecryptException
+     * @throws \FriendsOfHyperf\Encryption\Contract\DecryptException
      */
     public function decrypt(string $payload, bool $unserialize = true);
 

--- a/src/encryption/src/Contract/StringEncrypter.php
+++ b/src/encryption/src/Contract/StringEncrypter.php
@@ -8,21 +8,21 @@ declare(strict_types=1);
  * @document https://github.com/friendsofhyperf/components/blob/main/README.md
  * @contact  huangdijia@gmail.com
  */
-namespace Friendsofhyperf\Encryption\Contract;
+namespace FriendsOfHyperf\Encryption\Contract;
 
 interface StringEncrypter
 {
     /**
      * Encrypt a string without serialization.
      *
-     * @throws \Friendsofhyperf\Encryption\Contract\EncryptException
+     * @throws \FriendsOfHyperf\Encryption\Contract\EncryptException
      */
     public function encryptString(string $value): string;
 
     /**
      * Decrypt the given string without unserialization.
      *
-     * @throws \Friendsofhyperf\Encryption\Contract\DecryptException
+     * @throws \FriendsOfHyperf\Encryption\Contract\DecryptException
      */
     public function decryptString(string $payload): string;
 }

--- a/src/encryption/src/Encrypter.php
+++ b/src/encryption/src/Encrypter.php
@@ -71,14 +71,16 @@ class Encrypter implements EncrypterContract, StringEncrypter
     public function encrypt($value, bool $serialize = true): string
     {
         $iv = random_bytes(openssl_cipher_iv_length(strtolower($this->cipher)));
-        $value = \openssl_encrypt(
-            $serialize ? serialize($value) : $value,
-            strtolower($this->cipher),
-            $this->key,
-            0,
-            $iv,
-            $tag
-        );
+        $tag = '';
+        $value = self::$supportedCiphers[strtolower($this->cipher)]['aead']
+            ? \openssl_encrypt(
+                $serialize ? serialize($value) : $value,
+                strtolower($this->cipher), $this->key, 0, $iv, $tag
+            )
+            : \openssl_encrypt(
+                $serialize ? serialize($value) : $value,
+                strtolower($this->cipher), $this->key, 0, $iv
+            );
 
         if ($value === false) {
             throw new EncryptException('Could not encrypt the data.');

--- a/src/encryption/src/Encrypter.php
+++ b/src/encryption/src/Encrypter.php
@@ -90,11 +90,18 @@ class Encrypter implements EncrypterContract, StringEncrypter
         $value = self::$supportedCiphers[strtolower($this->cipher)]['aead']
             ? \openssl_encrypt(
                 $serialize ? serialize($value) : $value,
-                strtolower($this->cipher), $this->key, 0, $iv, $tag
+                strtolower($this->cipher),
+                $this->key,
+                0,
+                $iv,
+                $tag
             )
             : \openssl_encrypt(
                 $serialize ? serialize($value) : $value,
-                strtolower($this->cipher), $this->key, 0, $iv
+                strtolower($this->cipher),
+                $this->key,
+                0,
+                $iv
             );
 
         if ($value === false) {

--- a/src/encryption/src/Encrypter.php
+++ b/src/encryption/src/Encrypter.php
@@ -8,16 +8,26 @@ declare(strict_types=1);
  * @document https://github.com/friendsofhyperf/components/blob/main/README.md
  * @contact  huangdijia@gmail.com
  */
-namespace Friendsofhyperf\Encryption;
+namespace FriendsOfHyperf\Encryption;
 
-use Friendsofhyperf\Encryption\Contract\DecryptException;
-use Friendsofhyperf\Encryption\Contract\Encrypter as EncrypterContract;
-use Friendsofhyperf\Encryption\Contract\EncryptException;
-use Friendsofhyperf\Encryption\Contract\StringEncrypter;
+use FriendsOfHyperf\Encryption\Contract\DecryptException;
+use FriendsOfHyperf\Encryption\Contract\Encrypter as EncrypterContract;
+use FriendsOfHyperf\Encryption\Contract\EncryptException;
+use FriendsOfHyperf\Encryption\Contract\StringEncrypter;
 use RuntimeException;
 
 class Encrypter implements EncrypterContract, StringEncrypter
 {
+    /**
+     * The encryption key.
+     */
+    protected string $key;
+
+    /**
+     * The algorithm used for encryption.
+     */
+    protected string $cipher;
+
     /**
      * The supported cipher algorithms and their properties.
      */
@@ -33,13 +43,18 @@ class Encrypter implements EncrypterContract, StringEncrypter
      *
      * @throws RuntimeException
      */
-    public function __construct(protected string $key, protected string $cipher = 'AES-128-CBC')
+    public function __construct(string $key, string $cipher = 'aes-128-cbc')
     {
+        $key = (string) $key;
+
         if (! static::supported($key, $cipher)) {
             $ciphers = implode(', ', array_keys(self::$supportedCiphers));
 
             throw new RuntimeException("Unsupported cipher or incorrect key length. Supported ciphers are: {$ciphers}.");
         }
+
+        $this->key = $key;
+        $this->cipher = $cipher;
     }
 
     /**
@@ -87,10 +102,12 @@ class Encrypter implements EncrypterContract, StringEncrypter
         }
 
         $iv = base64_encode($iv);
-        $tag = base64_encode($tag);
+        $tag = base64_encode($tag ?? '');
+
         $mac = self::$supportedCiphers[strtolower($this->cipher)]['aead']
-            ? '' // For AEAD-algoritms, the tag / MAC is returned by openssl_encrypt...
+            ? '' // For AEAD-algorithms, the tag / MAC is returned by openssl_encrypt...
             : $this->hash($iv, $value);
+
         $json = json_encode(compact('iv', 'value', 'mac', 'tag'), JSON_UNESCAPED_SLASHES);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
@@ -113,18 +130,17 @@ class Encrypter implements EncrypterContract, StringEncrypter
     /**
      * Decrypt the given value.
      *
-     * @return mixed
      * @throws DecryptException
      */
-    public function decrypt(string $payload, bool $unserialize = true)
+    public function decrypt(string $payload, bool $unserialize = true): mixed
     {
-        $payload = $this->getJsonPayload((string) $payload);
-        $iv = base64_decode($payload['iv']);
-        $tag = empty($payload['tag']) ? null : base64_decode($payload['tag']);
+        $payload = $this->getJsonPayload($payload);
 
-        if (self::$supportedCiphers[strtolower($this->cipher)]['aead'] && strlen($tag) !== 16) {
-            throw new DecryptException('Could not decrypt the data.');
-        }
+        $iv = base64_decode($payload['iv']);
+
+        $this->ensureTagIsValid(
+            $tag = empty($payload['tag']) ? null : base64_decode($payload['tag'])
+        );
 
         // Here we will decrypt the value. If we are able to successfully decrypt it
         // we will then unserialize it and return it out to the caller. If we are
@@ -135,7 +151,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
             $this->key,
             0,
             $iv,
-            $tag
+            $tag ?? ''
         );
 
         if ($decrypted === false) {
@@ -156,7 +172,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
     }
 
     /**
-     * Get the encryption key.
+     * Get the encryption key that the encrypter is currently using.
      */
     public function getKey(): string
     {
@@ -165,11 +181,8 @@ class Encrypter implements EncrypterContract, StringEncrypter
 
     /**
      * Create a MAC for the given value.
-     *
-     * @param string $iv
-     * @param mixed $value
      */
-    protected function hash($iv, $value): string
+    protected function hash(string $iv, mixed $value): string
     {
         return hash_hmac('sha256', $iv . $value, $this->key);
     }
@@ -181,7 +194,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
      */
     protected function getJsonPayload(string $payload): array
     {
-        $payload = json_decode(base64_decode($payload), true, 512, JSON_THROW_ON_ERROR);
+        $payload = json_decode(base64_decode($payload), true);
 
         // If the payload is not valid JSON or does not have the proper keys set we will
         // assume it is invalid and bail out of the routine since we will not be able
@@ -199,13 +212,24 @@ class Encrypter implements EncrypterContract, StringEncrypter
 
     /**
      * Verify that the encryption payload is valid.
-     *
-     * @param mixed $payload
      */
-    protected function validPayload($payload): bool
+    protected function validPayload(mixed $payload): bool
     {
-        return is_array($payload) && isset($payload['iv'], $payload['value'], $payload['mac'])
-            && strlen(base64_decode($payload['iv'], true)) === openssl_cipher_iv_length(strtolower($this->cipher));
+        if (! is_array($payload)) {
+            return false;
+        }
+
+        foreach (['iv', 'value', 'mac'] as $item) {
+            if (! isset($payload[$item]) || ! is_string($payload[$item])) {
+                return false;
+            }
+        }
+
+        if (isset($payload['tag']) && ! is_string($payload['tag'])) {
+            return false;
+        }
+
+        return strlen((string) base64_decode($payload['iv'], true)) === openssl_cipher_iv_length(strtolower($this->cipher));
     }
 
     /**
@@ -217,5 +241,19 @@ class Encrypter implements EncrypterContract, StringEncrypter
             $this->hash($payload['iv'], $payload['value']),
             $payload['mac']
         );
+    }
+
+    /**
+     * Ensure the given tag is a valid tag given the selected cipher.
+     */
+    protected function ensureTagIsValid(?string $tag)
+    {
+        if (self::$supportedCiphers[strtolower($this->cipher)]['aead'] && strlen($tag) !== 16) {
+            throw new DecryptException('Could not decrypt the data.');
+        }
+
+        if (! self::$supportedCiphers[strtolower($this->cipher)]['aead'] && is_string($tag)) {
+            throw new DecryptException('Unable to use tag because the cipher algorithm does not support AEAD.');
+        }
     }
 }

--- a/src/encryption/src/EncrypterFactory.php
+++ b/src/encryption/src/EncrypterFactory.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @document https://github.com/friendsofhyperf/components/blob/main/README.md
  * @contact  huangdijia@gmail.com
  */
-namespace Friendsofhyperf\Encryption;
+namespace FriendsOfHyperf\Encryption;
 
 use Hyperf\Contract\ConfigInterface;
 use Psr\Container\ContainerInterface;

--- a/src/encryption/src/Exception/MissingKeyException.php
+++ b/src/encryption/src/Exception/MissingKeyException.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @document https://github.com/friendsofhyperf/components/blob/main/README.md
  * @contact  huangdijia@gmail.com
  */
-namespace Friendsofhyperf\Encryption\Exception;
+namespace FriendsOfHyperf\Encryption\Exception;
 
 use RuntimeException;
 

--- a/src/encryption/src/Functions.php
+++ b/src/encryption/src/Functions.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @document https://github.com/friendsofhyperf/components/blob/main/README.md
  * @contact  huangdijia@gmail.com
  */
-namespace Friendsofhyperf\Encryption;
+namespace FriendsOfHyperf\Encryption;
 
 use Hyperf\Context\ApplicationContext;
 

--- a/src/encryption/src/KeyParser.php
+++ b/src/encryption/src/KeyParser.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @document https://github.com/friendsofhyperf/components/blob/main/README.md
  * @contact  huangdijia@gmail.com
  */
-namespace Friendsofhyperf\Encryption;
+namespace FriendsOfHyperf\Encryption;
 
 use Hyperf\Stringable\Str;
 use RuntimeException;

--- a/src/encryption/src/Listener/BootEncryptionListener.php
+++ b/src/encryption/src/Listener/BootEncryptionListener.php
@@ -8,12 +8,12 @@ declare(strict_types=1);
  * @document https://github.com/friendsofhyperf/components/blob/main/README.md
  * @contact  huangdijia@gmail.com
  */
-namespace Friendsofhyperf\Encryption\Listener;
+namespace FriendsOfHyperf\Encryption\Listener;
 
-use Friendsofhyperf\Encryption\Contract\Encrypter as EncrypterInterface;
-use Friendsofhyperf\Encryption\Contract\StringEncrypter;
-use Friendsofhyperf\Encryption\Encrypter;
-use Friendsofhyperf\Encryption\KeyParser;
+use FriendsOfHyperf\Encryption\Contract\Encrypter as EncrypterInterface;
+use FriendsOfHyperf\Encryption\Contract\StringEncrypter;
+use FriendsOfHyperf\Encryption\Encrypter;
+use FriendsOfHyperf\Encryption\KeyParser;
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Di\Container;
 use Hyperf\Event\Contract\ListenerInterface;

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of friendsofhyperf/components.
+ *
+ * @link     https://github.com/friendsofhyperf/components
+ * @document https://github.com/friendsofhyperf/components/blob/main/README.md
+ * @contact  huangdijia@gmail.com
+ */
+namespace FriendsOfHyperf\Tests\Encryption;
+
+use FriendsOfHyperf\Encryption\Contract\DecryptException;
+use FriendsOfHyperf\Encryption\Encrypter;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class EncrypterTest extends TestCase
+{
+    public function testEncryption()
+    {
+        $e = new Encrypter(str_repeat('a', 16));
+        $encrypted = $e->encrypt('foo');
+        $this->assertNotSame('foo', $encrypted);
+        $this->assertSame('foo', $e->decrypt($encrypted));
+    }
+
+    public function testRawStringEncryption()
+    {
+        $e = new Encrypter(str_repeat('a', 16));
+        $encrypted = $e->encryptString('foo');
+        $this->assertNotSame('foo', $encrypted);
+        $this->assertSame('foo', $e->decryptString($encrypted));
+    }
+
+    public function testEncryptionUsingBase64EncodedKey()
+    {
+        $e = new Encrypter(random_bytes(16));
+        $encrypted = $e->encrypt('foo');
+        $this->assertNotSame('foo', $encrypted);
+        $this->assertSame('foo', $e->decrypt($encrypted));
+    }
+
+    public function testEncryptedLengthIsFixed()
+    {
+        $e = new Encrypter(str_repeat('a', 16));
+        $lengths = [];
+        for ($i = 0; $i < 100; ++$i) {
+            $lengths[] = strlen($e->encrypt('foo'));
+        }
+        $this->assertSame(min($lengths), max($lengths));
+    }
+
+    public function testWithCustomCipher()
+    {
+        $e = new Encrypter(str_repeat('b', 32), 'AES-256-GCM');
+        $encrypted = $e->encrypt('bar');
+        $this->assertNotSame('bar', $encrypted);
+        $this->assertSame('bar', $e->decrypt($encrypted));
+
+        $e = new Encrypter(random_bytes(32), 'AES-256-GCM');
+        $encrypted = $e->encrypt('foo');
+        $this->assertNotSame('foo', $encrypted);
+        $this->assertSame('foo', $e->decrypt($encrypted));
+    }
+
+    public function testCipherNamesCanBeMixedCase()
+    {
+        $upper = new Encrypter(str_repeat('b', 16), 'AES-128-GCM');
+        $encrypted = $upper->encrypt('bar');
+        $this->assertNotSame('bar', $encrypted);
+
+        $lower = new Encrypter(str_repeat('b', 16), 'aes-128-gcm');
+        $this->assertSame('bar', $lower->decrypt($encrypted));
+
+        $mixed = new Encrypter(str_repeat('b', 16), 'aEs-128-GcM');
+        $this->assertSame('bar', $mixed->decrypt($encrypted));
+    }
+
+    public function testThatAnAeadCipherIncludesTag()
+    {
+        $e = new Encrypter(str_repeat('b', 32), 'AES-256-GCM');
+        $encrypted = $e->encrypt('foo');
+        $data = json_decode(base64_decode($encrypted));
+
+        $this->assertEmpty($data->mac);
+        $this->assertNotEmpty($data->tag);
+    }
+
+    public function testThatAnAeadTagMustBeProvidedInFullLength()
+    {
+        $e = new Encrypter(str_repeat('b', 32), 'AES-256-GCM');
+        $encrypted = $e->encrypt('foo');
+        $data = json_decode(base64_decode($encrypted));
+
+        $this->expectException(DecryptException::class);
+        $this->expectExceptionMessage('Could not decrypt the data.');
+
+        $data->tag = substr($data->tag, 0, 4);
+        $encrypted = base64_encode(json_encode($data));
+        $e->decrypt($encrypted);
+    }
+
+    public function testThatAnAeadTagCantBeModified()
+    {
+        $e = new Encrypter(str_repeat('b', 32), 'AES-256-GCM');
+        $encrypted = $e->encrypt('foo');
+        $data = json_decode(base64_decode($encrypted));
+
+        $this->expectException(DecryptException::class);
+        $this->expectExceptionMessage('Could not decrypt the data.');
+
+        $data->tag[0] = $data->tag[0] === 'A' ? 'B' : 'A';
+        $encrypted = base64_encode(json_encode($data));
+        $e->decrypt($encrypted);
+    }
+
+    public function testThatANonAeadCipherIncludesMac()
+    {
+        $e = new Encrypter(str_repeat('b', 32), 'AES-256-CBC');
+        $encrypted = $e->encrypt('foo');
+        $data = json_decode(base64_decode($encrypted));
+
+        $this->assertEmpty($data->tag);
+        $this->assertNotEmpty($data->mac);
+    }
+
+    public function testDoNoAllowLongerKey()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
+
+        new Encrypter(str_repeat('z', 32));
+    }
+
+    public function testWithBadKeyLength()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
+
+        new Encrypter(str_repeat('a', 5));
+    }
+
+    public function testWithBadKeyLengthAlternativeCipher()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
+
+        new Encrypter(str_repeat('a', 16), 'AES-256-GCM');
+    }
+
+    public function testWithUnsupportedCipher()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
+
+        new Encrypter(str_repeat('c', 16), 'AES-256-CFB8');
+    }
+
+    public function testExceptionThrownWhenPayloadIsInvalid()
+    {
+        $this->expectException(DecryptException::class);
+        $this->expectExceptionMessage('The payload is invalid.');
+
+        $e = new Encrypter(str_repeat('a', 16));
+        $payload = $e->encrypt('foo');
+        $payload = str_shuffle($payload);
+        $e->decrypt($payload);
+    }
+
+    public function testDecryptionExceptionIsThrownWhenUnexpectedTagIsAdded()
+    {
+        $this->expectException(DecryptException::class);
+        $this->expectExceptionMessage('Unable to use tag because the cipher algorithm does not support AEAD.');
+
+        $e = new Encrypter(str_repeat('a', 16));
+        $payload = $e->encrypt('foo');
+        $decodedPayload = json_decode(base64_decode($payload));
+        $decodedPayload->tag = 'set-manually';
+        $e->decrypt(base64_encode(json_encode($decodedPayload)));
+    }
+
+    public function testExceptionThrownWithDifferentKey()
+    {
+        $this->expectException(DecryptException::class);
+        $this->expectExceptionMessage('The MAC is invalid.');
+
+        $a = new Encrypter(str_repeat('a', 16));
+        $b = new Encrypter(str_repeat('b', 16));
+        $b->decrypt($a->encrypt('baz'));
+    }
+
+    public function testExceptionThrownWhenIvIsTooLong()
+    {
+        $this->expectException(DecryptException::class);
+        $this->expectExceptionMessage('The payload is invalid.');
+
+        $e = new Encrypter(str_repeat('a', 16));
+        $payload = $e->encrypt('foo');
+        $data = json_decode(base64_decode($payload), true);
+        $data['iv'] .= $data['value'][0];
+        $data['value'] = substr($data['value'], 1);
+        $modified_payload = base64_encode(json_encode($data));
+        $e->decrypt($modified_payload);
+    }
+
+    public function testSupportedMethodAcceptsAnyCasing()
+    {
+        $key = str_repeat('a', 16);
+
+        $this->assertTrue(Encrypter::supported($key, 'AES-128-GCM'));
+        $this->assertTrue(Encrypter::supported($key, 'aes-128-CBC'));
+        $this->assertTrue(Encrypter::supported($key, 'aes-128-cbc'));
+    }
+
+    public static function provideTamperedData()
+    {
+        $validIv = base64_encode(str_repeat('.', 16));
+
+        return [
+            [['iv' => ['value_in_array'], 'value' => '', 'mac' => '']],
+            [['iv' => new class() {}, 'value' => '', 'mac' => '']],
+            [['iv' => $validIv, 'value' => ['value_in_array'], 'mac' => '']],
+            [['iv' => $validIv, 'value' => new class() {}, 'mac' => '']],
+            [['iv' => $validIv, 'value' => '', 'mac' => ['value_in_array']]],
+            [['iv' => $validIv, 'value' => '', 'mac' => null]],
+            [['iv' => $validIv, 'value' => '', 'mac' => '', 'tag' => ['value_in_array']]],
+            [['iv' => $validIv, 'value' => '', 'mac' => '', 'tag' => -1]],
+        ];
+    }
+
+    /**
+     * @dataProvider provideTamperedData
+     * @param mixed $payload
+     */
+    public function testTamperedPayloadWillGetRejected($payload)
+    {
+        $this->expectException(DecryptException::class);
+        $this->expectExceptionMessage('The payload is invalid.');
+
+        $enc = new Encrypter(str_repeat('x', 16));
+        $enc->decrypt(base64_encode(json_encode($payload)));
+    }
+}


### PR DESCRIPTION
For those ciphers which don't support ahead (eg. `aes-256-cbc`), it will throw an error in base64 encode with null content.
```
TypeError  base64_encode(): Argument #1 ($string) must be of type string, null given.
```

`$tag` value will be assigned when aead is supported. 