### PR TITLE
Add serialization support to SimpleDTO

### DIFF
--- a/src/validated-dto/src/SimpleDTO.php
+++ b/src/validated-dto/src/SimpleDTO.php
@@ -107,6 +107,16 @@ abstract class SimpleDTO implements BaseDTO, CastsAttributes, JsonSerializable
         return $this->{$name} ?? null;
     }
 
+    public function __serialize(): array
+    {
+        return $this->jsonSerialize();
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->__construct($data);
+    }
+
     /**
      * Cast the given value to a DTO instance.
      *

--- a/tests/ValidatedDTO/Unit/SimpleDTOTest.php
+++ b/tests/ValidatedDTO/Unit/SimpleDTOTest.php
@@ -335,3 +335,18 @@ it('checks that update for nested DTO property reflects while converting DTO to 
     expect($dto->inner->name)->toBe('updated inner name')
         ->and($dto->toJson())->toBe(json_encode(['name' => 'name', 'inner' => ['name' => 'updated inner name', 'number' => 2]]));
 });
+
+it('validates that a SimpleDTO can be instantiated from an Eloquent Model and also get serialized', function () {
+    $model = new class extends Model {
+        protected array $fillable = ['name'];
+    };
+
+    $model->fill(['name' => $this->subject_name]);
+
+    $simpleDTO = SimpleDTOInstance::fromModel($model);
+
+    $serialized = unserialize(serialize($simpleDTO));
+
+    expect($serialized->validatedData)
+        ->toBe(['name' => $this->subject_name]);
+});


### PR DESCRIPTION
Implemented __serialize and __unserialize methods in SimpleDTO to enable native PHP serialization. Added a unit test to verify that SimpleDTO instances can be serialized and unserialized correctly, including when instantiated from an Eloquent Model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 增加了对对象序列化和反序列化的支持，提升了数据传递和存储的灵活性。

- **测试**
  - 新增了针对序列化与反序列化功能的测试用例，确保数据在转换过程中的完整性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->