### PR TITLE
add Lock heartbeat

### DIFF
--- a/src/lock/src/Driver/AbstractLock.php
+++ b/src/lock/src/Driver/AbstractLock.php
@@ -176,7 +176,6 @@ abstract class AbstractLock implements LockInterface
                         $this->set();
                     } catch (Throwable $throwable){
                         ApplicationContext::getContainer()->get(StdoutLoggerInterface::class)?->error((string) $throwable);
-                        sleep(5);
                     }
                 }
             }

--- a/src/lock/src/Driver/CacheLock.php
+++ b/src/lock/src/Driver/CacheLock.php
@@ -49,12 +49,20 @@ class CacheLock extends AbstractLock
         return $this->store->set($this->name, $this->owner, $this->seconds);
     }
 
+    #[Override]
+    public function set(): bool
+    {
+        return $this->store->set($this->name, $this->owner, $this->seconds);
+    }
+
     /**
      * Release the lock.
      */
     #[Override]
     public function release(): bool
     {
+        $this->isRun = false;
+
         if ($this->isOwnedByCurrentProcess()) {
             return $this->store->delete($this->name);
         }
@@ -68,6 +76,7 @@ class CacheLock extends AbstractLock
     #[Override]
     public function forceRelease(): void
     {
+        $this->isRun = false;
         $this->store->delete($this->name);
     }
 

--- a/src/lock/src/Driver/CoroutineLock.php
+++ b/src/lock/src/Driver/CoroutineLock.php
@@ -85,12 +85,21 @@ class CoroutineLock extends AbstractLock
         return true;
     }
 
+    #[Override]
+    protected function set(): bool
+    {
+        return false;
+    }
+
+
     /**
      * Release the lock.
      */
     #[Override]
     public function release(): bool
     {
+        $this->isRun = false;
+
         if ($this->isOwnedByCurrentProcess()) {
             return (self::$channels[$this->name] ?? null)?->pop(0.01) ? true : false;
         }
@@ -104,6 +113,8 @@ class CoroutineLock extends AbstractLock
     #[Override]
     public function forceRelease(): void
     {
+        $this->isRun = false;
+
         if (! $chan = self::$channels[$this->name] ?? null) {
             return;
         }

--- a/src/lock/src/Driver/FileSystemLock.php
+++ b/src/lock/src/Driver/FileSystemLock.php
@@ -48,11 +48,21 @@ class FileSystemLock extends AbstractLock
     }
 
     /**
+     * Set the lock.
+     */
+    #[Override]
+    protected function set(): bool
+    {
+        return $this->store->set($this->name, $this->owner, $this->seconds) == true;
+    }
+
+    /**
      * Release the lock.
      */
     #[Override]
     public function release(): bool
     {
+        $this->isRun = false;
         if ($this->isOwnedByCurrentProcess()) {
             return $this->store->delete($this->name);
         }
@@ -66,6 +76,7 @@ class FileSystemLock extends AbstractLock
     #[Override]
     public function forceRelease(): void
     {
+        $this->isRun = false;
         $this->store->delete($this->name);
     }
 

--- a/src/lock/src/Driver/LockInterface.php
+++ b/src/lock/src/Driver/LockInterface.php
@@ -21,7 +21,7 @@ interface LockInterface
      * @param (callable(): T)|null $callback
      * @return ($callback is null ? bool : T)
      */
-    public function get(?callable $callback = null);
+    public function get(?callable $callback = null, int $heartbeat = 0);
 
     /**
      * Attempt to acquire the lock for the given number of seconds.
@@ -31,7 +31,7 @@ interface LockInterface
      * @return ($callback is null ? bool : T)
      * @throws LockTimeoutException
      */
-    public function block(int $seconds, ?callable $callback = null);
+    public function block(int $seconds, ?callable $callback = null, int $heartbeat = 0);
 
     /**
      * Release the lock.


### PR DESCRIPTION
增加心跳heartbeat参数;

防止任务执行过长,锁失效

```php
    public function handle()
    {
        co(function (){
            $this->lock(1);
        });
        sleep(7);
        co(function (){
            $this->lock(2);
        });

        var_dump('........end......');

    }

    public function lock($id)
    {
        lock('key',5)->get(function ()use ($id){
            var_dump('.............lock.......'.$id);
            sleep(10);
        },3);
    }

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 为锁机制引入了心跳机制
	- 增加了在锁定期间定期执行任务的能力

- **方法变更**
	- 更新了 `get()` 和 `block()` 方法的签名，增加了可选的心跳参数
	- 在各种锁类型中添加了 `set()` 方法

- **改进**
	- 提升了锁管理的灵活性和可靠性
	- 支持在持有锁期间周期性执行任务
<!-- end of auto-generated comment: release notes by coderabbit.ai -->