### PR TITLE
feat: add Arr::push() method for array manipulation with dot notation

### DIFF
--- a/src/macros/output/Hyperf/Collection/Arr.php
+++ b/src/macros/output/Hyperf/Collection/Arr.php
@@ -103,7 +103,7 @@ class Arr
      * Push an item into an array using "dot" notation.
      * @return array
      */
-    public static function push(ArrayAccess|array &$array, string|int|null $key, mixed ...$values)
+    public static function push(array $array, string|int|null $key, mixed ...$values)
     {
     }
 

--- a/src/macros/output/Hyperf/Collection/Arr.php
+++ b/src/macros/output/Hyperf/Collection/Arr.php
@@ -100,6 +100,14 @@ class Arr
     }
 
     /**
+     * Push an item into an array using "dot" notation.
+     * @return array
+     */
+    public static function push(ArrayAccess|array &$array, string|int|null $key, mixed ...$values)
+    {
+    }
+
+    /**
      * Get a string item from an array using "dot" notation.
      * @return string
      * @throws InvalidArgumentException

--- a/src/macros/src/ArrMixin.php
+++ b/src/macros/src/ArrMixin.php
@@ -220,12 +220,28 @@ class ArrMixin
 
     public function push()
     {
-        return function (ArrayAccess|array &$array, string|int|null $key, mixed ...$values) {
-            $target = Arr::array($array, $key, []); // @phpstan-ignore staticMethod.notFound
+        return function (array $array, string|int|null $key, mixed ...$values) {
+            if ($key === null) {
+                foreach ($values as $value) {
+                    $array[] = $value;
+                }
+                return $array;
+            }
 
-            array_push($target, ...$values);
-
-            return Arr::set($array, $key, $target); // @phpstan-ignore staticMethod.notFound
+            $current = Arr::get($array, $key, []);
+            
+            if (!is_array($current)) {
+                throw new InvalidArgumentException(
+                    sprintf('Array value for key [%s] must be an array, %s found.', $key, gettype($current))
+                );
+            }
+            
+            $merged = array_merge($current, $values);
+            
+            $result = $array;
+            Arr::set($result, $key, $merged);
+            
+            return $result;
         };
     }
 }

--- a/src/macros/src/ArrMixin.php
+++ b/src/macros/src/ArrMixin.php
@@ -217,4 +217,15 @@ class ArrMixin
             return $array;
         };
     }
+
+    public function push()
+    {
+        return function (ArrayAccess|array &$array, string|int|null $key, mixed ...$values) {
+            $target = Arr::array($array, $key, []); // @phpstan-ignore staticMethod.notFound
+
+            array_push($target, ...$values);
+
+            return Arr::set($array, $key, $target); // @phpstan-ignore staticMethod.notFound
+        };
+    }
 }

--- a/tests/Macros/ArrTest.php
+++ b/tests/Macros/ArrTest.php
@@ -8,7 +8,11 @@ declare(strict_types=1);
  * @document https://github.com/friendsofhyperf/components/blob/main/README.md
  * @contact  huangdijia@gmail.com
  */
+use FriendsOfHyperf\Macros\ArrMixin;
 use Hyperf\Collection\Arr;
+
+// Register the mixin for tests
+Arr::mixin(new ArrMixin());
 
 require_once __DIR__ . '/Stubs/Common.php';
 
@@ -246,18 +250,18 @@ test('test some', function () {
 test('test push', function () {
     $array = [];
 
-    Arr::push($array, 'office.furniture', 'Desk');
+    $array = Arr::push($array, 'office.furniture', 'Desk');
     $this->assertEquals(['Desk'], $array['office']['furniture']);
 
-    Arr::push($array, 'office.furniture', 'Chair', 'Lamp');
+    $array = Arr::push($array, 'office.furniture', 'Chair', 'Lamp');
     $this->assertEquals(['Desk', 'Chair', 'Lamp'], $array['office']['furniture']);
 
     $array = [];
 
-    Arr::push($array, null, 'Chris', 'Nuno');
+    $array = Arr::push($array, null, 'Chris', 'Nuno');
     $this->assertEquals(['Chris', 'Nuno'], $array);
 
-    Arr::push($array, null, 'Taylor');
+    $array = Arr::push($array, null, 'Taylor');
     $this->assertEquals(['Chris', 'Nuno', 'Taylor'], $array);
 
     $this->expectException(InvalidArgumentException::class);

--- a/tests/Macros/ArrTest.php
+++ b/tests/Macros/ArrTest.php
@@ -242,3 +242,27 @@ test('test some', function () {
     $this->assertTrue(Arr::some(['foo', 2], fn ($value, $key) => is_string($value)));
     $this->assertTrue(Arr::some(['foo', 'bar'], fn ($value, $key) => is_string($value)));
 });
+
+test('test push', function () {
+    $array = [];
+
+    Arr::push($array, 'office.furniture', 'Desk');
+    $this->assertEquals(['Desk'], $array['office']['furniture']);
+
+    Arr::push($array, 'office.furniture', 'Chair', 'Lamp');
+    $this->assertEquals(['Desk', 'Chair', 'Lamp'], $array['office']['furniture']);
+
+    $array = [];
+
+    Arr::push($array, null, 'Chris', 'Nuno');
+    $this->assertEquals(['Chris', 'Nuno'], $array);
+
+    Arr::push($array, null, 'Taylor');
+    $this->assertEquals(['Chris', 'Nuno', 'Taylor'], $array);
+
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessage('Array value for key [foo.bar] must be an array, boolean found.');
+
+    $array = ['foo' => ['bar' => false]];
+    Arr::push($array, 'foo.bar', 'baz');
+});


### PR DESCRIPTION
This PR adds a new Arr::push() method to the Hyperf Collection Arr class, enabling users to push values to arrays at any depth using dot notation.

## Features
- **Dot notation support**: Push values to nested arrays using dot notation (e.g., 'office.furniture')
- **Root-level pushing**: Support for pushing values to root-level arrays
- **Multiple value support**: Accept multiple values in a single call
- **Type safety**: Validates target is an array before pushing
- **Clear error messages**: Descriptive InvalidArgumentException for type mismatches

## Usage Examples


## Implementation Details
- Uses Arr::get() and Arr::set() for reliable dot notation handling
- Follows return-based pattern to work with Hyperf's macro system
- Comprehensive test coverage included
- IDE support via output class signature

## Testing
All tests pass including:
- Basic dot notation pushing
- Multiple value pushing  
- Root-level array pushing
- Error handling for invalid types
- Integration with macro system

The implementation has been thoroughly tested and follows the existing codebase patterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新功能
  * 新增数组推入能力，支持“点”路径向嵌套位置追加多个值；当键为空时追加到根级；对非数组目标给出明确错误提示。
* 测试
  * 增加单元测试，覆盖嵌套追加、根级追加与异常场景，确保行为稳定可靠。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->