### PR TITLE
Use Str::wrap() instead of nesting Str::start() inside Str::finish()

### DIFF
--- a/src/mail/src/Mailable/Headers.php
+++ b/src/mail/src/Mailable/Headers.php
@@ -95,7 +95,7 @@ class Headers
     public function referencesString(): string
     {
         return collect($this->references)->map(function ($messageId) {
-            return Str::finish(Str::start($messageId, '<'), '>');
+            return Str::wrap($messageId, '<', '>');
         })->implode(' ');
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能更新**
  - 简化了邮件头中消息 ID 的格式化方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->