### PR TITLE
Fix incorrect repository class in CacheManager

### DIFF
--- a/src/cache/src/CacheManager.php
+++ b/src/cache/src/CacheManager.php
@@ -13,6 +13,7 @@ namespace FriendsOfHyperf\Cache;
 
 use FriendsOfHyperf\Cache\Contract\Factory;
 use FriendsOfHyperf\Cache\Contract\Repository;
+use FriendsOfHyperf\Cache\Repository as CacheRepository;
 use Hyperf\Cache\CacheManager as HyperfCacheManager;
 
 use function Hyperf\Support\make;
@@ -49,7 +50,7 @@ class CacheManager implements Factory
      */
     public function resolve(string $name): Repository
     {
-        return make(Repository::class, [
+        return make(CacheRepository::class, [
             'name' => $name,
             'driver' => $this->cacheManager->getDriver($name),
         ]);


### PR DESCRIPTION
Replaced the use of the generic Repository interface with the specific CacheRepository class in the resolve method to ensure proper instantiation and functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **无用户可见变更**
	- 本次更新未引入任何用户可见的新功能或修复，内部实现有所调整，不影响现有功能的使用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->