### PR TITLE
refactor(sentry): replace CarrierPacker with new Carrier utility class

### DIFF
--- a/src/sentry/src/Tracing/Aspect/AmqpProducerAspect.php
+++ b/src/sentry/src/Tracing/Aspect/AmqpProducerAspect.php
@@ -91,7 +91,7 @@ class AmqpProducerAspect extends AbstractAspect
 
         (function () use ($carrier) {
             $this->properties['application_headers'] ??= new AMQPTable();
-            $this->properties['application_headers']->set(Constants::TRACE_CARRIER, (string) $carrier);
+            $this->properties['application_headers']->set(Constants::TRACE_CARRIER, $carrier->toJson());
         })->call($producerMessage);
 
         return tap($proceedingJoinPoint->process(), fn () => $span->setOrigin('auto.amqp')->finish());

--- a/src/sentry/src/Tracing/Aspect/AmqpProducerAspect.php
+++ b/src/sentry/src/Tracing/Aspect/AmqpProducerAspect.php
@@ -14,7 +14,7 @@ namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 use FriendsOfHyperf\Sentry\Constants;
 use FriendsOfHyperf\Sentry\Switcher;
 use FriendsOfHyperf\Sentry\Tracing\SpanStarter;
-use FriendsOfHyperf\Sentry\Util\CarrierPacker;
+use FriendsOfHyperf\Sentry\Util\Carrier;
 use Hyperf\Amqp\Message\ProducerMessage;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
@@ -33,10 +33,8 @@ class AmqpProducerAspect extends AbstractAspect
         'Hyperf\Amqp\Producer::produceMessage',
     ];
 
-    public function __construct(
-        protected Switcher $switcher,
-        protected CarrierPacker $packer
-    ) {
+    public function __construct(protected Switcher $switcher)
+    {
     }
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
@@ -84,8 +82,7 @@ class AmqpProducerAspect extends AbstractAspect
             'messaging.amqp.message.exchange' => $producerMessage->getExchange(),
             'messaging.amqp.message.pool_name' => $producerMessage->getPoolName(),
         ]);
