### PR TITLE
使用SwooleFileStream时,导致isSeekable报错

### DIFF
--- a/src/telescope/src/Listener/RequestHandledListener.php
+++ b/src/telescope/src/Listener/RequestHandledListener.php
@@ -29,6 +29,7 @@ use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Swow\Psr7\Message\ResponsePlusInterface;
+use Throwable;
 
 use function Hyperf\Collection\collect;
 use function Hyperf\Config\config;
@@ -129,8 +130,8 @@ class RequestHandledListener implements ListenerInterface
             }
 
             $content = $stream->getContents();
-        }catch (\Throwable $e){
-            return 'Purged By Hyperf Telescope: '.$e->getMessage();
+        }catch (Throwable $e){
+            return 'Purged By Hyperf Telescope: '. $e->getMessage();
         }
 
         if (is_string($content)) {

--- a/src/telescope/src/Listener/RequestHandledListener.php
+++ b/src/telescope/src/Listener/RequestHandledListener.php
@@ -123,11 +123,15 @@ class RequestHandledListener implements ListenerInterface
     {
         $stream = $response->getBody();
 
-        if ($stream->isSeekable()) {
-            $stream->rewind();
-        }
+        try {
+            if ($stream->isSeekable()) {
+                $stream->rewind();
+            }
 
-        $content = $stream->getContents();
+            $content = $stream->getContents();
+        }catch (\Throwable $e){
+            return 'Purged By Hyperf Telescope: '.$e->getMessage();
+        }
 
         if (is_string($content)) {
             if (! $this->contentWithinLimits($content)) {

--- a/src/telescope/src/Listener/RequestHandledListener.php
+++ b/src/telescope/src/Listener/RequestHandledListener.php
@@ -130,8 +130,8 @@ class RequestHandledListener implements ListenerInterface
             }
 
             $content = $stream->getContents();
-        }catch (Throwable $e){
-            return 'Purged By Hyperf Telescope: '. $e->getMessage();
+        } catch (Throwable $e) {
+            return 'Purged By Hyperf Telescope: ' . $e->getMessage();
         }
 
         if (is_string($content)) {


### PR DESCRIPTION
SwooleFileStream未适配isSeekable

复现代码
```
$stream = new SwooleFileStream($filePath);
$this->response->withBody($stream);
```

错误信息
```
[WARNING] [Coroutine::printLog] BadMethodCallException: Not implemented in /vendor/hyperf/http-message/src/Stream/SwooleFileStream.php:119
Stack trace:
#0 /vendor/friendsofhyperf/telescope/src/Listener/RequestHandledListener.php(127): Hyperf\HttpMessage\Stream\SwooleFileStream->isSeekable()
#1 /vendor/friendsofhyperf/telescope/src/Listener/RequestHandledListener.php(100): FriendsOfHyperf\Telescope\Listener\RequestHandledListener->getResponsePayload(Object(Hyperf\HttpMessage\Server\ResponsePlusProxy))
#2 /vendor/friendsofhyperf/telescope/src/Listener/RequestHandledListener.php(61): FriendsOfHyperf\Telescope\Listener\RequestHandledListener->requestHandled(Object(Hyperf\HttpServer\Event\RequestTerminated))
#3 /runtime/container/proxy/Hyperf_Event_EventDispatcher.proxy.php(38): FriendsOfHyperf\Telescope\Listener\RequestHandledListener->process(Object(Hyperf\HttpServer\Event\RequestTerminated))
#4 /vendor/hyperf/di/src/Aop/ProceedingJoinPoint.php(56): Hyperf\Event\EventDispatcher->Hyperf\Event\{closure}(Object(Hyperf\HttpServer\Event\RequestTerminated))
#5 /vendor/hyperf/di/src/Aop/ProxyTrait.php(86): Hyperf\Di\Aop\ProceedingJoinPoint->processOriginalMethod()
#6 /vendor/hyperf/pipeline/src/Pipeline.php(97): Hyperf\Event\EventDispatcher::Hyperf\Di\Aop\{closure}(Object(Hyperf\Di\Aop\ProceedingJoinPoint))
#7 /vendor/hyperf/di/src/Aop/ProceedingJoinPoint.php(45): Hyperf\Pipeline\Pipeline::Hyperf\Pipeline\{closure}(Object(Hyperf\Di\Aop\ProceedingJoinPoint))
#8 /vendor/friendsofhyperf/telescope/src/Aspect/EventAspect.php(39): Hyperf\Di\Aop\ProceedingJoinPoint->process()
#9 /vendor/hyperf/di/src/Aop/Pipeline.php(30): FriendsOfHyperf\Telescope\Aspect\EventAspect->process(Object(Hyperf\Di\Aop\ProceedingJoinPoint))
#10 /vendor/hyperf/pipeline/src/Pipeline.php(80): Hyperf\Di\Aop\Pipeline->Hyperf\Di\Aop\{closure}(Object(Hyperf\Di\Aop\ProceedingJoinPoint))
#11 /vendor/hyperf/di/src/Aop/ProxyTrait.php(87): Hyperf\Pipeline\Pipeline->then(Object(Closure))
#12 /vendor/hyperf/di/src/Aop/ProxyTrait.php(30): Hyperf\Event\EventDispatcher::handleAround(Object(Hyperf\Di\Aop\ProceedingJoinPoint))
#13 /runtime/container/proxy/Hyperf_Event_EventDispatcher.proxy.php(45): Hyperf\Event\EventDispatcher::__proxyCall('Hyperf\\Event\\Ev...', 'dispatch', Array, Object(Closure))
#14 /vendor/hyperf/http-server/src/Server.php(125): Hyperf\Event\EventDispatcher->dispatch(Object(Hyperf\HttpServer\Event\RequestTerminated))
#15 /runtime/container/proxy/Hyperf_Coroutine_Coroutine.proxy.php(42): Hyperf\HttpServer\Server->Hyperf\HttpServer\{closure}()
#16 [internal function]: Hyperf\Coroutine\Coroutine::Hyperf\Coroutine\{closure}(NULL)
#17 {main}

```