### PR TITLE
Fix issue of missing nested DTO properties when transforming DTO

### DIFF
--- a/src/validated-dto/src/SimpleDTO.php
+++ b/src/validated-dto/src/SimpleDTO.php
@@ -512,7 +512,7 @@ abstract class SimpleDTO implements BaseDTO, CastsAttributes, JsonSerializable
     private function transformDTOToArray(SimpleDTO $dto): array
     {
         $result = [];
-        foreach ($dto->validatedData as $key => $value) {
+        foreach ($dto->buildDataForExport() as $key => $value) {
             $result[$key] = $this->isArrayable($value)
                 ? $this->formatArrayableValue($value)
                 : $value;

--- a/tests/ValidatedDTO/Datasets/SimpleInnerDTO.php
+++ b/tests/ValidatedDTO/Datasets/SimpleInnerDTO.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of friendsofhyperf/components.
+ *
+ * @link     https://github.com/friendsofhyperf/components
+ * @document https://github.com/friendsofhyperf/components/blob/main/README.md
+ * @contact  huangdijia@gmail.com
+ */
+
+namespace FriendsOfHyperf\Tests\ValidatedDTO\Datasets;
+
+use FriendsOfHyperf\ValidatedDTO\Casting\IntegerCast;
+use FriendsOfHyperf\ValidatedDTO\Casting\StringCast;
+use FriendsOfHyperf\ValidatedDTO\SimpleDTO;
+
+class SimpleInnerDTO extends SimpleDTO
+{
+    public string $name;
+
+    public int $number;
+
+    protected function defaults(): array
+    {
+        return [];
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'name' => new StringCast(),
+            'number' => new IntegerCast(),
+        ];
+    }
+}

--- a/tests/ValidatedDTO/Datasets/SimpleOuterDTO.php
+++ b/tests/ValidatedDTO/Datasets/SimpleOuterDTO.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of friendsofhyperf/components.
+ *
+ * @link     https://github.com/friendsofhyperf/components
+ * @document https://github.com/friendsofhyperf/components/blob/main/README.md
+ * @contact  huangdijia@gmail.com
+ */
+
+namespace FriendsOfHyperf\Tests\ValidatedDTO\Datasets;
+
+use FriendsOfHyperf\ValidatedDTO\Casting\DTOCast;
+use FriendsOfHyperf\ValidatedDTO\Casting\IntegerCast;
+use FriendsOfHyperf\ValidatedDTO\Casting\StringCast;
+use FriendsOfHyperf\ValidatedDTO\SimpleDTO;
+
+class SimpleOuterDTO extends SimpleDTO
+{
+    public string $name;
+
+    public SimpleInnerDTO $inner;
+
+    protected function defaults(): array
+    {
+        return [];
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'name' => new StringCast(),
+            'number' => new IntegerCast(),
+            'inner' => new DTOCast(SimpleInnerDTO::class),
+        ];
+    }
+}

--- a/tests/ValidatedDTO/Unit/SimpleDTOTest.php
+++ b/tests/ValidatedDTO/Unit/SimpleDTOTest.php
@@ -17,6 +17,7 @@ use FriendsOfHyperf\Tests\ValidatedDTO\Datasets\SimpleMapDataDTO;
 use FriendsOfHyperf\Tests\ValidatedDTO\Datasets\SimpleMappedNameDTO;
 use FriendsOfHyperf\Tests\ValidatedDTO\Datasets\SimpleNameDTO;
 use FriendsOfHyperf\Tests\ValidatedDTO\Datasets\SimpleNullableDTO;
+use FriendsOfHyperf\Tests\ValidatedDTO\Datasets\SimpleOuterDTO;
 use FriendsOfHyperf\Tests\ValidatedDTO\Datasets\SimpleUserDTO;
 use FriendsOfHyperf\Tests\ValidatedDTO\Datasets\User;
 use FriendsOfHyperf\ValidatedDTO\Exception\InvalidJsonException;
@@ -296,4 +297,41 @@ it('checks that update for property reflects while converting DTO', function () 
 
     expect($dto->age)->toBe(20)
         ->and($dto->toArray())->toBe(['age' => 20, 'doc' => 'test']);
+});
+
+it('checks that update for nested DTO property reflects while converting DTO to array', function () {
+    $dto = SimpleOuterDTO::fromArray([
+        'name' => 'name',
+        'inner' => [
+            'name' => 'inner name',
+            'number' => 2,
+        ],
+    ]);
+
+    $dto->inner->name = 'updated inner name';
+
+    expect($dto->inner->name)->toBe('updated inner name')
+        ->and($dto->toArray())->toBe([
+            'name' => 'name',
+            'inner' => [
+                'name' => 'updated inner name',
+                'number' => 2,
+            ],
+        ]);
+});
+
+it('checks that update for nested DTO property reflects while converting DTO to json', function () {
+    $array = [
+        'name' => 'name',
+        'inner' => [
+            'name' => 'inner name',
+            'number' => 2,
+        ],
+    ];
+    $dto = SimpleOuterDTO::fromArray($array);
+
+    $dto->inner->name = 'updated inner name';
+
+    expect($dto->inner->name)->toBe('updated inner name')
+        ->and($dto->toJson())->toBe(json_encode(['name' => 'name', 'inner' => ['name' => 'updated inner name', 'number' => 2]]));
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增了 `SimpleInnerDTO` 和 `SimpleOuterDTO` 两个数据传输对象（DTO），支持嵌套属性及类型转换。
- **修复**
  - 优化了 DTO 转数组时的数据来源，提升了导出数据的准确性。
- **测试**
  - 增加了针对嵌套 DTO 属性序列化为数组和 JSON 的单元测试，确保数据修改能正确反映在序列化结果中。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->