### PR TITLE
refactor(telescope): rename save_mode to record_mode and use enum

### DIFF
--- a/src/telescope/publish/telescope.php
+++ b/src/telescope/publish/telescope.php
@@ -8,7 +8,8 @@ declare(strict_types=1);
  * @document https://github.com/friendsofhyperf/components/blob/main/README.md
  * @contact  huangdijia@gmail.com
  */
-use FriendsOfHyperf\Telescope\Telescope;
+use FriendsOfHyperf\Telescope\Middleware\Authorize;
+use FriendsOfHyperf\Telescope\RecordMode;
 
 use function Hyperf\Support\env;
 
@@ -38,10 +39,10 @@ return [
     'server' => env('TELESCOPE_SERVER', 'http'),
     'path' => env('TELESCOPE_PATH', '/telescope'),
     'middleware' => [
-        FriendsOfHyperf\Telescope\Middleware\Authorize::class,
+        Authorize::class,
     ],
 
-    'save_mode' => Telescope::ASYNC,
+    'record_mode' => RecordMode::ASYNC,
     'ignore_logs' => [
     ],
     'only_paths' => [

--- a/src/telescope/src/RecordMode.php
+++ b/src/telescope/src/RecordMode.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of friendsofhyperf/components.
+ *
+ * @link     https://github.com/friendsofhyperf/components
+ * @document https://github.com/friendsofhyperf/components/blob/main/README.md
+ * @contact  huangdijia@gmail.com
+ */
+
+namespace FriendsOfHyperf\Telescope;
+
+enum RecordMode: int
+{
+    case SYNC = 0;
+    case ASYNC = 1;
+}

--- a/src/telescope/src/Telescope.php
+++ b/src/telescope/src/Telescope.php
@@ -18,8 +18,14 @@ use Hyperf\Context\ApplicationContext;
 
 class Telescope
 {
+    /**
+     * @deprecated since v3.1, use `\FriendsOfHyperf\Telescope\SaveMode::SYNC` instead, will be removed in v3.2
+     */
     public const SYNC = 0;
 
+    /**
+     * @deprecated since v3.1, use `\FriendsOfHyperf\Telescope\SaveMode::ASYNC` instead, will be removed in v3.2
+     */
     public const ASYNC = 1;
 
     /**
@@ -200,14 +206,11 @@ class Telescope
             return;
         }
 
-        $entry->tags(Arr::collapse(array_map(function ($tagCallback) use ($entry) {
-            return $tagCallback($entry);
-        }, static::$tagUsing)));
+        $entry->tags(Arr::collapse(array_map(fn ($tagCallback) => $tagCallback($entry), static::$tagUsing)));
 
-        match (static::getConfig()->getSaveMode()) {
-            self::ASYNC => TelescopeContext::addEntry($entry),
-            self::SYNC => $entry->create(),
-            default => $entry->create(),
+        match (static::getConfig()->getRecordMode()) {
+            RecordMode::ASYNC => TelescopeContext::addEntry($entry),
+            RecordMode::SYNC => $entry->create(),
         };
     }
 }

--- a/src/telescope/src/TelescopeConfig.php
+++ b/src/telescope/src/TelescopeConfig.php
@@ -118,13 +118,16 @@ class TelescopeConfig
         return (string) $this->get('timezone', date_default_timezone_get());
     }
 
-    public function getSaveMode(): int
+    public function getRecordMode(): RecordMode
     {
-        return match ($this->get('save_mode', Telescope::SYNC)) {
-            Telescope::ASYNC => Telescope::ASYNC,
-            Telescope::SYNC => Telescope::SYNC,
-            default => Telescope::SYNC,
-        };
+        /** @var RecordMode|int $mode */
+        $mode = $this->get('record_mode', RecordMode::SYNC);
+
+        if ($mode instanceof RecordMode) {
+            return $mode;
+        }
+
+        return RecordMode::tryFrom((int) $mode) ?: RecordMode::SYNC;
     }
 
     public function getPath(): string

--- a/tests/Telescope/TelescopeConfigTest.php
+++ b/tests/Telescope/TelescopeConfigTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @document https://github.com/friendsofhyperf/components/blob/main/README.md
  * @contact  huangdijia@gmail.com
  */
-use FriendsOfHyperf\Telescope\Telescope;
+use FriendsOfHyperf\Telescope\RecordMode;
 use FriendsOfHyperf\Telescope\TelescopeConfig;
 use Hyperf\Config\Config;
 use Hyperf\Redis\Redis;
@@ -46,7 +46,7 @@ beforeEach(function () {
                 'host' => '0.0.0.0',
                 'port' => 9509,
             ],
-            'save_mode' => Telescope::SYNC,
+            'record_mode' => RecordMode::SYNC,
             'ignore_logs' => [
             ],
             'path' => 'telescope',


### PR DESCRIPTION
- Introduce RecordMode enum to replace magic constants
- Rename config key from 'save_mode' to 'record_mode'
- Mark Telescope::SYNC and ASYNC constants as deprecated
- Update config handling to support both enum and legacy integer values
- Update tests and default config file