### PR TITLE
fix: change default values to true in Sentry Switcher

### DIFF
--- a/src/sentry/src/Switcher.php
+++ b/src/sentry/src/Switcher.php
@@ -24,12 +24,12 @@ class Switcher
 
     public function isEnable(string $key): bool
     {
-        return (bool) $this->config->get('sentry.enable.' . $key, false);
+        return (bool) $this->config->get('sentry.enable.' . $key, true);
     }
 
     public function isBreadcrumbEnable(string $key): bool
     {
-        return (bool) $this->config->get('sentry.breadcrumbs.' . $key, false);
+        return (bool) $this->config->get('sentry.breadcrumbs.' . $key, true);
     }
 
     public function isTracingEnable(string $key): bool
@@ -38,7 +38,7 @@ class Switcher
             return false;
         }
 
-        return (bool) $this->config->get('sentry.tracing.enable.' . $key, false);
+        return (bool) $this->config->get('sentry.tracing.enable.' . $key, true);
     }
 
     public function isTracingSpanEnable(string $key): bool
@@ -47,12 +47,12 @@ class Switcher
             return false;
         }
 
-        return (bool) $this->config->get('sentry.tracing.spans.' . $key, false);
+        return (bool) $this->config->get('sentry.tracing.spans.' . $key, true);
     }
 
     public function isTracingExtraTagEnable(string $key): bool
     {
-        return (bool) ($this->config->get('sentry.tracing.extra_tags', [])[$key] ?? false);
+        return (bool) ($this->config->get('sentry.tracing.extra_tags', [])[$key] ?? true);
     }
 
     public function isExceptionIgnored(string|Throwable $exception): bool


### PR DESCRIPTION
## Summary
- Changed default values from `false` to `true` for all Sentry Switcher methods
- Affects configuration defaults for enable, breadcrumbs, tracing, spans, and extra tags

## Changes
Updated default values in the following methods:
- `isEnable()`: false → true
- `isBreadcrumbEnable()`: false → true  
- `isTracingEnable()`: false → true
- `isTracingSpanEnable()`: false → true
- `isTracingExtraTagEnable()`: false → true

## Impact
This change ensures Sentry features are enabled by default unless explicitly disabled in the configuration, following the principle of opt-out rather than opt-in for monitoring capabilities.

## Test plan
- [ ] Verify existing configurations continue to work as expected
- [ ] Confirm Sentry features are enabled by default without explicit configuration
- [ ] Test that explicit `false` values in config still disable features