### PR TITLE
feat(sentry): improve event flushing and expand listener coverage

### DIFF
--- a/src/sentry/src/Aspect/CoroutineAspect.php
+++ b/src/sentry/src/Aspect/CoroutineAspect.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Sentry\Aspect;
 
+use FriendsOfHyperf\Sentry\Integration;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Hyperf\Engine\Coroutine as Co;
@@ -49,6 +50,8 @@ class CoroutineAspect extends AbstractAspect
             } catch (Throwable $throwable) {
                 SentrySdk::getCurrentHub()->captureException($throwable);
                 throw $throwable;
+            } finally {
+                Integration::flushEvents();
             }
         };
 

--- a/src/sentry/src/Integration.php
+++ b/src/sentry/src/Integration.php
@@ -14,6 +14,7 @@ namespace FriendsOfHyperf\Sentry;
 use Sentry\Breadcrumb;
 use Sentry\Event;
 use Sentry\Integration\IntegrationInterface;
+use Sentry\Logs\Logs;
 use Sentry\SentrySdk;
 use Sentry\State\Scope;
 use Sentry\Tracing\Span;
@@ -108,6 +109,8 @@ class Integration implements IntegrationInterface
 
         if ($client !== null) {
             $client->flush();
+
+            Logs::getInstance()->flush();
         }
     }
 

--- a/src/sentry/src/Listener/AmqpExceptionListener.php
+++ b/src/sentry/src/Listener/AmqpExceptionListener.php
@@ -19,12 +19,13 @@ class AmqpExceptionListener extends CaptureExceptionListener
     {
         return [
             Event\BeforeConsume::class,
+            Event\AfterConsume::class,
             Event\FailToConsume::class,
         ];
     }
 
     /**
-     * @param Event\FailToConsume $event
+     * @param Event\FailToConsume|Event\AfterConsume|Event\BeforeConsume|object $event
      */
     public function process(object $event): void
     {
@@ -35,6 +36,12 @@ class AmqpExceptionListener extends CaptureExceptionListener
         match ($event::class) {
             Event\FailToConsume::class => $this->captureException($event->getThrowable()),
             default => $this->setupSentrySdk(),
+        };
+
+        match ($event::class) {
+            Event\AfterConsume::class,
+            Event\FailToConsume::class => $this->flushEvents(),
+            default => null,
         };
     }
 }

--- a/src/sentry/src/Listener/CaptureExceptionListener.php
+++ b/src/sentry/src/Listener/CaptureExceptionListener.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Sentry\Listener;
 
+use FriendsOfHyperf\Sentry\Integration;
 use FriendsOfHyperf\Sentry\Switcher;
 use Hyperf\Context\Context;
 use Hyperf\Contract\StdoutLoggerInterface;
@@ -59,5 +60,10 @@ abstract class CaptureExceptionListener implements ListenerInterface
 
         SentrySdk::init();
         Context::set(static::SETUP, true);
+    }
+
+    protected function flushEvents(): void
+    {
+        Integration::flushEvents();
     }
 }

--- a/src/sentry/src/Listener/CommandExceptionListener.php
+++ b/src/sentry/src/Listener/CommandExceptionListener.php
@@ -20,11 +20,12 @@ class CommandExceptionListener extends CaptureExceptionListener
         return [
             Event\BeforeHandle::class,
             Event\FailToHandle::class,
+            Event\AfterExecute::class,
         ];
     }
 
     /**
-     * @param Event\FailToHandle $event
+     * @param Event\FailToHandle|Event\BeforeHandle|Event\AfterExecute|object $event
      */
     public function process(object $event): void
     {
@@ -34,6 +35,7 @@ class CommandExceptionListener extends CaptureExceptionListener
 
         match ($event::class) {
             Event\FailToHandle::class => $this->captureException($event->getThrowable()),
+            Event\AfterExecute::class => $this->flushEvents(),
             default => $this->setupSentrySdk(),
         };
     }

