### PR TITLE
feat(tests): 添加 arrayable 和 from 方法的测试用例及相关辅助类

### DIFF
--- a/src/macros/output/Hyperf/Collection/Arr.php
+++ b/src/macros/output/Hyperf/Collection/Arr.php
@@ -17,6 +17,16 @@ use InvalidArgumentException;
 class Arr
 {
     /**
+     * Determine whether the given value is arrayable.
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public static function arrayable($value)
+    {
+    }
+
+    /**
      * Get an array item from an array using "dot" notation.
      * @return array
      * @throws InvalidArgumentException
@@ -40,6 +50,21 @@ class Arr
      * @throws InvalidArgumentException
      */
     public static function float(ArrayAccess|array $array, string|int|null $key, ?float $default = null)
+    {
+    }
+
+    /**
+     * Get the underlying array of items from the given argument.
+     *
+     * @template TKey of array-key = array-key
+     * @template TValue = mixed
+     *
+     * @param array<TKey, TValue>|Enumerable<TKey, TValue>|Arrayable<TKey, TValue>|WeakMap<object, TValue>|Traversable<TKey, TValue>|Jsonable|JsonSerializable|object $items
+     * @return ($items is WeakMap ? list<TValue> : array<TKey, TValue>)
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function from($items)
     {
     }
 

--- a/src/macros/src/ArrMixin.php
+++ b/src/macros/src/ArrMixin.php
@@ -94,7 +94,7 @@ class ArrMixin
             $items instanceof Arrayable => $items->toArray(),
             $items instanceof WeakMap => iterator_to_array($items, false),
             $items instanceof Traversable => iterator_to_array($items),
-            $items instanceof Jsonable => json_decode($items->toJson(), true),
+            $items instanceof Jsonable => json_decode($items->__toString(), true),
             $items instanceof JsonSerializable => (array) $items->jsonSerialize(),
             is_object($items) => (array) $items,
             default => throw new InvalidArgumentException('Items cannot be represented by a scalar value.'),

--- a/tests/Macros/Stubs/Common.php
+++ b/tests/Macros/Stubs/Common.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of friendsofhyperf/components.
+ *
+ * @link     https://github.com/friendsofhyperf/components
+ * @document https://github.com/friendsofhyperf/components/blob/main/README.md
+ * @contact  huangdijia@gmail.com
+ */
+
+namespace FriendsOfHyperf\Tests\Macros\Stubs;
+
+use ArrayIterator;
+use Hyperf\Contract\Arrayable;
+use Hyperf\Contract\Jsonable;
+use IteratorAggregate;
+use JsonSerializable;
+use Traversable;
+
+class TestArrayableObject implements Arrayable
+{
+    public function toArray(): array
+    {
+        return ['foo' => 'bar'];
+    }
+}
+
+class TestJsonableObject implements Jsonable
+{
+    public function __toString(): string
+    {
+        return '{"foo":"bar"}';
+    }
+
+    public function toJson($options = 0): string
+    {
+        return '{"foo":"bar"}';
+    }
+}
+
+class TestJsonSerializeObject implements JsonSerializable
+{
+    public function jsonSerialize(): array
+    {
+        return ['foo' => 'bar'];
+    }
+}
+
+class TestJsonSerializeWithScalarValueObject implements JsonSerializable
+{
+    public function jsonSerialize(): string
+    {
+        return 'foo';
+    }
+}
+
+class TestTraversableAndJsonSerializableObject implements IteratorAggregate, JsonSerializable
+{
+    public $items;
+
+    public function __construct($items = [])
+    {
+        $this->items = $items;
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->items);
+    }
+
+    public function jsonSerialize(): array
+    {
+        return json_decode(json_encode($this->items), true);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增用于判断值是否可被视为数组的功能。
  - 新增支持多种类型对象（如数组、可遍历对象、可序列化对象等）转换为数组的功能。
  - 将多个类型检查方法由静态方法改为实例方法，增强灵活性。

- **测试**
  - 增加了对新功能的测试用例，覆盖数组转换和数组能力检测的多种场景。
  - 新增多种用于测试的模拟对象，便于验证不同类型的数据结构转换和序列化行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->