### PR TITLE
refactor(cache): update CacheInterface references and remove deprecated Repository interface

### DIFF
--- a/docs/en/components/cache.md
+++ b/docs/en/components/cache.md
@@ -13,7 +13,7 @@ composer require friendsofhyperf/cache
 ```php
 namespace App\Controller;
 
-use FriendsOfHyperf\Cache\Contract\Repository as CacheInterface;
+use FriendsOfHyperf\Cache\Contract\CacheInterface;
 use Hyperf\Di\Annotation\Inject;
 
 class IndexController

--- a/docs/zh_CN/components/cache.md
+++ b/docs/zh_CN/components/cache.md
@@ -17,7 +17,7 @@ composer require friendsofhyperf/cache
 ```php
 namespace App\Controller;
 
-use FriendsOfHyperf\Cache\Contract\Repository as CacheInterface;
+use FriendsOfHyperf\Cache\Contract\CacheInterface;
 use Hyperf\Di\Annotation\Inject;
 
 class IndexController

--- a/src/cache/README.md
+++ b/src/cache/README.md
@@ -21,7 +21,7 @@ composer require friendsofhyperf/cache
 ```php
 namespace App\Controller;
 
-use FriendsOfHyperf\Cache\Contract\Repository as CacheInterface;
+use FriendsOfHyperf\Cache\Contract\CacheInterface;
 use Hyperf\Di\Annotation\Inject;
 
 class IndexController

--- a/src/cache/src/CacheInterface.php
+++ b/src/cache/src/CacheInterface.php
@@ -11,13 +11,13 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Cache;
 
-class_alias(Contract\Repository::class, CacheInterface::class);
+class_alias(Contract\CacheInterface::class, CacheInterface::class);
 
 if (false) { // @phpstan-ignore-line
     /**
      * @deprecated since v3.1, use `\FriendsOfHyperf\Cache\Contract\Repository` instead, will removed in v3.2
      */
-    interface CacheInterface extends Contract\Repository
+    interface CacheInterface extends Contract\CacheInterface
     {
     }
 }

--- a/src/cache/src/CacheManager.php
+++ b/src/cache/src/CacheManager.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Cache;
 
-use FriendsOfHyperf\Cache\Contract\Repository as CacheContract;
+use FriendsOfHyperf\Cache\Contract\CacheInterface;
 use Hyperf\Cache\CacheManager as HyperfCacheManager;
 
 use function Hyperf\Support\make;
@@ -19,7 +19,7 @@ use function Hyperf\Support\make;
 class CacheManager
 {
     /**
-     * @var CacheContract[]
+     * @var CacheInterface[]
      */
     protected array $drivers = [];
 
@@ -30,7 +30,7 @@ class CacheManager
     /**
      * Get a cache driver instance.
      */
-    public function store(string $name = 'default'): CacheContract
+    public function store(string $name = 'default'): CacheInterface
     {
         return $this->drivers[$name] ?? $this->drivers[$name] = $this->resolve($name);
     }
@@ -38,7 +38,7 @@ class CacheManager
     /**
      * Alias for the "store" method.
      */
-    public function driver(string $name = 'default'): CacheContract
+    public function driver(string $name = 'default'): CacheInterface
     {
         return $this->store($name);
     }
@@ -46,7 +46,7 @@ class CacheManager
     /**
      * Resolve a cache repository instance.
      */
-    public function resolve(string $name): CacheContract
+    public function resolve(string $name): CacheInterface
     {
         return make(Repository::class, [
             'name' => $name,

--- a/src/cache/src/ConfigProvider.php
+++ b/src/cache/src/ConfigProvider.php
@@ -17,8 +17,8 @@ class ConfigProvider
     {
         return [
             'dependencies' => [
-                Contract\Repository::class => RepositoryFactory::class,
-                CacheInterface::class => fn ($container) => $container->get(Contract\Repository::class), // Will removed in v3.2
+                Contract\CacheInterface::class => RepositoryFactory::class,
+                CacheInterface::class => fn ($container) => $container->get(Contract\CacheInterface::class), // Will removed in v3.2
             ],
         ];
     }

--- a/src/cache/src/Contract/CacheInterface.php
+++ b/src/cache/src/Contract/CacheInterface.php
@@ -15,7 +15,7 @@ use Closure;
 use DateInterval;
 use DateTimeInterface;
 
-interface Repository
+interface CacheInterface extends \Psr\SimpleCache\CacheInterface
 {
     /**
      * @param string $key

--- a/src/cache/src/Contract/CacheInterface.php
+++ b/src/cache/src/Contract/CacheInterface.php
@@ -88,17 +88,6 @@ interface CacheInterface extends \Psr\SimpleCache\CacheInterface
     public function increment($key, $value = 1);
 
     /**
-     * Retrieve an item from the cache by key.
-     *
-     * @template TCacheValue
-     *
-     * @param string[]|string $key
-     * @param (Closure(): TCacheValue)|TCacheValue $default
-     * @return (TCacheValue is null ? mixed : TCacheValue)
-     */
-    public function get($key, $default = null);
-
-    /**
      * @return iterable
      */
     public function many(array $keys);

--- a/src/cache/src/Facade/Cache.php
+++ b/src/cache/src/Facade/Cache.php
@@ -15,7 +15,7 @@ use Closure;
 use DateInterval;
 use DateTimeInterface;
 use FriendsOfHyperf\Cache\CacheManager;
-use FriendsOfHyperf\Cache\Contract\Repository as CacheContract;
+use FriendsOfHyperf\Cache\Contract\CacheInterface;
 use Hyperf\Context\ApplicationContext;
 
 class Cache
@@ -30,17 +30,17 @@ class Cache
         return self::store()->{$name}(...$arguments);
     }
 
-    public static function store(string $name = 'default'): CacheContract
+    public static function store(string $name = 'default'): CacheInterface
     {
         return self::getFacadeAccessor()->store($name);
     }
 
-    public static function driver(string $name = 'default'): CacheContract
+    public static function driver(string $name = 'default'): CacheInterface
     {
         return self::getFacadeAccessor()->driver($name);
     }
 
-    public static function resolve(string $name): CacheContract
+    public static function resolve(string $name): CacheInterface
     {
         return self::getFacadeAccessor()->resolve($name);
     }

--- a/src/cache/src/Repository.php
+++ b/src/cache/src/Repository.php
@@ -49,16 +49,29 @@ class Repository implements Contract\CacheInterface
     ) {
     }
 
+    /**
+     * @param string $key
+     * @param mixed $value
+     * @param int|DateInterval|null $ttl
+     * @return bool
+     */
     public function set($key, $value, $ttl = null)
     {
         return $this->put($key, $value, $ttl);
     }
 
+    /**
+     * @param string $key
+     * @return bool
+     */
     public function delete($key)
     {
         return $this->forget($key);
     }
 
+    /**
+     * @return bool
+     */
     public function clear()
     {
         return $this->flush();
@@ -223,6 +236,15 @@ class Repository implements Contract\CacheInterface
         return with((int) $this->get($key, 0) + (int) $value, fn ($value) => ! $this->put($key, $value) ? false : $value);
     }
 
+    /**
+     * Retrieve an item from the cache by key.
+     *
+     * @template TCacheValue
+     *
+     * @param string[]|string $key
+     * @param (Closure(): TCacheValue)|TCacheValue $default
+     * @return (TCacheValue is null ? mixed : TCacheValue)
+     */
     public function get($key, $default = null)
     {
         if (is_array($key)) {

--- a/src/cache/src/Repository.php
+++ b/src/cache/src/Repository.php
@@ -53,26 +53,21 @@ class Repository implements Contract\CacheInterface
      * @param string $key
      * @param mixed $value
      * @param int|DateInterval|null $ttl
-     * @return bool
      */
-    public function set($key, $value, $ttl = null)
+    public function set($key, $value, $ttl = null): bool
     {
         return $this->put($key, $value, $ttl);
     }
 
     /**
      * @param string $key
-     * @return bool
      */
-    public function delete($key)
+    public function delete($key): bool
     {
         return $this->forget($key);
     }
 
-    /**
-     * @return bool
-     */
-    public function clear()
+    public function clear(): bool
     {
         return $this->flush();
     }
@@ -245,7 +240,7 @@ class Repository implements Contract\CacheInterface
      * @param (Closure(): TCacheValue)|TCacheValue $default
      * @return (TCacheValue is null ? mixed : TCacheValue)
      */
-    public function get($key, $default = null)
+    public function get($key, $default = null): mixed
     {
         if (is_array($key)) {
             return $this->many($key);

--- a/src/cache/src/Repository.php
+++ b/src/cache/src/Repository.php
@@ -37,7 +37,7 @@ use function Hyperf\Coroutine\defer;
 use function Hyperf\Support\with;
 use function Hyperf\Tappable\tap;
 
-class Repository implements Contract\Repository
+class Repository implements Contract\CacheInterface
 {
     use InteractsWithTime;
     use Macroable;
@@ -47,6 +47,21 @@ class Repository implements Contract\Repository
         protected ?EventDispatcherInterface $eventDispatcher = null,
         protected string $name = 'default'
     ) {
+    }
+
+    public function set($key, $value, $ttl = null)
+    {
+        return $this->put($key, $value, $ttl);
+    }
+
+    public function delete($key)
+    {
+        return $this->forget($key);
+    }
+
+    public function clear()
+    {
+        return $this->flush();
     }
 
     public function add($key, $value, $ttl = null): bool
@@ -298,7 +313,10 @@ class Repository implements Contract\Repository
         return $this->putMany(is_array($values) ? $values : iterator_to_array($values), $ttl);
     }
 
-    public function deleteMultiple(array $keys)
+    /**
+     * @param iterable $keys
+     */
+    public function deleteMultiple($keys): bool
     {
         $result = true;
 


### PR DESCRIPTION
…

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档更新**
  - 更新了关于 `CacheInterface` 的命名空间引用，确保文档中的示例和用法与最新的接口一致。
  
- **新特性**
  - `Repository` 类实现了 `CacheInterface`，并新增了 `set`、`delete` 和 `clear` 方法，增强了缓存管理功能。

- **功能改进**
  - 更新了多个方法的返回类型，从 `CacheContract` 改为 `CacheInterface`，确保类型一致性和安全性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->