### PR TITLE
fix(tracing): use routing key for AMQP destination name instead of exchange

### DIFF
--- a/src/sentry/src/Tracing/Aspect/AmqpProducerAspect.php
+++ b/src/sentry/src/Tracing/Aspect/AmqpProducerAspect.php
@@ -85,7 +85,7 @@ class AmqpProducerAspect extends AbstractAspect
         }
 
         $messageId = uniqid('amqp_', true);
-        $destinationName = $exchange ?: 'default';
+        $destinationName = implode(', ', (array) $routingKey);
         $bodySize = strlen($producerMessage->payload());
         $span->setData([
             'messaging.system' => 'amqp',

--- a/src/sentry/src/Tracing/Listener/TracingAmqpListener.php
+++ b/src/sentry/src/Tracing/Listener/TracingAmqpListener.php
@@ -109,7 +109,7 @@ class TracingAmqpListener implements ListenerInterface
             'messaging.message.body.size' => $carrier?->get('body_size'),
             'messaging.message.receive.latency' => $carrier?->has('publish_time') ? (microtime(true) - $carrier->get('publish_time')) : null,
             'messaging.message.retry.count' => 0,
-            'messaging.destination.name' => $carrier?->get('destination_name') ?: $message->getExchange(),
+            'messaging.destination.name' => $carrier?->get('destination_name') ?: implode(', ', (array) $message->getRoutingKey()),
             // for amqp
             'messaging.amqp.message.type' => $message->getTypeString(),
             'messaging.amqp.message.routing_key' => $message->getRoutingKey(),


### PR DESCRIPTION
## Summary
- Update AmqpProducerAspect to use routing key for destination name instead of exchange
- Update TracingAmqpListener to use routing key for destination name instead of exchange  
- Improves tracing accuracy by using more specific routing information

## Test plan
- [ ] Verify AMQP producer tracing shows correct destination name based on routing key
- [ ] Verify AMQP consumer tracing shows correct destination name based on routing key
- [ ] Test with multiple routing keys to ensure comma-separated format works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 发送与消费路径的目的地名称计算逻辑保持一致，提升追踪数据的可读性与可比性。
- 缺陷修复
  - 调整 AMQP 追踪的目的地名称：改为基于 routing key（标量直取、数组逗号拼接），不再回退到交换机或默认值。
  - messaging.destination.name 与 Carrier.destination_name 现与实际路由一致；routing key 缺失时为空字符串。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->