### PR TITLE
chore: fix naming/spelling; rename DatabaseMessages→DatabaseMessage (BC alias)

### DIFF
--- a/src/cache/src/CacheInterface.php
+++ b/src/cache/src/CacheInterface.php
@@ -15,7 +15,7 @@ class_alias(Contract\Repository::class, CacheInterface::class);
 
 if (false) { // @phpstan-ignore-line
     /**
-     * @deprecated since v3.1, use `\FriendsOfHyperf\Cache\Contract\Repository` instead, will removed in v3.2
+     * @deprecated since v3.1, use `\FriendsOfHyperf\Cache\Contract\Repository` instead, will be removed in v3.2
      */
     interface CacheInterface extends Contract\Repository
     {

--- a/src/cache/src/ConfigProvider.php
+++ b/src/cache/src/ConfigProvider.php
@@ -19,8 +19,8 @@ class ConfigProvider
             'dependencies' => [
                 Contract\Factory::class => fn ($container) => $container->get(CacheManager::class),
                 Contract\Repository::class => RepositoryFactory::class,
-                Contract\CacheInterface::class => fn ($container) => $container->get(Contract\Repository::class), // Will removed in v3.2
-                CacheInterface::class => fn ($container) => $container->get(Contract\Repository::class), // Will removed in v3.2
+                Contract\CacheInterface::class => fn ($container) => $container->get(Contract\Repository::class), // Will be removed in v3.2
+                CacheInterface::class => fn ($container) => $container->get(Contract\Repository::class), // Will be removed in v3.2
             ],
         ];
     }

