### PR TITLE
fix(trigger): 优化 TriggerSubscriber 中的异常处理

### DIFF
--- a/src/trigger/src/Subscriber/TriggerSubscriber.php
+++ b/src/trigger/src/Subscriber/TriggerSubscriber.php
@@ -84,7 +84,11 @@ class TriggerSubscriber extends AbstractSubscriber
                         }
 
                         try {
-                            $this->concurrent->create($closure);
+                            if (is_callable($closure)) {
+                                $this->concurrent->create($closure);
+                            } else {
+                                $this->consumer->logger?->warning('[{connection}] Received non-callable from channel', $context);
+                            }
                         } catch (Throwable $e) {
                             $this->consumer->logger?->error('[{connection}] ' . (string) $e, $context);
                             break;


### PR DESCRIPTION
swoole

Swoole => enabled
Author => Swoole Team <team@swoole.com>
Version => 5.1.6
Built => Jul 25 2025 07:56:39
coroutine => enabled with boost asm context
epoll => enabled
eventfd => enabled
signalfd => enabled
spinlock => enabled
rwlock => enabled
sockets => enabled
openssl => OpenSSL 3.1.6 4 Jun 2024
dtls => enabled
http2 => enabled
json => enabled
curl-native => enabled
zlib => 1.2.13
brotli => E16777225/D16777225
mutex_timedlock => enabled
pthread_barrier => enabled
futex => enabled
mysqlnd => enabled
async_redis => enabled

Directive => Local Value => Master Value
swoole.enable_coroutine => On => On
swoole.enable_library => On => On
swoole.enable_fiber_mock => Off => Off
swoole.enable_preemptive_scheduler => Off => Off
swoole.display_errors => On => On
swoole.use_shortname => Off => Off
swoole.unixsock_buffer_size => 8388608 => 8388608

生产环境报错
[ERROR] [default] TypeError: Hyperf\Coroutine\Concurrent::create(): Argument #1 ($callable) must be of type callable, bool given, called in /vendor/friendsofhyperf/trigger/src/Subscriber/TriggerSubscriber.php on line 87 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **修复问题**
  * 修复了在处理通道回调时，非可调用项会导致错误的问题。现在系统会在遇到不可调用项时记录警告日志。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->