### PR TITLE
feat(Stringable): 添加 hash 方法及相应测试

### DIFF
--- a/src/macros/output/Hyperf/Stringable/Stringable.php
+++ b/src/macros/output/Hyperf/Stringable/Stringable.php
@@ -23,6 +23,15 @@ class Stringable
     }
 
     /**
+     * Hash the string using the given algorithm.
+     *
+     * @return static
+     */
+    public function hash(string $algorithm)
+    {
+    }
+
+    /**
      * Convert GitHub flavored Markdown into HTML.
      *
      * @return static

--- a/src/macros/src/StringableMixin.php
+++ b/src/macros/src/StringableMixin.php
@@ -27,6 +27,12 @@ class StringableMixin
         return fn (string $character = ' ') => new static(Str::deduplicate($this->value, $character));
     }
 
+    public function hash()
+    {
+        /* @phpstan-ignore-next-line */
+        return fn (string $algorithm) => new static(hash($algorithm, $this->value));
+    }
+
     public function inlineMarkdown()
     {
         /* @phpstan-ignore-next-line */

--- a/tests/Macros/StringableTest.php
+++ b/tests/Macros/StringableTest.php
@@ -17,6 +17,12 @@ test('test deduplicate', function () {
     $this->assertSame('ムだム', (string) $this->stringable('ムだだム')->deduplicate('だ'));
 });
 
+test('test hash', function () {
+    $this->assertSame(hash('xxh3', 'foo'), (string) $this->stringable('foo')->hash('xxh3'));
+    $this->assertSame(hash('xxh3', 'foobar'), (string) $this->stringable('foobar')->hash('xxh3'));
+    $this->assertSame(hash('sha256', 'foobarbaz'), (string) $this->stringable('foobarbaz')->hash('sha256'));
+});
+
 test('test toHtmlString', function () {
     $this->assertEquals(
         new HtmlString('<h1>Test string</h1>'),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 为字符串对象新增了 hash 方法，可根据指定算法对字符串进行哈希处理。

- **测试**
  - 增加了针对 hash 方法的测试用例，验证其在多种哈希算法下的正确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->