### PR TITLE
feat: Improve error handling in ProfileFactory

### DIFF
--- a/src/http-logger/src/Profile/ProfileFactory.php
+++ b/src/http-logger/src/Profile/ProfileFactory.php
@@ -13,6 +13,7 @@ namespace FriendsOfHyperf\Http\Logger\Profile;
 
 use Hyperf\Contract\ConfigInterface;
 use Psr\Container\ContainerInterface;
+use RuntimeException;
 
 use function Hyperf\Support\make;
 
@@ -22,6 +23,10 @@ class ProfileFactory
     {
         $config = $container->get(ConfigInterface::class);
         $class = $config->get('http_logger.log_profile', DefaultLogProfile::class);
+
+        if (! is_a($class, LogProfile::class, true)) {
+            throw new RuntimeException(sprintf('Invalid log profile class %s', $class));
+        }
 
         return make($class);
     }

--- a/src/http-logger/src/Writer/WriterFactory.php
+++ b/src/http-logger/src/Writer/WriterFactory.php
@@ -13,6 +13,7 @@ namespace FriendsOfHyperf\Http\Logger\Writer;
 
 use Hyperf\Contract\ConfigInterface;
 use Psr\Container\ContainerInterface;
+use RuntimeException;
 
 use function Hyperf\Support\make;
 
@@ -22,6 +23,10 @@ class WriterFactory
     {
         $config = $container->get(ConfigInterface::class);
         $class = $config->get('http_logger.log_writer', DefaultLogWriter::class);
+
+        if (! is_a($class, LogWriter::class, true)) {
+            throw new RuntimeException(sprintf('Invalid log writer class %s', $class));
+        }
 
         return make($class);
     }


### PR DESCRIPTION
Refactor the ProfileFactory class to include error handling when validating the log profile class. If an invalid log profile class is provided, a RuntimeException is thrown with a corresponding error message.

Co-authored-by: Deeka Wong