### PR TITLE
fix(tracing): standardize HTTP response field names in GuzzleHttpClientAspect

### DIFF
--- a/src/sentry/publish/sentry.php
+++ b/src/sentry/publish/sentry.php
@@ -115,7 +115,7 @@ return [
             'annotation.result' => false,
             'db.result' => false,
             'elasticsearch.result' => false,
-            'response.body' => false,
+            'http.response.body.contents' => false,
             'redis.result' => false,
             'rpc.result' => false,
         ],


### PR DESCRIPTION
## Summary
- Standardize HTTP response field names in GuzzleHttpClientAspect to follow HTTP semantic conventions
- Update configuration key to match new field naming
- Improve HTTP status-based span status handling

## Changes
- `response.status` → `http.response.status_code`
- `response.reason` → `http.response.reason`  
- `response.headers` → `http.response.headers`
- `response.body.size` → `http.response.body.size`
- `response.body` → `http.response.body.contents`
- Update config key from `response.body` to `http.response.body.contents`
- Add proper HTTP status-based span status setting using `SpanStatus::createFromHttpStatusCode()`
- Improve error handling with standardized field names

## Test plan
- [ ] Verify HTTP tracing still works correctly with new field names
- [ ] Test configuration option `http.response.body.contents` works as expected
- [ ] Confirm span status is properly set based on HTTP status codes
- [ ] Validate error scenarios still capture appropriate data