### PR TITLE
model-factory: add examples to docs, change dir and file names to match seeders/migraitons

### DIFF
--- a/src/model-factory/README.md
+++ b/src/model-factory/README.md
@@ -1,30 +1,92 @@
 # model-factory
 
-[![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/model-factory)](https://packagist.org/packages/friendsofhyperf/model-factory)
-[![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/model-factory)](https://packagist.org/packages/friendsofhyperf/model-factory)
+[![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/model-factory)](https://packagist.org/packages/friendsofhyperf/model-factory)  
+[![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/model-factory)](https://packagist.org/packages/friendsofhyperf/model-factory)  
 [![License](https://img.shields.io/packagist/l/friendsofhyperf/model-factory)](https://github.com/friendsofhyperf/model-factory)
 
 ## Installation
 
 Install the package with Composer:
 
-```shell
+```
 composer require friendsofhyperf/model-factory --dev
 ```
 
 Also, publish the vendor config files to your application (necessary for the dependencies):
 
-```shell
+```
 php bin/hyperf.php vendor:publish friendsofhyperf/model-factory
+```
+
+## Example usage
+
+`/factories/user_factory.php`
+
+```
+<?php
+
+
+declare(strict_types=1);
+/**
+ * This file is part of friendsofhyperf/components.
+ *
+ * @link     https://github.com/friendsofhyperf/components
+ * @document https://github.com/friendsofhyperf/components/blob/3.0/README.md
+ * @contact  huangdijia@gmail.com
+ */
+use App\Model\User;
+
+
+$factory->define(User::class, function (Faker\Generator $faker) {
+    return [
+        'name' => $faker->name,
+        'email' => $faker->unique()->email,
+    ];
+});
+```
+
+`/seeders/user_seeder.php`
+
+
+
+```
+<?php
+
+declare(strict_types=1);
+
+use Hyperf\Database\Seeders\Seeder;
+use App\Model\User;
+use function FriendsOfHyperf\ModelFactory\factory;
+
+class UserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run(): void
+    {
+		// Create 1 user with name 'Admin'
+        factory(User::class)->create([
+            'name' => 'Admin'
+        ]);
+
+
+		// Create 20 random users
+        factory(User::class, 20)->create();
+    }
+}
+
 ```
 
 ## Donate
 
 > If you like them, Buy me a cup of coffee.
 
-| Alipay | WeChat |
-|  ----  | ----  |
-| <img src="https://hdj.me/images/alipay-min.jpg" width="200" height="200" />  | <img src="https://hdj.me/images/wechat-pay-min.jpg" width="200" height="200" /> |
+| Alipay                                    | WeChat                                        |
+| ----------------------------------------- | --------------------------------------------- |
+| ![](https://hdj.me/images/alipay-min.jpg) | ![](https://hdj.me/images/wechat-pay-min.jpg) |
 
 ## Contact
 

--- a/src/model-factory/README.md
+++ b/src/model-factory/README.md
@@ -1,20 +1,20 @@
 # model-factory
 
-[![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/model-factory)](https://packagist.org/packages/friendsofhyperf/model-factory)  
-[![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/model-factory)](https://packagist.org/packages/friendsofhyperf/model-factory)  
+[![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/model-factory)](https://packagist.org/packages/friendsofhyperf/model-factory)
+[![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/model-factory)](https://packagist.org/packages/friendsofhyperf/model-factory)
 [![License](https://img.shields.io/packagist/l/friendsofhyperf/model-factory)](https://github.com/friendsofhyperf/model-factory)
 
 ## Installation
 
 Install the package with Composer:
 
-```
+```shell
 composer require friendsofhyperf/model-factory --dev
 ```
 
 Also, publish the vendor config files to your application (necessary for the dependencies):
 
-```
+```shell
 php bin/hyperf.php vendor:publish friendsofhyperf/model-factory
 ```
 
@@ -22,7 +22,7 @@ php bin/hyperf.php vendor:publish friendsofhyperf/model-factory
 
 `/factories/user_factory.php`
 
-```
+```php
 <?php
 
 
@@ -47,9 +47,7 @@ $factory->define(User::class, function (Faker\Generator $faker) {
 
 `/seeders/user_seeder.php`
 
-
-
-```
+```php
 <?php
 
 declare(strict_types=1);
@@ -67,13 +65,13 @@ class UserSeeder extends Seeder
      */
     public function run(): void
     {
-		// Create 1 user with name 'Admin'
+        // Create 1 user with name 'Admin'
         factory(User::class)->create([
             'name' => 'Admin'
         ]);
 
 
-		// Create 20 random users
+        // Create 20 random users
         factory(User::class, 20)->create();
     }
 }
@@ -84,9 +82,9 @@ class UserSeeder extends Seeder
 
 > If you like them, Buy me a cup of coffee.
 
-| Alipay                                    | WeChat                                        |
-| ----------------------------------------- | --------------------------------------------- |
-| ![](https://hdj.me/images/alipay-min.jpg) | ![](https://hdj.me/images/wechat-pay-min.jpg) |
+| Alipay | WeChat |
+|  ----  | ----  |
+| <img src="https://hdj.me/images/alipay-min.jpg" width="200" height="200" />  | <img src="https://hdj.me/images/wechat-pay-min.jpg" width="200" height="200" /> |
 
 ## Contact
 

--- a/src/model-factory/publish/model_factory.php
+++ b/src/model-factory/publish/model_factory.php
@@ -9,5 +9,5 @@ declare(strict_types=1);
  * @contact  huangdijia@gmail.com
  */
 return [
-    'path' => BASE_PATH . '/database/factory/',
+    'path' => BASE_PATH . '/factories/',
 ];

--- a/src/model-factory/src/ConfigProvider.php
+++ b/src/model-factory/src/ConfigProvider.php
@@ -31,7 +31,7 @@ class ConfigProvider
                     'id' => 'model_factory_example',
                     'description' => 'The example for model factory.',
                     'source' => __DIR__ . '/../publish/example.php.stub',
-                    'destination' => BASE_PATH . '/database/factory/ModelFactory.php',
+                    'destination' => BASE_PATH . '/factories/model_factory.php',
                 ],
             ],
         ];


### PR DESCRIPTION
Hi

- I added some usage examples to the docs
- I suggest changing the example starter file to snake_case to match seeder and migration file names, so there is no confusion that the class is not autoloaded. 
- I suggest changing the default directory to `/factories` to match `/seeders` and `/migrations`