### PR TITLE
fix: handle false return value for Channel::pop in TriggerSubscriber

### DIFF
--- a/src/trigger/src/Subscriber/TriggerSubscriber.php
+++ b/src/trigger/src/Subscriber/TriggerSubscriber.php
@@ -76,10 +76,10 @@ class TriggerSubscriber extends AbstractSubscriber
             try {
                 while (true) {
                     while (true) {
-                        /** @var Closure|null $closure */
+                        /** @var Closure|false|null $closure */
                         $closure = $this->chan?->pop();
 
-                        if ($closure === null) {
+                        if ($closure === null || $closure === false) {
                             break 2;
                         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 优化了内部处理流程，使操作在遇到特定退出条件时能更稳定地终止，从而提升了系统整体的可靠性和响应性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->