--- a/src/cache/src/Contract/CacheInterface.php
+++ b/src/cache/src/Contract/CacheInterface.php
@@ -15,7 +15,7 @@ class_alias(Repository::class, CacheInterface::class);
 
 if (false) { // @phpstan-ignore-line
     /**
-     * @deprecated since v3.1, use `\FriendsOfHyperf\Cache\Contract\Repository` instead, will removed in v3.2
+     * @deprecated since v3.1, use `\FriendsOfHyperf\Cache\Contract\Repository` instead, will be removed in v3.2
      */
     interface CacheInterface extends Repository
     {

--- a/src/helpers/src/Functions.php
+++ b/src/helpers/src/Functions.php
@@ -215,14 +215,14 @@ function dispatch($job, ...$arguments)
             ->getProducer((string) ($arguments[0] ?? 'default'))
             ->sendBatch([$job]),
         class_exists(AsyncTask::class) && interface_exists(AsyncTaskInterface::class) && $job instanceof AsyncTaskInterface => AsyncTask::deliver($job, ...$arguments), // @deprecated since v3.1, will be removed in v3.2
-        default => throw new InvalidArgumentException('Not Support job type.')
+        default => throw new InvalidArgumentException('Unsupported job type.')
     };
 }
 
 /**
  * @param mixed $environments
  * @return bool|Environment
- * @deprecated since 3.1, use `Str::is($patterns, env('APP_ENV'))` instead, will removed in 3.2.
+ * @deprecated since 3.1, use `Str::is($patterns, env('APP_ENV'))` instead, will be removed in 3.2.
  */
 function environment(...$environments)
 {

--- a/src/notification/src/Message/DatabaseMessage.php
+++ b/src/notification/src/Message/DatabaseMessage.php
@@ -27,7 +27,7 @@ class_alias(DatabaseMessage::class, DatabaseMessages::class);
 
 if (false) { // @phpstan-ignore-line
     /**
-     * @deprecated Use DatabaseMessage instead. Will be removed in v3.2.
+     * @deprecated since v3.1, use `DatabaseMessage` instead. Will be removed in v3.2.
      */
     class DatabaseMessages extends DatabaseMessage
     {

--- a/src/notification/src/Message/DatabaseMessage.php
+++ b/src/notification/src/Message/DatabaseMessage.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Notification\Message;
 
-class DatabaseMessages
+class DatabaseMessage
 {
     /**
      * Create a new message instance.
@@ -20,5 +20,16 @@ class DatabaseMessages
     public function __construct(
         public array $data
     ) {
+    }
+}
+
+class_alias(DatabaseMessage::class, DatabaseMessages::class);
+
+if (false) { // @phpstan-ignore-line
+    /**
+     * @deprecated Use DatabaseMessage instead. Will be removed in v3.2.
+     */
+    class DatabaseMessages extends DatabaseMessage
+    {
     }
 }

--- a/src/notification/src/Message/DatabaseMessages.php
+++ b/src/notification/src/Message/DatabaseMessages.php
@@ -11,14 +11,9 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Notification\Message;
 
-class DatabaseMessage
+/**
+ * @deprecated since v3.1, use `DatabaseMessage` instead. Will be removed in v3.2.
+ */
+class DatabaseMessages extends DatabaseMessage
 {
-    /**
-     * Create a new message instance.
-     * @param array $data the data that should be stored with the notification
-     */
-    public function __construct(
-        public array $data
-    ) {
-    }
 }

--- a/src/recaptcha/src/ReCaptchaManager.php
+++ b/src/recaptcha/src/ReCaptchaManager.php
@@ -40,7 +40,7 @@ class ReCaptchaManager
         }
 
         if (! $this->config->has('recaptcha')) {
-            throw new RuntimeException('Not publish yet, please run \'php bin/hyperf.php vendor:publish friendsofhyperf/recaptcha\'');
+            throw new RuntimeException('Configuration not published yet, please run \'php bin/hyperf.php vendor:publish friendsofhyperf/recaptcha\'.');
         }
 
         $version ??= (string) $this->config->get('recaptcha.default', 'v3');

--- a/src/support/src/Environment.php
+++ b/src/support/src/Environment.php
@@ -23,7 +23,7 @@ use function Hyperf\Support\env;
  * @method bool isDevelop()
  * @method bool isProduction()
  * @method bool isOnline()
- * @deprecated since 3.1, use `Str::is($patterns, env('APP_ENV'))` instead, will removed in 3.2.
+ * @deprecated since 3.1, use `Str::is($patterns, env('APP_ENV'))` instead, will be removed in 3.2.
  */
 class Environment
 {

--- a/src/support/src/Once/Backtrace.php
+++ b/src/support/src/Once/Backtrace.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace FriendsOfHyperf\Support\Once;
 
 /**
- * @deprecated since v3.1, use FriendsOfHyperf\Support\Onceable instead, will removed in v3.2
+ * @deprecated since v3.1, use FriendsOfHyperf\Support\Onceable instead, will be removed in v3.2
  */
 class Backtrace
 {

--- a/src/support/src/Once/Cache.php
+++ b/src/support/src/Once/Cache.php
@@ -15,7 +15,7 @@ use Countable;
 use WeakMap;
 
 /**
- * @deprecated since v3.1, use FriendsOfHyperf\Support\Once instead, will removed in v3.2
+ * @deprecated since v3.1, use FriendsOfHyperf\Support\Once instead, will be removed in v3.2
  */
 class Cache implements Countable
 {

--- a/src/telescope/src/EntryType.php
+++ b/src/telescope/src/EntryType.php
@@ -41,6 +41,10 @@ class EntryType
 
     public const REQUEST = 'request';
 
+    /**
+     * Alias for SCHEDULE; kept for backward compatibility.
+     * @deprecated Use EntryType::SCHEDULE instead. Will be removed in v3.2.
+     */
     public const SCHEDULED_TASK = 'schedule';
 
     public const GATE = 'gate';

--- a/tests/Notification/Stubs/NotificationDatabaseChannelCustomizeTypeTestNotification.php
+++ b/tests/Notification/Stubs/NotificationDatabaseChannelCustomizeTypeTestNotification.php
@@ -11,14 +11,14 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Tests\Notification\Stubs;
 
-use FriendsOfHyperf\Notification\Message\DatabaseMessages;
+use FriendsOfHyperf\Notification\Message\DatabaseMessage;
 use FriendsOfHyperf\Notification\Notification;
 
 class NotificationDatabaseChannelCustomizeTypeTestNotification extends Notification
 {
-    public function toDatabase($notifiable): DatabaseMessages
+    public function toDatabase($notifiable): DatabaseMessage
     {
-        return new DatabaseMessages([
+        return new DatabaseMessage([
             'invoice_id' => 1,
         ]);
     }

--- a/tests/Notification/Stubs/NotificationDatabaseChannelTestNotification.php
+++ b/tests/Notification/Stubs/NotificationDatabaseChannelTestNotification.php
@@ -11,14 +11,14 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Tests\Notification\Stubs;
 
-use FriendsOfHyperf\Notification\Message\DatabaseMessages;
+use FriendsOfHyperf\Notification\Message\DatabaseMessage;
 use FriendsOfHyperf\Notification\Notification;
 
 class NotificationDatabaseChannelTestNotification extends Notification
 {
-    public function toDatabase($notifiable): DatabaseMessages
+    public function toDatabase($notifiable): DatabaseMessage
     {
-        return new DatabaseMessages([
+        return new DatabaseMessage([
             'message' => 'Hello World',
         ]);
     }


### PR DESCRIPTION
This PR fixes wording/naming issues and clarifies deprecations.

Changes:
- Replace 'Not Support job type.' with 'Unsupported job type.' in helpers
- Correct 'will removed' → 'will be removed' across deprecation notes
- Improve ReCaptcha configuration message when not published
- Document EntryType::SCHEDULED_TASK as a deprecated alias of SCHEDULE
- Rename DatabaseMessages → DatabaseMessage; update tests; add class_alias for backward compatibility
- Tweak comments in cache ConfigProvider (Will be removed in v3.2)

Notes:
- The rename is non-breaking via class_alias, but projects should migrate to DatabaseMessage.
- SCHEDULED_TASK is marked deprecated and can be removed in v3.2.