### PR TITLE
feat(Number): 添加 fileSize 方法的二进制前缀选项及相应测试

### DIFF
--- a/src/support/src/Number.php
+++ b/src/support/src/Number.php
@@ -123,12 +123,17 @@ class Number
      *
      * @return string
      */
-    public static function fileSize(int|float $bytes, int $precision = 0, ?int $maxPrecision = null)
+    public static function fileSize(int|float $bytes, int $precision = 0, ?int $maxPrecision = null, bool $useBinaryPrefix = false)
     {
+        $base = $useBinaryPrefix ? 1024 : 1000;
         $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
-        for ($i = 0; ($bytes / 1024) > 0.9 && ($i < count($units) - 1); ++$i) {
-            $bytes /= 1024;
+        $units = $useBinaryPrefix
+            ? ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB', 'RiB', 'QiB']
+            : ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB', 'RB', 'QB'];
+
+        for ($i = 0; ($bytes / $base) > 0.9 && ($i < count($units) - 1); ++$i) {
+            $bytes /= $base;
         }
 
         return sprintf('%s %s', static::format($bytes, $precision, $maxPrecision), $units[$i]);

--- a/tests/Support/NumberTest.php
+++ b/tests/Support/NumberTest.php
@@ -166,18 +166,38 @@ class NumberTest extends TestCase
         $this->assertSame('0 B', Number::fileSize(0));
         $this->assertSame('0.00 B', Number::fileSize(0, precision: 2));
         $this->assertSame('1 B', Number::fileSize(1));
-        $this->assertSame('1 KB', Number::fileSize(1024));
-        $this->assertSame('2 KB', Number::fileSize(2048));
-        $this->assertSame('2.00 KB', Number::fileSize(2048, precision: 2));
-        $this->assertSame('1.23 KB', Number::fileSize(1264, precision: 2));
-        $this->assertSame('1.234 KB', Number::fileSize(1264.12345, maxPrecision: 3));
-        $this->assertSame('1.234 KB', Number::fileSize(1264, 3));
-        $this->assertSame('5 GB', Number::fileSize(1024 * 1024 * 1024 * 5));
-        $this->assertSame('10 TB', Number::fileSize((1024 ** 4) * 10));
-        $this->assertSame('10 PB', Number::fileSize((1024 ** 5) * 10));
-        $this->assertSame('1 ZB', Number::fileSize(1024 ** 7));
-        $this->assertSame('1 YB', Number::fileSize(1024 ** 8));
-        $this->assertSame('1,024 YB', Number::fileSize(1024 ** 9));
+        $this->assertSame('1 KB', Number::fileSize(1000));
+        $this->assertSame('2 KB', Number::fileSize(2000));
+        $this->assertSame('2.00 KB', Number::fileSize(2000, precision: 2));
+        $this->assertSame('1.23 KB', Number::fileSize(1234, precision: 2));
+        $this->assertSame('1.234 KB', Number::fileSize(1234, maxPrecision: 3));
+        $this->assertSame('1.234 KB', Number::fileSize(1234, 3));
+        $this->assertSame('5 GB', Number::fileSize(1000 * 1000 * 1000 * 5));
+        $this->assertSame('10 TB', Number::fileSize((1000 ** 4) * 10));
+        $this->assertSame('10 PB', Number::fileSize((1000 ** 5) * 10));
+        $this->assertSame('1 ZB', Number::fileSize(1000 ** 7));
+        $this->assertSame('1 YB', Number::fileSize(1000 ** 8));
+        $this->assertSame('1 RB', Number::fileSize(1000 ** 9));
+        $this->assertSame('1 QB', Number::fileSize(1000 ** 10));
+        $this->assertSame('1,000 QB', Number::fileSize(1000 ** 11));
+
+        $this->assertSame('0 B', Number::fileSize(0, useBinaryPrefix: true));
+        $this->assertSame('0.00 B', Number::fileSize(0, precision: 2, useBinaryPrefix: true));
+        $this->assertSame('1 B', Number::fileSize(1, useBinaryPrefix: true));
+        $this->assertSame('1 KiB', Number::fileSize(1024, useBinaryPrefix: true));
+        $this->assertSame('2 KiB', Number::fileSize(2048, useBinaryPrefix: true));
+        $this->assertSame('2.00 KiB', Number::fileSize(2048, precision: 2, useBinaryPrefix: true));
+        $this->assertSame('1.23 KiB', Number::fileSize(1264, precision: 2, useBinaryPrefix: true));
+        $this->assertSame('1.234 KiB', Number::fileSize(1264.12345, maxPrecision: 3, useBinaryPrefix: true));
+        $this->assertSame('1.234 KiB', Number::fileSize(1264, 3, useBinaryPrefix: true));
+        $this->assertSame('5 GiB', Number::fileSize(1024 * 1024 * 1024 * 5, useBinaryPrefix: true));
+        $this->assertSame('10 TiB', Number::fileSize((1024 ** 4) * 10, useBinaryPrefix: true));
+        $this->assertSame('10 PiB', Number::fileSize((1024 ** 5) * 10, useBinaryPrefix: true));
+        $this->assertSame('1 ZiB', Number::fileSize(1024 ** 7, useBinaryPrefix: true));
+        $this->assertSame('1 YiB', Number::fileSize(1024 ** 8, useBinaryPrefix: true));
+        $this->assertSame('1 RiB', Number::fileSize(1024 ** 9, useBinaryPrefix: true));
+        $this->assertSame('1 QiB', Number::fileSize(1024 ** 10, useBinaryPrefix: true));
+        $this->assertSame('1,024 QiB', Number::fileSize(1024 ** 11, useBinaryPrefix: true));
     }
 
     public function testClamp()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 文件大小格式化功能现支持选择二进制前缀（如KiB、MiB）或十进制前缀（如KB、MB）显示。
- **测试**
  - 增加并完善了文件大小格式化在二进制和十进制前缀下的测试用例，覆盖更多单位和精度情况。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->