### PR TITLE
fix(bugs): all coroutines are asleep - deadlock!

### DIFF
--- a/src/sentry/src/HttpClient/HttpClient.php
+++ b/src/sentry/src/HttpClient/HttpClient.php
@@ -73,6 +73,8 @@ class HttpClient extends \Sentry\HttpClient\HttpClient
             return;
         }
 
+        CoordinatorManager::until(Constants::WORKER_START)->yield();
+
         $this->chan = new Channel($this->channelSize);
 
         Coroutine::create(function () {


### PR DESCRIPTION
===================================================================
 [FATAL ERROR]: all coroutines (count: 2) are asleep - deadlock!

===================================================================

 [Coroutine-1]
--------------------------------------------------------------------
#0 /xx/vendor/hyperf/engine/src/Channel.php(41): Swoole\Coroutine\Channel->pop()
#1 /xx/vendor/friendsofhyperf/sentry/src/HttpClient/HttpClient.php(83): Hyperf\Engine\Channel->pop()
#2 [internal function]: FriendsOfHyperf\Sentry\HttpClient\HttpClient->FriendsOfHyperf\Sentry\HttpClient\{closure}()

