### PR TITLE
Refactor Purifier class, cache HTMLPurifier instance using WeakMap, optimize configuration management

### DIFF
--- a/src/purifier/src/Purifier.php
+++ b/src/purifier/src/Purifier.php
@@ -40,11 +40,22 @@ class Purifier
      */
     public function __construct(protected Filesystem $files, protected ConfigInterface $config)
     {
+        $this->instances = new WeakMap();
+        $this->setUp();
+    }
+
+    /**
+     * Setup.
+     *
+     * @throws Exception
+     */
+    private function setUp(): void
+    {
         if (! $this->config->has('purifier')) {
             throw new Exception('Configuration parameters not loaded!');
         }
+
         $this->checkCacheDirectory();
-        $this->instances = new WeakMap();
     }
 
     /**

--- a/src/purifier/src/Purifier.php
+++ b/src/purifier/src/Purifier.php
@@ -40,6 +40,10 @@ class Purifier
      */
     public function __construct(protected Filesystem $files, protected ConfigInterface $config)
     {
+        if (! $this->config->has('purifier')) {
+            throw new Exception('Configuration parameters not loaded!');
+        }
+        $this->checkCacheDirectory();
         $this->instances = new WeakMap();
     }
 
@@ -64,15 +68,7 @@ class Purifier
             return $dirty;
         }
 
-        if (! isset($this->instances[$configObject])) {
-            if (! $this->config->has('purifier')) {
-                throw new Exception('Configuration parameters not loaded!');
-            }
-
-            $this->checkCacheDirectory();
-
-            $this->instances[$configObject] = new HTMLPurifier($configObject);
-        }
+        $this->instances[$configObject] ??= new HTMLPurifier($configObject);
 
         return $this->instances[$configObject]->purify($dirty, $configObject);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 优化了 HTMLPurifier 实例的管理和配置处理
	- 引入 WeakMap 提高内存管理效率

- **弃用提示**
	- `getInstance()` 方法已标记为已弃用，将在未来版本中移除

- **性能改进**
	- 改进了配置对象的缓存机制
	- 支持多配置实例的更高效处理
<!-- end of auto-generated comment: release notes by coderabbit.ai -->