--- a/src/sentry/src/Listener/CrontabExceptionListener.php
+++ b/src/sentry/src/Listener/CrontabExceptionListener.php
@@ -24,12 +24,13 @@ class CrontabExceptionListener extends CaptureExceptionListener
     {
         return [
             Event\BeforeExecute::class,
+            Event\AfterExecute::class,
             Event\FailToExecute::class,
         ];
     }
 
     /**
-     * @param Event\FailToExecute $event
+     * @param Event\FailToExecute|Event\AfterExecute|Event\BeforeExecute|object $event
      */
     public function process(object $event): void
     {
@@ -40,6 +41,12 @@ class CrontabExceptionListener extends CaptureExceptionListener
         match ($event::class) {
             Event\FailToExecute::class => $this->captureException($event->throwable),
             default => $this->setupSentrySdk(),
+        };
+
+        match ($event::class) {
+            Event\AfterExecute::class,
+            Event\FailToExecute::class => $this->flushEvents(),
+            default => null,
         };
     }
 }

--- a/src/sentry/src/Listener/KafkaExceptionListener.php
+++ b/src/sentry/src/Listener/KafkaExceptionListener.php
@@ -20,11 +20,12 @@ class KafkaExceptionListener extends CaptureExceptionListener
         return [
             Event\BeforeConsume::class,
             Event\FailToConsume::class,
+            Event\AfterConsume::class,
         ];
     }
 
     /**
-     * @param Event\FailToConsume $event
+     * @param Event\FailToConsume|Event\AfterConsume|Event\BeforeConsume|object $event
      */
     public function process(object $event): void
     {
@@ -35,6 +36,12 @@ class KafkaExceptionListener extends CaptureExceptionListener
         match ($event::class) {
             Event\FailToConsume::class => $this->captureException($event->getThrowable()),
             default => $this->setupSentrySdk(),
+        };
+
+        match ($event::class) {
+            Event\AfterConsume::class,
+            Event\FailToConsume::class => $this->flushEvents(),
+            default => null,
         };
     }
 }

--- a/src/sentry/src/Listener/RequestExceptionListener.php
+++ b/src/sentry/src/Listener/RequestExceptionListener.php
@@ -29,7 +29,7 @@ class RequestExceptionListener extends CaptureExceptionListener
     }
 
     /**
-     * @param RequestTerminated|object $event
+     * @param RequestTerminated|RpcRequestTerminated|object $event
      */
     public function process(object $event): void
     {
@@ -40,6 +40,12 @@ class RequestExceptionListener extends CaptureExceptionListener
         match ($event::class) {
             RequestTerminated::class, RpcRequestTerminated::class => $this->captureException($event->exception),
             default => $this->setupSentrySdk(),
+        };
+
+        match ($event::class) {
+            RequestTerminated::class,
+            RpcRequestTerminated::class => $this->flushEvents(),
+            default => null,
         };
     }
 }


### PR DESCRIPTION
## Summary
- Enhance Sentry integration with comprehensive event flushing across all listeners
- Add log flushing to Integration::flushEvents() to ensure all logs are sent
- Implement automatic event flushing in CoroutineAspect finally block
- Expand event listener coverage to handle completion events (AfterConsume, AfterHandle, AfterExecute, RetryHandle)
- Add flushEvents() calls after processing completion and failure events

## Changes Made
- **Integration.php**: Added `Logs::getInstance()->flush()` to ensure logs are flushed
- **CoroutineAspect.php**: Added `Integration::flushEvents()` in finally block for proper cleanup
- **All Exception Listeners**: 
  - Expanded event coverage to include completion events
  - Added flush functionality after event processing
  - Improved event handling reliability

## Test plan
- [ ] Verify event flushing works correctly in coroutine contexts
- [ ] Test that completion events (AfterConsume, AfterHandle, etc.) are properly handled
- [ ] Confirm no events are lost when processes terminate
- [ ] Validate log flushing functionality
- [ ] Test async queue, AMQP, Kafka, Command, and Crontab listeners

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 监听器新增对 AfterConsume/AfterHandle/RetryHandle/AfterExecute 等事件的支持；请求与 RPC 终止事件可触发刷写。
- 修复
  - 在任务/消费/执行/终止后统一强制刷新已捕获事件与日志，避免丢失；协程执行无论成功或异常均保证刷新。
- 文档
  - 更新监听器方法的注释，明确可接收的事件类型与处理路径。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->