### PR TITLE
fix(macros): throw original ValidationException with error bag in RequestMixin

### DIFF
--- a/src/macros/src/RequestMixin.php
+++ b/src/macros/src/RequestMixin.php
@@ -379,8 +379,7 @@ class RequestMixin
             try {
                 $this->validate($rules, ...$params);
             } catch (ValidationException $e) {
-                $e->errorBag = $errorBag;
-                throw new $e();
+                throw $e->errorBag($errorBag);
             }
         };
     }


### PR DESCRIPTION
This fixes RequestMixin::validateWithBag() to rethrow the original ValidationException while setting the error bag via method chaining (errorBag()).\n\n- Replaces dynamic instantiation of caught exception\n- Preserves exception type, stack trace, and context\n\nRef: vendor/hyperf/validation/src/ValidationException.php

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新特性
  - 无
- 重构
  - 优化请求验证的异常处理：改用方法驱动的错误袋附加与抛出，减少属性突变与实例重建，使代码更清晰且行为更一致；不影响现有表单验证与错误展示；在边界场景下可降低异常处理歧义与潜在副作用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->