### PR TITLE
fix the error "Class "FriendsOfHyperf\Support\RedisCommand" not found "

### DIFF
--- a/src/sentry/composer.json
+++ b/src/sentry/composer.json
@@ -22,6 +22,7 @@
         "pull-request": "https://github.com/friendsofhyperf/components/pulls"
     },
     "require": {
+        "friendsofhyperf/support": "~3.1.61",
         "hyperf/command": "~3.1.0",
         "hyperf/context": "~3.1.0",
         "hyperf/coroutine": "~3.1.0",


### PR DESCRIPTION
fix the error "Class "FriendsOfHyperf\Support\RedisCommand" not found " 