-
-        $carrier = $this->packer->pack($span, [
+        $carrier = Carrier::fromSpan($span)->with([
             'publish_time' => microtime(true),
             'message_id' => $messageId,
             'destination_name' => $destinationName,
@@ -94,7 +91,7 @@ class AmqpProducerAspect extends AbstractAspect
 
         (function () use ($carrier) {
             $this->properties['application_headers'] ??= new AMQPTable();
-            $this->properties['application_headers']->set(Constants::TRACE_CARRIER, $carrier);
+            $this->properties['application_headers']->set(Constants::TRACE_CARRIER, (string) $carrier);
         })->call($producerMessage);
 
         return tap($proceedingJoinPoint->process(), fn () => $span->setOrigin('auto.amqp')->finish());

--- a/src/sentry/src/Tracing/Aspect/AsyncQueueJobMessageAspect.php
+++ b/src/sentry/src/Tracing/Aspect/AsyncQueueJobMessageAspect.php
@@ -151,15 +151,11 @@ class AsyncQueueJobMessageAspect extends AbstractAspect
     {
         /** @var array $data */
         $data = $proceedingJoinPoint->arguments['keys']['data'] ?? [];
-        $carrier = null;
-
-        if (is_array($data)) {
-            if (array_is_list($data)) {
-                $carrier = array_last($data);
-            } elseif (isset($data['job'])) {
-                $carrier = $data[Constants::TRACE_CARRIER] ?? '';
-            }
-        }
+        $carrier = match (true) {
+            is_array($data) && array_is_list($data) => array_last($data),
+            isset($data['job']) => $data[Constants::TRACE_CARRIER] ?? '',
+            default => null,
+        };
 
         /** @var string|null $carrier */
         if ($carrier) {

--- a/src/sentry/src/Tracing/Aspect/RpcAspect.php
+++ b/src/sentry/src/Tracing/Aspect/RpcAspect.php
@@ -14,7 +14,7 @@ namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 use FriendsOfHyperf\Sentry\Constants;
 use FriendsOfHyperf\Sentry\Switcher;
 use FriendsOfHyperf\Sentry\Tracing\SpanStarter;
-use FriendsOfHyperf\Sentry\Util\CarrierPacker;
+use FriendsOfHyperf\Sentry\Util\Carrier;
 use Hyperf\Context\Context;
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Coroutine\Coroutine;
@@ -46,8 +46,7 @@ class RpcAspect extends AbstractAspect
 
     public function __construct(
         protected ContainerInterface $container,
-        protected Switcher $switcher,
-        protected CarrierPacker $packer
+        protected Switcher $switcher
     ) {
     }
 
@@ -99,7 +98,7 @@ class RpcAspect extends AbstractAspect
         Context::set(static::SPAN, $span->setData($data));
 
         if ($this->container->has(Rpc\Context::class)) {
-            $this->container->get(Rpc\Context::class)->set(Constants::TRACE_CARRIER, $this->packer->pack($span));
+            $this->container->get(Rpc\Context::class)->set(Constants::TRACE_CARRIER, Carrier::fromSpan($span)->toJson());
         }
 
         return $path;

--- a/src/sentry/src/Tracing/Listener/TracingAmqpListener.php
+++ b/src/sentry/src/Tracing/Listener/TracingAmqpListener.php
@@ -64,7 +64,6 @@ class TracingAmqpListener implements ListenerInterface
     protected function startTransaction(BeforeConsume $event): void
     {
         $message = $event->getMessage();
-        $sentryTrace = $baggage = '';
 
         if (method_exists($event, 'getAMQPMessage')) {
             /** @var AMQPMessage $amqpMessage */
@@ -72,14 +71,14 @@ class TracingAmqpListener implements ListenerInterface
             /** @var AMQPTable|null $applicationHeaders */
             $applicationHeaders = $amqpMessage->has('application_headers') ? $amqpMessage->get('application_headers') : null;
             if ($applicationHeaders && isset($applicationHeaders[Constants::TRACE_CARRIER])) {
-                [$sentryTrace, $baggage] = Carrier::fromJson($applicationHeaders[Constants::TRACE_CARRIER])->extract();
-                Context::set(Constants::TRACE_CARRIER, $applicationHeaders[Constants::TRACE_CARRIER]);
+                $carrier = Carrier::fromJson($applicationHeaders[Constants::TRACE_CARRIER]);
+                Context::set(Constants::TRACE_CARRIER, $carrier);
             }
         }
 
         $this->continueTrace(
-            sentryTrace: $sentryTrace,
-            baggage: $baggage,
+            sentryTrace: $carrier?->getSentryTrace(),
+            baggage: $carrier?->getBaggage(),
             name: $message::class,
             op: 'queue.process',
             description: $message::class,
@@ -96,19 +95,19 @@ class TracingAmqpListener implements ListenerInterface
             return;
         }
 
-        $carrier = Carrier::fromJson((string) Context::get(Constants::TRACE_CARRIER));
-        $payload = $carrier->toArray();
+        /** @var Carrier|null $carrier */
+        $carrier = Context::get(Constants::TRACE_CARRIER);
 
         /** @var ConsumerMessage $message */
         $message = $event->getMessage();
         $data = [
             'messaging.system' => 'amqp',
             'messaging.operation' => 'process',
-            'messaging.message.id' => $payload['message_id'] ?? null,
-            'messaging.message.body.size' => $payload['body_size'] ?? null,
-            'messaging.message.receive.latency' => isset($payload['publish_time']) ? (microtime(true) - $payload['publish_time']) : null,
+            'messaging.message.id' => $carrier->get('message_id'),
+            'messaging.message.body.size' => $carrier->get('body_size'),
+            'messaging.message.receive.latency' => $carrier->has('publish_time') ? (microtime(true) - $carrier->get('publish_time')) : null,
             'messaging.message.retry.count' => 0,
-            'messaging.destination.name' => $payload['destination_name'] ?? $message->getExchange(),
+            'messaging.destination.name' => $carrier->get('destination_name') ?? $message->getExchange(),
             // for amqp
             'messaging.amqp.message.type' => $message->getTypeString(),
             'messaging.amqp.message.routing_key' => $message->getRoutingKey(),

--- a/src/sentry/src/Tracing/Listener/TracingAmqpListener.php
+++ b/src/sentry/src/Tracing/Listener/TracingAmqpListener.php
@@ -64,6 +64,7 @@ class TracingAmqpListener implements ListenerInterface
     protected function startTransaction(BeforeConsume $event): void
     {
         $message = $event->getMessage();
+        $carrier = null;
 
         if (method_exists($event, 'getAMQPMessage')) {
             /** @var AMQPMessage $amqpMessage */

--- a/src/sentry/src/Tracing/Listener/TracingAmqpListener.php
+++ b/src/sentry/src/Tracing/Listener/TracingAmqpListener.php
@@ -104,11 +104,11 @@ class TracingAmqpListener implements ListenerInterface
         $data = [
             'messaging.system' => 'amqp',
             'messaging.operation' => 'process',
-            'messaging.message.id' => $carrier->get('message_id'),
-            'messaging.message.body.size' => $carrier->get('body_size'),
-            'messaging.message.receive.latency' => $carrier->has('publish_time') ? (microtime(true) - $carrier->get('publish_time')) : null,
+            'messaging.message.id' => $carrier?->get('message_id'),
+            'messaging.message.body.size' => $carrier?->get('body_size'),
+            'messaging.message.receive.latency' => $carrier?->has('publish_time') ? (microtime(true) - $carrier->get('publish_time')) : null,
             'messaging.message.retry.count' => 0,
-            'messaging.destination.name' => $carrier->get('destination_name') ?? $message->getExchange(),
+            'messaging.destination.name' => $carrier?->get('destination_name') ?? $message->getExchange(),
             // for amqp
             'messaging.amqp.message.type' => $message->getTypeString(),
             'messaging.amqp.message.routing_key' => $message->getRoutingKey(),

--- a/src/sentry/src/Tracing/Listener/TracingKafkaListener.php
+++ b/src/sentry/src/Tracing/Listener/TracingKafkaListener.php
@@ -76,8 +76,8 @@ class TracingKafkaListener implements ListenerInterface
         }
 
         $this->continueTrace(
-            sentryTrace: (string) $carrier?->getSentryTrace(),
-            baggage: (string) $carrier?->getBaggage(),
+            sentryTrace: $carrier?->getSentryTrace() ?? '',
+            baggage: $carrier?->getBaggage() ?? '',
             name: $consumer->getTopic() . ' process',
             op: 'queue.process',
             description: $consumer::class,

--- a/src/sentry/src/Tracing/Listener/TracingKafkaListener.php
+++ b/src/sentry/src/Tracing/Listener/TracingKafkaListener.php
@@ -14,7 +14,7 @@ namespace FriendsOfHyperf\Sentry\Tracing\Listener;
 use FriendsOfHyperf\Sentry\Constants;
 use FriendsOfHyperf\Sentry\Switcher;
 use FriendsOfHyperf\Sentry\Tracing\SpanStarter;
-use FriendsOfHyperf\Sentry\Util\CarrierPacker;
+use FriendsOfHyperf\Sentry\Util\Carrier;
 use Hyperf\Context\Context;
 use Hyperf\Event\Contract\ListenerInterface;
 use Hyperf\Kafka\Event\AfterConsume;
@@ -30,8 +30,7 @@ class TracingKafkaListener implements ListenerInterface
     use SpanStarter;
 
     public function __construct(
-        protected Switcher $switcher,
-        protected CarrierPacker $packer
+        protected Switcher $switcher
     ) {
     }
 
@@ -64,21 +63,20 @@ class TracingKafkaListener implements ListenerInterface
     {
         $consumer = $event->getConsumer();
         $message = $event->getData();
-        $sentryTrace = $baggage = '';
 
         if ($message instanceof ConsumeMessage) {
             foreach ($message->getHeaders() as $header) {
                 if ($header->getHeaderKey() === Constants::TRACE_CARRIER) {
-                    [$sentryTrace, $baggage] = $this->packer->unpack($header->getValue());
-                    Context::set(Constants::TRACE_CARRIER, $header->getValue());
+                    $carrier = Carrier::fromJson($header->getValue());
+                    Context::set(Constants::TRACE_CARRIER, $carrier);
                     break;
                 }
             }
         }
 
         $this->continueTrace(
-            sentryTrace: $sentryTrace,
-            baggage: $baggage,
+            sentryTrace: $carrier->getSentryTrace(),
+            baggage: $carrier->getBaggage(),
             name: $consumer->getTopic() . ' process',
             op: 'queue.process',
             description: $consumer::class,
@@ -95,21 +93,18 @@ class TracingKafkaListener implements ListenerInterface
             return;
         }
 
-        $payload = [];
-        if ($carrier = (string) Context::get(Constants::TRACE_CARRIER)) {
-            $payload = json_decode($carrier, true);
-        }
-
+        /** @var Carrier|null $carrier */
+        $carrier = Context::get(Constants::TRACE_CARRIER);
         $consumer = $event->getConsumer();
         $tags = [];
         $data = [
             'messaging.system' => 'kafka',
             'messaging.operation' => 'process',
-            'messaging.message.id' => $payload['message_id'] ?? null,
-            'messaging.message.body.size' => $payload['body_size'] ?? null,
-            'messaging.message.receive.latency' => isset($payload['publish_time']) ? (microtime(true) - $payload['publish_time']) : null,
+            'messaging.message.id' => $carrier->get('message_id'),
+            'messaging.message.body.size' => $carrier->get('body_size'),
+            'messaging.message.receive.latency' => $carrier->has('publish_time') ? (microtime(true) - $carrier->get('publish_time')) : null,
             'messaging.message.retry.count' => 0,
-            'messaging.destination.name' => $payload['destination_name'] ?? 'unknown',
+            'messaging.destination.name' => $carrier->get('destination_name'),
             // for kafka
             'messaging.kafka.consumer.group' => $consumer->getGroupId(),
             'messaging.kafka.consumer.pool' => $consumer->getPool(),

--- a/src/sentry/src/Tracing/Listener/TracingKafkaListener.php
+++ b/src/sentry/src/Tracing/Listener/TracingKafkaListener.php
@@ -63,6 +63,7 @@ class TracingKafkaListener implements ListenerInterface
     {
         $consumer = $event->getConsumer();
         $message = $event->getData();
+        $carrier = null;
 
         if ($message instanceof ConsumeMessage) {
             foreach ($message->getHeaders() as $header) {
@@ -75,8 +76,8 @@ class TracingKafkaListener implements ListenerInterface
         }
 
         $this->continueTrace(
-            sentryTrace: $carrier->getSentryTrace(),
-            baggage: $carrier->getBaggage(),
+            sentryTrace: (string) $carrier?->getSentryTrace(),
+            baggage: (string) $carrier?->getBaggage(),
             name: $consumer->getTopic() . ' process',
             op: 'queue.process',
             description: $consumer::class,
@@ -100,11 +101,11 @@ class TracingKafkaListener implements ListenerInterface
         $data = [
             'messaging.system' => 'kafka',
             'messaging.operation' => 'process',
-            'messaging.message.id' => $carrier->get('message_id'),
-            'messaging.message.body.size' => $carrier->get('body_size'),
-            'messaging.message.receive.latency' => $carrier->has('publish_time') ? (microtime(true) - $carrier->get('publish_time')) : null,
+            'messaging.message.id' => $carrier?->get('message_id'),
+            'messaging.message.body.size' => $carrier?->get('body_size'),
+            'messaging.message.receive.latency' => $carrier?->has('publish_time') ? (microtime(true) - $carrier->get('publish_time')) : null,
             'messaging.message.retry.count' => 0,
-            'messaging.destination.name' => $carrier->get('destination_name'),
+            'messaging.destination.name' => $carrier?->get('destination_name'),
             // for kafka
             'messaging.kafka.consumer.group' => $consumer->getGroupId(),
             'messaging.kafka.consumer.pool' => $consumer->getPool(),

--- a/src/sentry/src/Tracing/SpanStarter.php
+++ b/src/sentry/src/Tracing/SpanStarter.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace FriendsOfHyperf\Sentry\Tracing;
 
 use FriendsOfHyperf\Sentry\Constants;
-use FriendsOfHyperf\Sentry\Util\CarrierPacker;
+use FriendsOfHyperf\Sentry\Util\Carrier;
 use Hyperf\Context\ApplicationContext;
 use Hyperf\Rpc\Context as RpcContext;
 use Psr\Http\Message\ServerRequestInterface;
@@ -59,12 +59,13 @@ trait SpanStarter
         $baggage = $request->getHeaderLine('baggage');
         $container = $this->container ?? ApplicationContext::getContainer();
 
+        // Rpc Context
         if ($container->has(RpcContext::class)) {
             $rpcContext = $container->get(RpcContext::class);
-            $carrier = $rpcContext->get(Constants::TRACE_CARRIER);
-            if ($carrier) {
-                $packer = $container->get(CarrierPacker::class);
-                [$sentryTrace, $baggage] = $packer->unpack($carrier);
+            $payload = $rpcContext->get(Constants::TRACE_CARRIER);
+            if ($payload) {
+                $carrier = Carrier::fromJson($payload);
+                [$sentryTrace, $baggage] = [$carrier->getSentryTrace(), $carrier->getBaggage()];
             }
         }
 

--- a/src/sentry/src/Tracing/SpanStarter.php
+++ b/src/sentry/src/Tracing/SpanStarter.php
@@ -62,6 +62,7 @@ trait SpanStarter
         // Rpc Context
         if ($container->has(RpcContext::class)) {
             $rpcContext = $container->get(RpcContext::class);
+            /** @var string|null $payload */
             $payload = $rpcContext->get(Constants::TRACE_CARRIER);
             if ($payload) {
                 $carrier = Carrier::fromJson($payload);

--- a/src/sentry/src/Util/Carrier.php
+++ b/src/sentry/src/Util/Carrier.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Sentry\Util;
 
-use Hyperf\Collection\Arr;
 use Hyperf\Contract\Arrayable;
 use Hyperf\Contract\Jsonable;
 use JsonException;
@@ -98,20 +97,6 @@ class Carrier implements JsonSerializable, Arrayable, Stringable, Jsonable
     public function get(string $key, mixed $default = null): mixed
     {
         return $this->data[$key] ?? $default;
-    }
-
-    public function extract(): array
-    {
-        return [
-            $this->data['sentry-trace'] ?? $this->data['traceparent'] ?? '',
-            $this->data['baggage'] ?? '',
-            $this->data['traceparent'] ?? '',
-        ];
-    }
-
-    public function only(array $keys): array
-    {
-        return Arr::only($this->data, $keys);
     }
 
     public function jsonSerialize(): mixed

--- a/src/sentry/src/Util/Carrier.php
+++ b/src/sentry/src/Util/Carrier.php
@@ -38,7 +38,14 @@ class Carrier implements JsonSerializable, Arrayable, Stringable, Jsonable
 
     public static function fromJson(string $json): static
     {
-        $data = (array) json_decode($json, true);
+        try {
+            $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+            if (! is_array($data)) {
+                $data = [];
+            }
+        } catch (JsonException $e) {
+            $data = [];
+        }
 
         return new static($data);
     }

--- a/src/sentry/src/Util/Carrier.php
+++ b/src/sentry/src/Util/Carrier.php
@@ -65,15 +65,6 @@ class Carrier implements JsonSerializable, Arrayable, Stringable, Jsonable
         return $new;
     }
 
-    public function withSpan(Span $span): static
-    {
-        return $this->with([
-            'sentry-trace' => $span->toTraceparent(),
-            'baggage' => $span->toBaggage(),
-            'traceparent' => $span->toW3CTraceparent(),
-        ]);
-    }
-
     public function getSentryTrace(): string
     {
         return $this->data['sentry-trace'] ?? '';

--- a/src/sentry/src/Util/Carrier.php
+++ b/src/sentry/src/Util/Carrier.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of friendsofhyperf/components.
+ *
+ * @link     https://github.com/friendsofhyperf/components
+ * @document https://github.com/friendsofhyperf/components/blob/main/README.md
+ * @contact  huangdijia@gmail.com
+ */
+
+namespace FriendsOfHyperf\Sentry\Util;
+
+use Hyperf\Collection\Arr;
+use Hyperf\Contract\Arrayable;
+use JsonSerializable;
+use Sentry\Tracing\Span;
+use Stringable;
+
+class Carrier implements JsonSerializable, Arrayable, Stringable
+{
+    public function __construct(
+        protected array $data = []
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return json_encode($this->data, JSON_UNESCAPED_UNICODE);
+    }
+
+    public static function fromArray(array $data): static
+    {
+        return new static($data);
+    }
+
+    public static function fromJson(string $json): static
+    {
+        $data = (array) json_decode($json, true);
+
+        return new static($data);
+    }
+
+    public static function fromSpan(Span $span): static
+    {
+        return new static([
+            'sentry-trace' => $span->toTraceparent(),
+            'baggage' => $span->toBaggage(),
+            'traceparent' => $span->toW3CTraceparent(),
+        ]);
+    }
+
+    public function with(array $data): static
+    {
+        $new = clone $this;
+        $new->data = array_merge($this->data, $data);
+        return $new;
+    }
+
+    public function withSpan(Span $span): static
+    {
+        return $this->with([
+            'sentry-trace' => $span->toTraceparent(),
+            'baggage' => $span->toBaggage(),
+            'traceparent' => $span->toW3CTraceparent(),
+        ]);
+    }
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return $this->data[$key] ?? $default;
+    }
+
+    public function extract(): array
+    {
+        return [
+            $this->data['sentry-trace'] ?? $this->data['traceparent'] ?? '',
+            $this->data['baggage'] ?? '',
+            $this->data['traceparent'] ?? '',
+        ];
+    }
+
+    public function only(array $keys): array
+    {
+        return Arr::only($this->data, $keys);
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return $this->data;
+    }
+
+    public function toArray(): array
+    {
+        return $this->jsonSerialize();
+    }
+}

--- a/src/sentry/src/Util/CarrierPacker.php
+++ b/src/sentry/src/Util/CarrierPacker.php
@@ -14,6 +14,9 @@ namespace FriendsOfHyperf\Sentry\Util;
 use Sentry\Tracing\Span;
 use Throwable;
 
+/**
+ * @deprecated since v3.1, use FriendsOfHyperf\Sentry\Util\Carrier instead, will be removed in v3.2
+ */
 class CarrierPacker
 {
     /**

--- a/tests/Sentry/CarrierTest.php
+++ b/tests/Sentry/CarrierTest.php
@@ -95,19 +95,6 @@ describe('Data Manipulation', function () {
             'key3' => 'new',
         ]);
     });
-
-    test('can add span data using withSpan method', function () {
-        $spanContext = new SpanContext();
-        $span = new Span($spanContext);
-
-        $carrier = new Carrier(['existing' => 'data']);
-        $newCarrier = $carrier->withSpan($span);
-
-        $data = $newCarrier->toArray();
-        expect($data)->toHaveKey('existing');
-        expect($data)->toHaveKeys(['sentry-trace', 'baggage', 'traceparent']);
-        expect($data['existing'])->toBe('data');
-    });
 });
 
 describe('Data Access', function () {

--- a/tests/Sentry/CarrierTest.php
+++ b/tests/Sentry/CarrierTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace FriendsOfHyperf\Tests\Sentry;
 
 use FriendsOfHyperf\Sentry\Util\Carrier;
-use JsonException;
 use Sentry\Tracing\Span;
 use Sentry\Tracing\SpanContext;
 
@@ -100,7 +99,7 @@ describe('Data Manipulation', function () {
     test('can add span data using withSpan method', function () {
         $spanContext = new SpanContext();
         $span = new Span($spanContext);
-        
+
         $carrier = new Carrier(['existing' => 'data']);
         $newCarrier = $carrier->withSpan($span);
 
@@ -158,54 +157,6 @@ describe('Data Access', function () {
     });
 });
 
-describe('Data Extraction', function () {
-    test('extract returns array with tracing data', function () {
-        $carrier = new Carrier($this->testData);
-        $extracted = $carrier->extract();
-
-        expect($extracted)->toBe([
-            '12345678901234567890123456789012-1234567890123456-1',
-            'sentry-trace_id=12345678901234567890123456789012,sentry-public_key=public_key',
-            '00-12345678901234567890123456789012-1234567890123456-01',
-        ]);
-    });
-
-    test('extract handles missing sentry-trace gracefully', function () {
-        $data = $this->testData;
-        unset($data['sentry-trace']);
-        $carrier = new Carrier($data);
-        $extracted = $carrier->extract();
-
-        expect($extracted[0])->toBe('00-12345678901234567890123456789012-1234567890123456-01');
-    });
-
-    test('extract handles missing traceparent and sentry-trace gracefully', function () {
-        $data = $this->testData;
-        unset($data['sentry-trace'], $data['traceparent']);
-        $carrier = new Carrier($data);
-        $extracted = $carrier->extract();
-
-        expect($extracted[0])->toBe('');
-    });
-
-    test('only returns specified keys', function () {
-        $carrier = new Carrier($this->testData);
-        $result = $carrier->only(['custom_field', 'publish_time']);
-
-        expect($result)->toBe([
-            'custom_field' => 'custom_value',
-            'publish_time' => 1234567890.123,
-        ]);
-    });
-
-    test('only handles nonexistent keys gracefully', function () {
-        $carrier = new Carrier($this->testData);
-        $result = $carrier->only(['nonexistent', 'custom_field']);
-
-        expect($result)->toBe(['custom_field' => 'custom_value']);
-    });
-});
-
 describe('Serialization', function () {
     test('implements JsonSerializable', function () {
         $carrier = new Carrier($this->testData);
@@ -220,7 +171,7 @@ describe('Serialization', function () {
     test('toJson returns valid JSON string', function () {
         $carrier = new Carrier($this->testData);
         $json = $carrier->toJson();
-        
+
         expect($json)->toBeString();
         expect(json_decode($json, true))->toBe($this->testData);
     });
@@ -229,7 +180,7 @@ describe('Serialization', function () {
         $data = ['key' => 'value with unicode: 中文'];
         $carrier = new Carrier($data);
         $json = $carrier->toJson(JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
-        
+
         expect($json)->toContain('中文');
         expect($json)->toContain("\n"); // Pretty print adds newlines
     });
@@ -239,7 +190,7 @@ describe('Serialization', function () {
         $resource = fopen('php://memory', 'r');
         $carrier = new Carrier(['resource' => $resource]);
         fclose($resource);
-        
+
         $json = $carrier->toJson();
         expect($json)->toBe('{}');
     });
@@ -247,7 +198,7 @@ describe('Serialization', function () {
     test('__toString returns JSON representation', function () {
         $carrier = new Carrier($this->testData);
         $string = (string) $carrier;
-        
+
         expect($string)->toBe($carrier->toJson());
         expect(json_decode($string, true))->toBe($this->testData);
     });
@@ -255,7 +206,7 @@ describe('Serialization', function () {
     test('can be JSON encoded directly', function () {
         $carrier = new Carrier($this->testData);
         $json = json_encode($carrier);
-        
+
         expect(json_decode($json, true))->toBe($this->testData);
     });
 });
@@ -264,7 +215,7 @@ describe('Edge Cases and Error Handling', function () {
     test('handles null values in data', function () {
         $data = ['key' => null, 'other' => 'value'];
         $carrier = new Carrier($data);
-        
+
         expect($carrier->get('key'))->toBeNull();
         expect($carrier->has('key'))->toBeFalse(); // isset() returns false for null values
         expect($carrier->toArray())->toBe($data);
@@ -278,7 +229,7 @@ describe('Edge Cases and Error Handling', function () {
             'float' => 3.14,
         ];
         $carrier = new Carrier($data);
-        
+
         expect($carrier->get('bool_true'))->toBeTrue();
         expect($carrier->get('bool_false'))->toBeFalse();
         expect($carrier->get('int'))->toBe(42);
@@ -291,7 +242,7 @@ describe('Edge Cases and Error Handling', function () {
             'object' => (object) ['property' => 'value'],
         ];
         $carrier = new Carrier($data);
-        
+
         expect($carrier->get('array'))->toBe(['nested', 'array']);
         expect($carrier->get('object'))->toBeInstanceOf('stdClass');
     });
@@ -299,7 +250,7 @@ describe('Edge Cases and Error Handling', function () {
     test('immutability of original carrier in with method', function () {
         $original = new Carrier(['original' => 'data']);
         $modified = $original->with(['new' => 'data']);
-        
+
         expect($original === $modified)->toBeFalse();
         expect($original->has('new'))->toBeFalse();
         expect($modified->has('new'))->toBeTrue();
@@ -309,11 +260,11 @@ describe('Edge Cases and Error Handling', function () {
         $data = ['nested' => ['array' => 'value']];
         $original = new Carrier($data);
         $modified = $original->with(['other' => 'data']);
-        
+
         // Modify the nested array in the modified carrier
         $modifiedData = $modified->toArray();
         $modifiedData['nested']['array'] = 'changed';
-        
+
         // Original should remain unchanged
         expect($original->get('nested'))->toBe(['array' => 'value']);
     });
@@ -324,7 +275,7 @@ describe('Integration Tests', function () {
         $original = new Carrier($this->testData);
         $json = $original->toJson();
         $restored = Carrier::fromJson($json);
-        
+
         expect($restored->toArray())->toBe($original->toArray());
     });
 
@@ -333,7 +284,7 @@ describe('Integration Tests', function () {
             ->with(['step1' => 'data1'])
             ->with(['step2' => 'data2'])
             ->with(['step1' => 'updated']); // Override step1
-        
+
         expect($carrier->toArray())->toBe([
             'step1' => 'updated',
             'step2' => 'data2',
@@ -343,14 +294,14 @@ describe('Integration Tests', function () {
     test('works with Span integration', function () {
         $spanContext = new SpanContext();
         $span = new Span($spanContext);
-        
+
         $carrier = Carrier::fromSpan($span)
             ->with(['custom' => 'data']);
-        
+
         $data = $carrier->toArray();
         expect($data)->toHaveKey('custom');
         expect($data)->toHaveKeys(['sentry-trace', 'baggage', 'traceparent']);
-        
+
         // Test round trip
         $json = $carrier->toJson();
         $restored = Carrier::fromJson($json);

--- a/tests/Sentry/CarrierTest.php
+++ b/tests/Sentry/CarrierTest.php
@@ -1,0 +1,360 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of friendsofhyperf/components.
+ *
+ * @link     https://github.com/friendsofhyperf/components
+ * @document https://github.com/friendsofhyperf/components/blob/main/README.md
+ * @contact  huangdijia@gmail.com
+ */
+
+namespace FriendsOfHyperf\Tests\Sentry;
+
+use FriendsOfHyperf\Sentry\Util\Carrier;
+use JsonException;
+use Sentry\Tracing\Span;
+use Sentry\Tracing\SpanContext;
+
+beforeEach(function () {
+    $this->testData = [
+        'sentry-trace' => '12345678901234567890123456789012-1234567890123456-1',
+        'baggage' => 'sentry-trace_id=12345678901234567890123456789012,sentry-public_key=public_key',
+        'traceparent' => '00-12345678901234567890123456789012-1234567890123456-01',
+        'custom_field' => 'custom_value',
+        'publish_time' => 1234567890.123,
+    ];
+});
+
+describe('Carrier Construction', function () {
+    test('can be constructed with empty data', function () {
+        $carrier = new Carrier();
+        expect($carrier->toArray())->toBe([]);
+    });
+
+    test('can be constructed with initial data', function () {
+        $carrier = new Carrier($this->testData);
+        expect($carrier->toArray())->toBe($this->testData);
+    });
+
+    test('can be created from array', function () {
+        $carrier = Carrier::fromArray($this->testData);
+        expect($carrier->toArray())->toBe($this->testData);
+    });
+
+    test('can be created from valid JSON', function () {
+        $json = json_encode($this->testData);
+        $carrier = Carrier::fromJson($json);
+        expect($carrier->toArray())->toBe($this->testData);
+    });
+
+    test('handles invalid JSON gracefully', function () {
+        $carrier = Carrier::fromJson('invalid json');
+        expect($carrier->toArray())->toBe([]);
+    });
+
+    test('handles non-array JSON gracefully', function () {
+        $carrier = Carrier::fromJson('"string value"');
+        expect($carrier->toArray())->toBe([]);
+    });
+
+    test('handles empty JSON', function () {
+        $carrier = Carrier::fromJson('');
+        expect($carrier->toArray())->toBe([]);
+    });
+
+    test('can be created from Span', function () {
+        $spanContext = new SpanContext();
+        $span = new Span($spanContext);
+
+        $carrier = Carrier::fromSpan($span);
+        $data = $carrier->toArray();
+
+        expect($data)->toHaveKeys(['sentry-trace', 'baggage', 'traceparent']);
+        expect($data['sentry-trace'])->toBeString();
+        expect($data['baggage'])->toBeString();
+        expect($data['traceparent'])->toBeString();
+    });
+});
+
+describe('Data Manipulation', function () {
+    test('can add data using with method', function () {
+        $carrier = new Carrier(['existing' => 'value']);
+        $newCarrier = $carrier->with(['new' => 'data']);
+
+        expect($carrier->toArray())->toBe(['existing' => 'value']);
+        expect($newCarrier->toArray())->toBe(['existing' => 'value', 'new' => 'data']);
+    });
+
+    test('with method merges data correctly', function () {
+        $carrier = new Carrier(['key1' => 'value1', 'key2' => 'value2']);
+        $newCarrier = $carrier->with(['key2' => 'updated', 'key3' => 'new']);
+
+        expect($newCarrier->toArray())->toBe([
+            'key1' => 'value1',
+            'key2' => 'updated',
+            'key3' => 'new',
+        ]);
+    });
+
+    test('can add span data using withSpan method', function () {
+        $spanContext = new SpanContext();
+        $span = new Span($spanContext);
+        
+        $carrier = new Carrier(['existing' => 'data']);
+        $newCarrier = $carrier->withSpan($span);
+
+        $data = $newCarrier->toArray();
+        expect($data)->toHaveKey('existing');
+        expect($data)->toHaveKeys(['sentry-trace', 'baggage', 'traceparent']);
+        expect($data['existing'])->toBe('data');
+    });
+});
+
+describe('Data Access', function () {
+    test('can check if key exists', function () {
+        $carrier = new Carrier($this->testData);
+
+        expect($carrier->has('sentry-trace'))->toBeTrue();
+        expect($carrier->has('nonexistent'))->toBeFalse();
+    });
+
+    test('can get value by key', function () {
+        $carrier = new Carrier($this->testData);
+
+        expect($carrier->get('custom_field'))->toBe('custom_value');
+        expect($carrier->get('nonexistent'))->toBeNull();
+        expect($carrier->get('nonexistent', 'default'))->toBe('default');
+    });
+
+    test('getSentryTrace returns correct value', function () {
+        $carrier = new Carrier($this->testData);
+        expect($carrier->getSentryTrace())->toBe('12345678901234567890123456789012-1234567890123456-1');
+    });
+
+    test('getSentryTrace returns empty string when not set', function () {
+        $carrier = new Carrier();
+        expect($carrier->getSentryTrace())->toBe('');
+    });
+
+    test('getBaggage returns correct value', function () {
+        $carrier = new Carrier($this->testData);
+        expect($carrier->getBaggage())->toBe('sentry-trace_id=12345678901234567890123456789012,sentry-public_key=public_key');
+    });
+
+    test('getBaggage returns empty string when not set', function () {
+        $carrier = new Carrier();
+        expect($carrier->getBaggage())->toBe('');
+    });
+
+    test('getTraceparent returns correct value', function () {
+        $carrier = new Carrier($this->testData);
+        expect($carrier->getTraceparent())->toBe('00-12345678901234567890123456789012-1234567890123456-01');
+    });
+
+    test('getTraceparent returns empty string when not set', function () {
+        $carrier = new Carrier();
+        expect($carrier->getTraceparent())->toBe('');
+    });
+});
+
+describe('Data Extraction', function () {
+    test('extract returns array with tracing data', function () {
+        $carrier = new Carrier($this->testData);
+        $extracted = $carrier->extract();
+
+        expect($extracted)->toBe([
+            '12345678901234567890123456789012-1234567890123456-1',
+            'sentry-trace_id=12345678901234567890123456789012,sentry-public_key=public_key',
+            '00-12345678901234567890123456789012-1234567890123456-01',
+        ]);
+    });
+
+    test('extract handles missing sentry-trace gracefully', function () {
+        $data = $this->testData;
+        unset($data['sentry-trace']);
+        $carrier = new Carrier($data);
+        $extracted = $carrier->extract();
+
+        expect($extracted[0])->toBe('00-12345678901234567890123456789012-1234567890123456-01');
+    });
+
+    test('extract handles missing traceparent and sentry-trace gracefully', function () {
+        $data = $this->testData;
+        unset($data['sentry-trace'], $data['traceparent']);
+        $carrier = new Carrier($data);
+        $extracted = $carrier->extract();
+
+        expect($extracted[0])->toBe('');
+    });
+
+    test('only returns specified keys', function () {
+        $carrier = new Carrier($this->testData);
+        $result = $carrier->only(['custom_field', 'publish_time']);
+
+        expect($result)->toBe([
+            'custom_field' => 'custom_value',
+            'publish_time' => 1234567890.123,
+        ]);
+    });
+
+    test('only handles nonexistent keys gracefully', function () {
+        $carrier = new Carrier($this->testData);
+        $result = $carrier->only(['nonexistent', 'custom_field']);
+
+        expect($result)->toBe(['custom_field' => 'custom_value']);
+    });
+});
+
+describe('Serialization', function () {
+    test('implements JsonSerializable', function () {
+        $carrier = new Carrier($this->testData);
+        expect($carrier->jsonSerialize())->toBe($this->testData);
+    });
+
+    test('toArray returns correct data', function () {
+        $carrier = new Carrier($this->testData);
+        expect($carrier->toArray())->toBe($this->testData);
+    });
+
+    test('toJson returns valid JSON string', function () {
+        $carrier = new Carrier($this->testData);
+        $json = $carrier->toJson();
+        
+        expect($json)->toBeString();
+        expect(json_decode($json, true))->toBe($this->testData);
+    });
+
+    test('toJson with custom options', function () {
+        $data = ['key' => 'value with unicode: 中文'];
+        $carrier = new Carrier($data);
+        $json = $carrier->toJson(JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
+        
+        expect($json)->toContain('中文');
+        expect($json)->toContain("\n"); // Pretty print adds newlines
+    });
+
+    test('toJson handles encoding errors gracefully', function () {
+        // Create data that cannot be JSON encoded
+        $resource = fopen('php://memory', 'r');
+        $carrier = new Carrier(['resource' => $resource]);
+        fclose($resource);
+        
+        $json = $carrier->toJson();
+        expect($json)->toBe('{}');
+    });
+
+    test('__toString returns JSON representation', function () {
+        $carrier = new Carrier($this->testData);
+        $string = (string) $carrier;
+        
+        expect($string)->toBe($carrier->toJson());
+        expect(json_decode($string, true))->toBe($this->testData);
+    });
+
+    test('can be JSON encoded directly', function () {
+        $carrier = new Carrier($this->testData);
+        $json = json_encode($carrier);
+        
+        expect(json_decode($json, true))->toBe($this->testData);
+    });
+});
+
+describe('Edge Cases and Error Handling', function () {
+    test('handles null values in data', function () {
+        $data = ['key' => null, 'other' => 'value'];
+        $carrier = new Carrier($data);
+        
+        expect($carrier->get('key'))->toBeNull();
+        expect($carrier->has('key'))->toBeFalse(); // isset() returns false for null values
+        expect($carrier->toArray())->toBe($data);
+    });
+
+    test('handles boolean and numeric values', function () {
+        $data = [
+            'bool_true' => true,
+            'bool_false' => false,
+            'int' => 42,
+            'float' => 3.14,
+        ];
+        $carrier = new Carrier($data);
+        
+        expect($carrier->get('bool_true'))->toBeTrue();
+        expect($carrier->get('bool_false'))->toBeFalse();
+        expect($carrier->get('int'))->toBe(42);
+        expect($carrier->get('float'))->toBe(3.14);
+    });
+
+    test('handles array and object values', function () {
+        $data = [
+            'array' => ['nested', 'array'],
+            'object' => (object) ['property' => 'value'],
+        ];
+        $carrier = new Carrier($data);
+        
+        expect($carrier->get('array'))->toBe(['nested', 'array']);
+        expect($carrier->get('object'))->toBeInstanceOf('stdClass');
+    });
+
+    test('immutability of original carrier in with method', function () {
+        $original = new Carrier(['original' => 'data']);
+        $modified = $original->with(['new' => 'data']);
+        
+        expect($original === $modified)->toBeFalse();
+        expect($original->has('new'))->toBeFalse();
+        expect($modified->has('new'))->toBeTrue();
+    });
+
+    test('deep cloning behavior', function () {
+        $data = ['nested' => ['array' => 'value']];
+        $original = new Carrier($data);
+        $modified = $original->with(['other' => 'data']);
+        
+        // Modify the nested array in the modified carrier
+        $modifiedData = $modified->toArray();
+        $modifiedData['nested']['array'] = 'changed';
+        
+        // Original should remain unchanged
+        expect($original->get('nested'))->toBe(['array' => 'value']);
+    });
+});
+
+describe('Integration Tests', function () {
+    test('round trip JSON serialization', function () {
+        $original = new Carrier($this->testData);
+        $json = $original->toJson();
+        $restored = Carrier::fromJson($json);
+        
+        expect($restored->toArray())->toBe($original->toArray());
+    });
+
+    test('chaining operations', function () {
+        $carrier = (new Carrier())
+            ->with(['step1' => 'data1'])
+            ->with(['step2' => 'data2'])
+            ->with(['step1' => 'updated']); // Override step1
+        
+        expect($carrier->toArray())->toBe([
+            'step1' => 'updated',
+            'step2' => 'data2',
+        ]);
+    });
+
+    test('works with Span integration', function () {
+        $spanContext = new SpanContext();
+        $span = new Span($spanContext);
+        
+        $carrier = Carrier::fromSpan($span)
+            ->with(['custom' => 'data']);
+        
+        $data = $carrier->toArray();
+        expect($data)->toHaveKey('custom');
+        expect($data)->toHaveKeys(['sentry-trace', 'baggage', 'traceparent']);
+        
+        // Test round trip
+        $json = $carrier->toJson();
+        $restored = Carrier::fromJson($json);
+        expect($restored->getSentryTrace())->toBe($carrier->getSentryTrace());
+        expect($restored->get('custom'))->toBe('data');
+    });
+});


### PR DESCRIPTION
## Summary
- Replace CarrierPacker dependency with new Carrier utility class in AmqpProducerAspect and TracingAmqpListener
- Add new Carrier utility class with fluent API for span carrier operations  
- Deprecate CarrierPacker class (marked for removal in v3.2)
- Simplify constructor dependencies by removing CarrierPacker injection

## Changes Made
- **AmqpProducerAspect.php**: Removed CarrierPacker dependency, updated to use `Carrier::fromSpan()` method
- **TracingAmqpListener.php**: Removed CarrierPacker dependency, updated to use `Carrier::fromJson()` method
- **CarrierPacker.php**: Added deprecation notice for v3.2 removal
- **Carrier.php**: Added new utility class with fluent API for carrier operations

## Test plan
- [ ] Verify AMQP producer tracing still works correctly
- [ ] Verify AMQP consumer tracing still works correctly
- [ ] Confirm carrier data is properly packed/unpacked
- [ ] Run existing test suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 新增通用追踪载体 Carrier，支持数组/JSON/Span 的构建与读取（fromJson/fromSpan/toJson 等）。

- 重构
  - 多处生产/消费侧追踪（AMQP/Kafka/RPC/异步队列/监听器/SpanStarter 等）统一改为使用 Carrier，追踪头以 JSON 字符串存储，构造函数简化，上下文读写统一，向后兼容处理。

- 杂务
  - 将旧版 CarrierPacker 标记为已弃用，建议迁移至 Carrier。

- 测试
  - 新增 Carrier 单元测试，覆盖序列化、反序列化、Span 集成与边界情况。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->