### PR TITLE
Add Arr::push() method for pushing items into arrays using dot notation

### DIFF
--- a/src/macros/output/Hyperf/Collection/Arr.php
+++ b/src/macros/output/Hyperf/Collection/Arr.php
@@ -100,6 +100,14 @@ class Arr
     }
 
     /**
+     * Push an item into an array using "dot" notation.
+     * @return array
+     */
+    public static function push(ArrayAccess|array &$array, string|int|null $key, mixed ...$values)
+    {
+    }
+
+    /**
      * Get a string item from an array using "dot" notation.
      * @return string
      * @throws InvalidArgumentException

--- a/src/macros/src/ArrMixin.php
+++ b/src/macros/src/ArrMixin.php
@@ -217,4 +217,15 @@ class ArrMixin
             return $array;
         };
     }
+
+    public function push()
+    {
+        return function (ArrayAccess|array &$array, string|int|null $key, mixed ...$values) {
+            $target = Arr::array($array, $key, []); // @phpstan-ignore staticMethod.notFound
+
+            array_push($target, ...$values);
+
+            return Arr::set($array, $key, $target); // @phpstan-ignore staticMethod.notFound
+        };
+    }
 }

--- a/tests/Macros/ArrTest.php
+++ b/tests/Macros/ArrTest.php
@@ -242,3 +242,27 @@ test('test some', function () {
     $this->assertTrue(Arr::some(['foo', 2], fn ($value, $key) => is_string($value)));
     $this->assertTrue(Arr::some(['foo', 'bar'], fn ($value, $key) => is_string($value)));
 });
+
+test('test push', function () {
+    $array = [];
+
+    Arr::push($array, 'office.furniture', 'Desk');
+    $this->assertEquals(['Desk'], $array['office']['furniture']);
+
+    Arr::push($array, 'office.furniture', 'Chair', 'Lamp');
+    $this->assertEquals(['Desk', 'Chair', 'Lamp'], $array['office']['furniture']);
+
+    $array = [];
+
+    Arr::push($array, null, 'Chris', 'Nuno');
+    $this->assertEquals(['Chris', 'Nuno'], $array);
+
+    Arr::push($array, null, 'Taylor');
+    $this->assertEquals(['Chris', 'Nuno', 'Taylor'], $array);
+
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessage('Array value for key [foo.bar] must be an array, boolean found.');
+
+    $array = ['foo' => ['bar' => false]];
+    Arr::push($array, 'foo.bar', 'baz');
+});


### PR DESCRIPTION
## Summary

This PR adds a new `Arr::push()` method that allows pushing items into arrays using dot notation for nested array paths.

## Changes

- Added `push()` method to `ArrMixin` class
- Added corresponding output method to `Arr` class
- Added comprehensive test cases covering various usage scenarios

## Features

- Support for dot notation keys (e.g., 'office.furniture')
- Support for pushing multiple values at once
- Support for root-level pushing (when key is null)
- Proper error handling for non-array targets

## Test Coverage

The implementation includes tests for:
- Basic dot notation pushing
- Multiple value pushing
- Root-level array pushing
- Error handling for invalid target types

## Usage Examples

```php
// Dot notation pushing
$array = [];
Arr::push($array, 'office.furniture', 'Desk', 'Chair');
// Result: ['office' => ['furniture' => ['Desk', 'Chair']]]

// Root-level pushing
Arr::push($array, null, 'item1', 'item2');
// Result: ['item1', 'item2']
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 新增“推入”能力：可用点号路径向数组指定位置追加一个或多个值；路径不存在将自动创建嵌套；未提供路径时默认在顶层追加；对非数组目标给出明确错误提示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->