### PR TITLE
fix: collapseWithKeys on empty collection

### DIFF
--- a/src/macros/src/CollectionMixin.php
+++ b/src/macros/src/CollectionMixin.php
@@ -27,7 +27,7 @@ class CollectionMixin
     public function collapseWithKeys()
     {
         return function () {
-            if (! $this->items) {
+            if (! $this->items) { // @phpstan-ignore-line
                 return new static();
             }
 

--- a/src/macros/src/CollectionMixin.php
+++ b/src/macros/src/CollectionMixin.php
@@ -27,6 +27,10 @@ class CollectionMixin
     public function collapseWithKeys()
     {
         return function () {
+            if (! $this->items) {
+                return new static();
+            }
+
             $results = [];
 
             foreach ($this->items as $key => $values) { // @phpstan-ignore-line

--- a/tests/Macros/CollectionTest.php
+++ b/tests/Macros/CollectionTest.php
@@ -36,3 +36,8 @@ test('test collapseWithKeysOnNestedCollections', function ($collection) {
     $data = new $collection([new $collection(['a' => '1a', 'b' => '1b']), new $collection(['b' => '2b', 'c' => '2c']), 'drop']);
     $this->assertEquals(['a' => '1a', 'b' => '2b', 'c' => '2c'], $data->collapseWithKeys()->all());
 })->with('collectionClassProvider');
+
+test('test collapseWithKeysOnEmptyCollection', function ($collection) {
+    $data = new $collection();
+    $this->assertEquals([], $data->collapseWithKeys()->all());
+})->with('collectionClassProvider');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
	- 在 `collapseWithKeys` 方法中添加了对空项目集合的安全检查，防止在未初始化项目时出现潜在的处理错误。
- **测试**
	- 新增测试用例 `test collapseWithKeysOnEmptyCollection`，确保 `collapseWithKeys` 方法在空集合上正确处理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->