### PR TITLE
Upgrade sentry/sentry from 4.4.0 to 4.15.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "psr/http-factory-implementation": "*",
         "psy/psysh": "^0.10.0 || ^0.11.0",
         "ramsey/uuid": "^4.7",
-        "sentry/sentry": "^4.4.0",
+        "sentry/sentry": "^4.15.0",
         "symfony/console": "^5.3 || ^6.0 || ^7.0",
         "symfony/http-foundation": "^5.3 || ^6.0 || ^7.0",
         "symfony/process": "^5.3 || ^6.0 || ^7.0",

--- a/src/sentry/README.md
+++ b/src/sentry/README.md
@@ -30,9 +30,9 @@ return [
     // ...
     'sentry' => [
         'handler' => [
-            'class' => FriendsOfHyperf\Sentry\SentryHandler::class,
+            'class' => \Sentry\Monolog\LogsHandler::class,
             'constructor' => [
-                'level' => \Monolog\Level::Debug,
+                'level' => \Sentry\Logs\LogLevel::debug(),
             ],
         ],
         'formatter' => [

--- a/src/sentry/composer.json
+++ b/src/sentry/composer.json
@@ -33,7 +33,7 @@
         "hyperf/http-server": "~3.1.0",
         "hyperf/support": "~3.1.0",
         "hyperf/tappable": "~3.1.0",
-        "sentry/sentry": "^4.4.0"
+        "sentry/sentry": "^4.15.0"
     },
     "suggest": {
         "elasticsearch/elasticsearch": "Required to use the elasticsearch client (^7.0|^8.0).",

--- a/src/sentry/src/SentryHandler.php
+++ b/src/sentry/src/SentryHandler.php
@@ -26,6 +26,9 @@ use Sentry\SentrySdk;
 use Sentry\State\Scope;
 use Throwable;
 
+/**
+ * @deprecated since v3.1, use `Sentry\Monolog\LogsHandler` instead, will remove in v3.2
+ */
 class SentryHandler extends AbstractProcessingHandler
 {
     use CompatibilityProcessingHandlerTrait;


### PR DESCRIPTION
## Summary

This PR upgrades the sentry/sentry package from version 4.4.0 to 4.15.0 across the project.

## Changes

- Updated sentry/sentry version constraint from ^4.4.0 to ^4.15.0 in:
  - Root composer.json
  - src/sentry/composer.json
- Added deprecation notice to SentryHandler class recommending migration to Sentry\Monolog\LogsHandler

## Testing

- [ ] Verify that all existing Sentry functionality continues to work
- [ ] Test error reporting and logging
- [ ] Check that no breaking changes affect the current implementation

## Migration Notes

Users are encouraged to migrate from  to  as the former is deprecated and will be removed in v3.2.