### PR TITLE
Remove macro `Arr::shuffleAssoc`

### DIFF
--- a/src/macros/composer.json
+++ b/src/macros/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "friendsofhyperf/support": "~3.1.0",
-        "hyperf/collection": "~3.1.23",
+        "hyperf/collection": "~3.1.45",
         "hyperf/macroable": "~3.1.0",
         "hyperf/stringable": "~3.1.20",
         "hyperf/support": "~3.1.0",

--- a/src/macros/output/Hyperf/Collection/Arr.php
+++ b/src/macros/output/Hyperf/Collection/Arr.php
@@ -14,17 +14,6 @@ namespace Hyperf\Collection;
 class Arr
 {
     /**
-     * Shuffle an associative array.
-     *
-     * @param array $array
-     * @param int|null $seed
-     * @return array
-     */
-    public static function shuffleAssoc($array, $seed = null)
-    {
-    }
-
-    /**
      * Sort given array by many properties.
      *
      * @param array $array

--- a/src/macros/src/ArrMixin.php
+++ b/src/macros/src/ArrMixin.php
@@ -18,25 +18,6 @@ use Hyperf\Collection\Arr;
  */
 class ArrMixin
 {
-    public function shuffleAssoc()
-    {
-        return function ($array, $seed = null) {
-            if (empty($array)) {
-                return $array;
-            }
-
-            $keys = array_keys($array);
-            $keys = Arr::shuffle($keys, $seed);
-            $shuffled = [];
-
-            foreach ($keys as $key) {
-                $shuffled[$key] = $array[$key];
-            }
-
-            return $shuffled;
-        };
-    }
-
     public function sortByMany()
     {
         return function ($array, $comparisons = []) {

--- a/tests/Macros/ArrTest.php
+++ b/tests/Macros/ArrTest.php
@@ -10,34 +10,6 @@ declare(strict_types=1);
  */
 use Hyperf\Collection\Arr;
 
-test('test shuffleAssoc', function () {
-    $array = ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5];
-    $shuffled = Arr::shuffleAssoc($array);
-
-    expect($shuffled)->not->toBe($array)
-        ->toBeArray()
-        ->toHaveKey('a')
-        ->toHaveKey('b')
-        ->toHaveKey('c')
-        ->toHaveKey('d')
-        ->toHaveKey('e')
-        ->toHaveCount(5);
-});
-
-test('test shuffleAssoc with seed', function () {
-    $array = ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5];
-    $shuffled = Arr::shuffleAssoc($array, 123);
-
-    expect($shuffled)->not->toBe($array)
-        ->toBeArray()
-        ->toHaveKey('a')
-        ->toHaveKey('b')
-        ->toHaveKey('c')
-        ->toHaveKey('d')
-        ->toHaveKey('e')
-        ->toHaveCount(5);
-});
-
 test('test sortByMany', function () {
     $unsorted = [
         ['name' => 'John', 'age' => 8, 'meta' => ['key' => 3]],


### PR DESCRIPTION
https://github.com/hyperf/hyperf/pull/7141

This feature has been added to the official hyperf expansion