### PR TITLE
Refactor TagManager to use getTags method

### DIFF
--- a/src/sentry/src/Tracing/TagManager.php
+++ b/src/sentry/src/Tracing/TagManager.php
@@ -26,12 +26,9 @@ class TagManager
         }
 
         [$type, $key] = explode('.', $key, 2);
+        $tags = $this->getTags($type);
 
-        $config = $this->config->get(
-            $this->buildTagKey($type)
-        );
-
-        return isset($config[$key]);
+        return isset($tags[$key]);
     }
 
     public function get(string $key): string
@@ -41,16 +38,16 @@ class TagManager
         }
 
         [$type, $key] = explode('.', $key, 2);
+        $tags = $this->getTags($type);
 
-        $config = $this->config->get(
-            $this->buildTagKey($type)
-        );
-
-        return $config[$key] ?? $type . '.' . $key;
+        return $tags[$key] ?? $type . '.' . $key;
     }
 
-    private function buildTagKey(string $type): string
+    private function getTags(string $type, mixed $default = []): array
     {
-        return sprintf('sentry.tracing.tags.%s', $type);
+        return $this->config->get(
+            sprintf('sentry.tracing.tags.%s', $type),
+            $default
+        );
     }
 }


### PR DESCRIPTION
This commit refactors the TagManager class in the Tracing namespace to use the newly introduced getTags method. This simplifies the code by removing the need to call the buildTagKey method and directly retrieves the tags from the configuration.