### PR TITLE
Fix preg_replace_array

### DIFF
--- a/src/helpers/src/Functions.php
+++ b/src/helpers/src/Functions.php
@@ -369,10 +369,11 @@ function object_get($object, $key = '', $default = null)
  */
 function preg_replace_array(string $pattern, array $replacements, string $subject): string
 {
-    return preg_replace_callback($pattern, function () use (&$replacements) {
-        foreach ($replacements as $key => $value) {
+    return preg_replace_callback($pattern, function ($matches) use (&$replacements) {
+        if (! empty($replacements)) {
             return array_shift($replacements);
         }
+        return $matches[0];
     }, $subject);
 }
 


### PR DESCRIPTION
```    
        // bug 复现
        $pattern = '/\d+/';
        $replacements = ['one', 'two'];
        $subject = '1 2 3';
        $result = preg_replace_array($pattern, $replacements, $subject);
        // 预期输出：one two 3 
        // 实际输出 one two
```
