### PR TITLE
refactor(telescope): improve database unique constraint handling

### DIFF
--- a/src/telescope/composer.json
+++ b/src/telescope/composer.json
@@ -34,7 +34,7 @@
     "suggest": {
         "guzzlehttp/guzzle": "Required to use Guzzle annotation.(^6.0|^7.0)",
         "hyperf/command": "Required to use Command annotation.(~3.1.0)",
-        "hyperf/database": "Required to use Database annotation.(~3.1.0)",
+        "hyperf/database": "Required to use Database annotation.(~3.1.48)",
         "hyperf/db-connection": "Required to use db-connection annotation.(~3.1.0)",
         "hyperf/dispatcher": "Required to use BootApplication event.(~3.1.0)",
         "hyperf/event": "Required to use Event annotation.(~3.1.0)",


### PR DESCRIPTION
Replace custom unique constraint error detection with direct exception handling. Remove isUniqueConstraintError method in favor of catching Hyperf's UniqueConstraintViolationException directly, making the code more maintainable and framework-aligned.