### PR TITLE
Add repository forget event tests

### DIFF
--- a/tests/Cache/RepositoryEventTest.php
+++ b/tests/Cache/RepositoryEventTest.php
@@ -58,7 +58,9 @@ class RepositoryEventTest extends TestCase
 
         $repository = new Repository($this->container, $driver);
 
-        $repository->forget('foo');
+        $result = $repository->forget('foo');
+
+        $this->assertTrue($result);
     }
 
     public function testForgetDispatchesKeyForgetFailedEvent(): void
@@ -73,6 +75,8 @@ class RepositoryEventTest extends TestCase
 
         $repository = new Repository($this->container, $driver);
 
-        $repository->forget('foo');
+        $result = $repository->forget('foo');
+
+        $this->assertFalse($result);
     }
 }

--- a/tests/Cache/RepositoryEventTest.php
+++ b/tests/Cache/RepositoryEventTest.php
@@ -16,7 +16,6 @@ use FriendsOfHyperf\Cache\Event\KeyForgetFailed;
 use FriendsOfHyperf\Cache\Event\KeyForgotten;
 use FriendsOfHyperf\Cache\Repository;
 use FriendsOfHyperf\Tests\Concerns\InteractsWithContainer;
-use FriendsOfHyperf\Tests\Concerns\RunTestsInCoroutine;
 use Hyperf\Cache\Driver\DriverInterface;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\Group;
