### PR TITLE
Fix event dispatch on cache forget failure

### DIFF
--- a/src/cache/src/Repository.php
+++ b/src/cache/src/Repository.php
@@ -20,6 +20,7 @@ use FriendsOfHyperf\Cache\Event\CacheFlushing;
 use FriendsOfHyperf\Cache\Event\CacheHit;
 use FriendsOfHyperf\Cache\Event\CacheMissed;
 use FriendsOfHyperf\Cache\Event\ForgettingKey;
+use FriendsOfHyperf\Cache\Event\KeyForgetFailed;
 use FriendsOfHyperf\Cache\Event\KeyForgotten;
 use FriendsOfHyperf\Cache\Event\KeyWriteFailed;
 use FriendsOfHyperf\Cache\Event\KeyWritten;


### PR DESCRIPTION
## Summary
- trigger `KeyForgetFailed` event instead of repeating `ForgettingKey`

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840429b6d748331a264b3f953eb2064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **优化**
  - 优化缓存删除失败时的事件通知，提升事件区分度和准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->