### PR TITLE
Optimize RedisCommand formatting with caching

### DIFF
--- a/src/support/src/RedisCommand.php
+++ b/src/support/src/RedisCommand.php
@@ -17,13 +17,15 @@ use function Hyperf\Collection\collect;
 
 class RedisCommand implements Stringable
 {
+    private ?string $formatted = null;
+
     public function __construct(public string $command, public array $parameters = [])
     {
     }
 
     public function __toString(): string
     {
-        return $this->formatCommand($this->command, $this->parameters);
+        return $this->formatted ??= $this->formatCommand($this->command, $this->parameters);
     }
 
     protected function formatCommand(string $command, array $parameters): string


### PR DESCRIPTION
## Summary
- Add private `$formatted` property to cache the formatted command string
- Use null coalescing assignment operator to prevent redundant formatting operations
- Improve performance when `__toString()` is called multiple times on the same RedisCommand instance

## Test plan
- [ ] Verify existing functionality remains unchanged
- [ ] Test that repeated calls to `__toString()` return consistent results
- [ ] Run existing test suite to ensure no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 性能优化
  - 对命令字符串的格式化结果进行缓存，避免重复计算，在多次转换为字符串时显著降低开销并提升响应速度；对外行为保持一致，无需任何配置或迁移。
- 重构
  - 调整内部实现以引入惰性计算与缓存机制，不影响现有接口或使用方式，全面兼容现有调用场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->