### PR TITLE
feat(telescope): make telescope enabled by default

### DIFF
--- a/src/telescope/src/TelescopeConfig.php
+++ b/src/telescope/src/TelescopeConfig.php
@@ -105,7 +105,7 @@ class TelescopeConfig
 
     public function isEnabled(): bool
     {
-        return (bool) $this->get('enabled', true);
+        return (bool) $this->get('enabled', true); // will default to false after v3.2
     }
 
     public function getAppName(): string

--- a/src/telescope/src/TelescopeConfig.php
+++ b/src/telescope/src/TelescopeConfig.php
@@ -105,7 +105,11 @@ class TelescopeConfig
 
     public function isEnabled(): bool
     {
-        return (bool) $this->get('enabled', false);
+        $enabled = $this->get('enabled');
+        if ($enabled === null) {
+            return true;
+        }
+        return (bool) $enabled;
     }
 
     public function getAppName(): string

--- a/src/telescope/src/TelescopeConfig.php
+++ b/src/telescope/src/TelescopeConfig.php
@@ -105,11 +105,7 @@ class TelescopeConfig
 
     public function isEnabled(): bool
     {
-        $enabled = $this->get('enabled');
-        if ($enabled === null) {
-            return true;
-        }
-        return (bool) $enabled;
+        return (bool) $this->get('enabled', true);
     }
 
     public function getAppName(): string


### PR DESCRIPTION
Change isEnabled() to return true when 'enabled' config is not set, allowing telescope to be enabled by default while still respecting explicit enable/disable settings