### PR TITLE
Optimized `MailManager::createSmtpTransport`

### DIFF
--- a/src/mail/src/MailManager.php
+++ b/src/mail/src/MailManager.php
@@ -203,7 +203,6 @@ class MailManager implements Factory
     protected function createSmtpTransport(array $config): EsmtpTransport
     {
         $factory = new EsmtpTransportFactory();
-
         $scheme = $config['scheme'] ?? null;
 
         if (! $scheme) {
@@ -215,10 +214,10 @@ class MailManager implements Factory
         /** @var EsmtpTransport $transport */
         $transport = $factory->create(new Dsn(
             $scheme,
-            $config['host'],
-            $config['username'] ?? null,
-            $config['password'] ?? null,
-            $config['port'] ?? null,
+            (string) $config['host'],
+            isset($config['username']) ? ((string) $config['username']) : null,
+            isset($config['password']) ? ((string) $config['password']) : null,
+            isset($config['port']) ? ((int) $config['port']) : null,
             $config
         ));
 

--- a/src/mail/src/MailManager.php
+++ b/src/mail/src/MailManager.php
@@ -216,9 +216,9 @@ class MailManager implements Factory
         $transport = $factory->create(new Dsn(
             $scheme,
             $config['host'],
-            $config['username'] ?? null,
-            $config['password'] ?? null,
-            $config['port'] ?? null,
+            (string)Arr::get($config,'username'),
+            (string)Arr::get($config,'password'),
+            (int)Arr::get($config,'port'),
             $config
         ));
 

--- a/src/mail/src/MailManager.php
+++ b/src/mail/src/MailManager.php
@@ -216,9 +216,9 @@ class MailManager implements Factory
         $transport = $factory->create(new Dsn(
             $scheme,
             $config['host'],
-            (string)Arr::get($config,'username'),
-            (string)Arr::get($config,'password'),
-            (int)Arr::get($config,'port'),
+            $config['username'] ?? null,
+            $config['password'] ?? null,
+            $config['port'] ?? null,
             $config
         ));
 


### PR DESCRIPTION
当 `mail.mailers.smtp.url` dsn  配置为 `smtp://2771717608:xxx@smtp.qq.com:465` 时，会将 username 解析成 int 类型。导致报错。考虑使用 Arr::get 强转