### PR TITLE
docs(cache): add introduction for friendsofhyperf/cache component

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,7 +4,7 @@ reviews:
   profile: "chill"
   request_changes_workflow: true
   high_level_summary: true
-  auto_title_placeholder: true
+  auto_title_placeholder: "@coderabbitai"
   commit_status: true
   poem: true
   review_status: true
@@ -12,7 +12,6 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
-    base_branches:
-      type: ["main"]
+    base_branches: ["main"]
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,7 +13,6 @@ reviews:
     enabled: true
     drafts: false
     base_branches:
-      type:
-        - main
+      type: ["main"]
 chat:
   auto_reply: true

--- a/docs/zh_CN/components/cache.md
+++ b/docs/zh_CN/components/cache.md
@@ -1,5 +1,9 @@
 # Cache
 
+## 简介
+
+`friendsofhyperf/cache` 是一个基于 `hyperf/cache` 的组件。 提供更多简洁性的扩展方法
+
 ## 安装
 
 ```shell


### PR DESCRIPTION
- Add a brief introduction to the `friendsofhyperf/cache` component
- Highlight its purpose of providing more concise extension methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an "Introduction" section to the cache component documentation in Chinese, providing a brief overview of the `friendsofhyperf/cache` component.
  
- **Configuration Updates**
	- Updated the `auto_title_placeholder` configuration to a string value.
	- Simplified the structure of `base_branches` configuration for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->