### PR TITLE
Add Arr::every() and Arr::some() methods

### DIFF
--- a/src/macros/output/Hyperf/Collection/Arr.php
+++ b/src/macros/output/Hyperf/Collection/Arr.php
@@ -45,6 +45,17 @@ class Arr
     }
 
     /**
+     * Determine if all items pass the given truth test.
+     *
+     * @param iterable $array
+     * @param (callable(mixed, array-key): bool) $callback
+     * @return bool
+     */
+    public static function every($array, callable $callback)
+    {
+    }
+
+    /**
      * Get a float item from an array using "dot" notation.
      * @return float
      * @throws InvalidArgumentException
@@ -105,6 +116,17 @@ class Arr
      * @return array
      */
     public static function sortByMany($array, $comparisons = [])
+    {
+    }
+
+    /**
+     * Determine if some items pass the given truth test.
+     *
+     * @param iterable $array
+     * @param (callable(mixed, array-key): bool) $callback
+     * @return bool
+     */
+    public static function some($array, callable $callback)
     {
     }
 }

--- a/src/macros/src/ArrMixin.php
+++ b/src/macros/src/ArrMixin.php
@@ -68,6 +68,19 @@ class ArrMixin
         };
     }
 
+    public static function every()
+    {
+        return function ($array, callable $callback) {
+            foreach ($array as $key => $value) {
+                if (! $callback($value, $key)) {
+                    return false;
+                }
+            }
+
+            return true;
+        };
+    }
+
     /**
      * Get a float item from an array using "dot" notation.
      */
@@ -153,6 +166,19 @@ class ArrMixin
             }
 
             return $value;
+        };
+    }
+
+    public static function some()
+    {
+        return function ($array, callable $callback) {
+            foreach ($array as $key => $value) {
+                if ($callback($value, $key)) {
+                    return true;
+                }
+            }
+
+            return false;
         };
     }
 

--- a/tests/Macros/ArrTest.php
+++ b/tests/Macros/ArrTest.php
@@ -230,3 +230,15 @@ test('test sortByMany', function () {
         ['name' => 'John', 'age' => 8, 'meta' => ['key' => 3]],
     ]);
 });
+
+test('test every', function () {
+    $this->assertFalse(Arr::every([1, 2], fn ($value, $key) => is_string($value)));
+    $this->assertFalse(Arr::every(['foo', 2], fn ($value, $key) => is_string($value)));
+    $this->assertTrue(Arr::every(['foo', 'bar'], fn ($value, $key) => is_string($value)));
+});
+
+test('test some', function () {
+    $this->assertFalse(Arr::some([1, 2], fn ($value, $key) => is_string($value)));
+    $this->assertTrue(Arr::some(['foo', 2], fn ($value, $key) => is_string($value)));
+    $this->assertTrue(Arr::some(['foo', 'bar'], fn ($value, $key) => is_string($value)));
+});


### PR DESCRIPTION
## Summary
- Add `Arr::every()` method to check if all items pass a truth test
- Add `Arr::some()` method to check if any items pass a truth test
- Include proper PHPDoc type annotations for both methods
- Add comprehensive test coverage

## Test plan
- [x] Added unit tests for both `every()` and `some()` methods
- [x] Tests cover various scenarios including mixed types
- [x] All tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增了用于判断数组中所有元素或部分元素是否满足条件的 `every` 和 `some` 方法。

* **测试**
  * 增加了针对 `every` 和 `some` 方法的测试用例，确保其功能正确。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->