@@ -31,7 +30,6 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 class RepositoryEventTest extends TestCase
 {
     use InteractsWithContainer;
-    use RunTestsInCoroutine;
 
     protected function setUp(): void
     {

--- a/tests/Cache/RepositoryEventTest.php
+++ b/tests/Cache/RepositoryEventTest.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 namespace FriendsOfHyperf\Tests\Cache;
 
 use FriendsOfHyperf\Cache\Event\ForgettingKey;
-use FriendsOfHyperf\Cache\Event\KeyForgotten;
 use FriendsOfHyperf\Cache\Event\KeyForgetFailed;
+use FriendsOfHyperf\Cache\Event\KeyForgotten;
 use FriendsOfHyperf\Cache\Repository;
 use Hyperf\Cache\Driver\DriverInterface;
 use Mockery as m;

--- a/tests/Cache/RepositoryEventTest.php
+++ b/tests/Cache/RepositoryEventTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of friendsofhyperf/components.
+ *
+ * @link     https://github.com/friendsofhyperf/components
+ * @document https://github.com/friendsofhyperf/components/blob/main/README.md
+ * @contact  huangdijia@gmail.com
+ */
+
+namespace FriendsOfHyperf\Tests\Cache;
+
+use FriendsOfHyperf\Cache\Event\ForgettingKey;
+use FriendsOfHyperf\Cache\Event\KeyForgotten;
+use FriendsOfHyperf\Cache\Event\KeyForgetFailed;
+use FriendsOfHyperf\Cache\Repository;
+use Hyperf\Cache\Driver\DriverInterface;
+use Mockery as m;
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class RepositoryEventTest extends \PHPUnit\Framework\TestCase
+{
+    use \FriendsOfHyperf\Tests\Concerns\InteractsWithContainer;
+    use \FriendsOfHyperf\Tests\Concerns\RunTestsInCoroutine;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->refreshContainer();
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+        $this->flushContainer();
+        parent::tearDown();
+    }
+
+    public function testForgetDispatchesKeyForgottenEvent(): void
+    {
+        $driver = m::mock(DriverInterface::class);
+        $driver->shouldReceive('delete')->with('foo')->once()->andReturnTrue();
+
+        $events = m::mock(EventDispatcherInterface::class);
+        $events->shouldReceive('dispatch')->once()->with(m::type(ForgettingKey::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(KeyForgotten::class));
+        $this->instance(EventDispatcherInterface::class, $events);
+
+        $repository = new Repository($this->container, $driver);
+
+        $repository->forget('foo');
+    }
+
+    public function testForgetDispatchesKeyForgetFailedEvent(): void
+    {
+        $driver = m::mock(DriverInterface::class);
+        $driver->shouldReceive('delete')->with('foo')->once()->andReturnFalse();
+
+        $events = m::mock(EventDispatcherInterface::class);
+        $events->shouldReceive('dispatch')->once()->with(m::type(ForgettingKey::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(KeyForgetFailed::class));
+        $this->instance(EventDispatcherInterface::class, $events);
+
+        $repository = new Repository($this->container, $driver);
+
+        $repository->forget('foo');
+    }
+}

--- a/tests/Cache/RepositoryEventTest.php
+++ b/tests/Cache/RepositoryEventTest.php
@@ -13,8 +13,12 @@ namespace FriendsOfHyperf\Tests\Cache;
 
 use FriendsOfHyperf\Cache\Event\ForgettingKey;
 use FriendsOfHyperf\Cache\Event\KeyForgetFailed;
-use FriendsOfHyperf\Cache\Event\KeyForgotten;
-use FriendsOfHyperf\Cache\Repository;
+use FriendsOfHyperf\Tests\Concerns\InteractsWithContainer;
+use FriendsOfHyperf\Tests\Concerns\RunTestsInCoroutine;
+use PHPUnit\Framework\Attributes\Group;
+#[Group('cache')]
+    use InteractsWithContainer;
+    use RunTestsInCoroutine;
 use Hyperf\Cache\Driver\DriverInterface;
 use Mockery as m;
 use Psr\EventDispatcher\EventDispatcherInterface;

--- a/tests/Cache/RepositoryEventTest.php
+++ b/tests/Cache/RepositoryEventTest.php
@@ -13,14 +13,13 @@ namespace FriendsOfHyperf\Tests\Cache;
 
 use FriendsOfHyperf\Cache\Event\ForgettingKey;
 use FriendsOfHyperf\Cache\Event\KeyForgetFailed;
+use FriendsOfHyperf\Cache\Event\KeyForgotten;
+use FriendsOfHyperf\Cache\Repository;
 use FriendsOfHyperf\Tests\Concerns\InteractsWithContainer;
 use FriendsOfHyperf\Tests\Concerns\RunTestsInCoroutine;
-use PHPUnit\Framework\Attributes\Group;
-#[Group('cache')]
-    use InteractsWithContainer;
-    use RunTestsInCoroutine;
 use Hyperf\Cache\Driver\DriverInterface;
 use Mockery as m;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
 
@@ -28,10 +27,11 @@ use Psr\EventDispatcher\EventDispatcherInterface;
  * @internal
  * @coversNothing
  */
+#[Group('cache')]
 class RepositoryEventTest extends TestCase
 {
-    use \FriendsOfHyperf\Tests\Concerns\InteractsWithContainer;
-    use \FriendsOfHyperf\Tests\Concerns\RunTestsInCoroutine;
+    use InteractsWithContainer;
+    use RunTestsInCoroutine;
 
     protected function setUp(): void
     {

--- a/tests/Cache/RepositoryEventTest.php
+++ b/tests/Cache/RepositoryEventTest.php
@@ -21,8 +21,8 @@ use PHPUnit\Framework\Attributes\Group;
     use RunTestsInCoroutine;
 use Hyperf\Cache\Driver\DriverInterface;
 use Mockery as m;
-use Psr\EventDispatcher\EventDispatcherInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @internal

--- a/tests/Cache/RepositoryEventTest.php
+++ b/tests/Cache/RepositoryEventTest.php
@@ -18,12 +18,13 @@ use FriendsOfHyperf\Cache\Repository;
 use Hyperf\Cache\Driver\DriverInterface;
 use Mockery as m;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
  * @coversNothing
  */
-class RepositoryEventTest extends \PHPUnit\Framework\TestCase
+class RepositoryEventTest extends TestCase
 {
     use \FriendsOfHyperf\Tests\Concerns\InteractsWithContainer;
     use \FriendsOfHyperf\Tests\Concerns\RunTestsInCoroutine;


### PR DESCRIPTION
## Summary
- add tests for KeyForgotten and KeyForgetFailed dispatches

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684047e8159c8331a03dae36f2902407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **测试**
  - 新增了用于验证缓存仓库事件分发行为的单元测试，确保在删除缓存键时根据操作结果正确触发相关事件。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->