### PR TITLE
feat(sentry): add custom Monolog LogsHandler implementation

### DIFF
--- a/src/sentry/README.md
+++ b/src/sentry/README.md
@@ -30,9 +30,11 @@ return [
     // ...
     'sentry' => [
         'handler' => [
-            'class' => \Sentry\Monolog\LogsHandler::class,
+            'class' => \FriendsOfHyperf\Sentry\Monolog\LogsHandler::class,
             'constructor' => [
+                'group' => 'sentry',
                 'level' => \Sentry\Logs\LogLevel::debug(),
+                'bubble' => true,
             ],
         ],
         'formatter' => [

--- a/src/sentry/src/Monolog/LogsHandler.php
+++ b/src/sentry/src/Monolog/LogsHandler.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of friendsofhyperf/components.
+ *
+ * @link     https://github.com/friendsofhyperf/components
+ * @document https://github.com/friendsofhyperf/components/blob/main/README.md
+ * @contact  huangdijia@gmail.com
+ */
+
+namespace FriendsOfHyperf\Sentry\Monolog;
+
+use Monolog\LogRecord;
+use Sentry\Logs\LogLevel;
+use Sentry\Logs\Logs;
+use Sentry\Monolog\CompatibilityLogLevelTrait;
+use Throwable;
+
+class LogsHandler extends \Sentry\Monolog\LogsHandler
+{
+    use CompatibilityLogLevelTrait;
+
+    public function __construct(
+        protected string $group = 'default',
+        ?LogLevel $logLevel = null,
+        protected bool $bubble = true
+    ) {
+        parent::__construct($logLevel, $bubble);
+    }
+
+    /**
+     * @param array<string, mixed>|LogRecord $record
+     */
+    public function handle($record): bool
+    {
+        if (! $this->isHandling($record)) {
+            return false;
+        }
+        // Do not collect logs for exceptions, they should be handled seperately by the `Handler` or `captureException`
+        if (isset($record['context']['exception']) && $record['context']['exception'] instanceof Throwable) {
+            return false;
+        }
+
+        Logs::getInstance()->aggregator()->add(
+            self::getSentryLogLevelFromMonologLevel($record['level']),
+            $record['message'],
+            [],
+            array_merge(
+                ['log_context' => $record['context']],
+                ['log_extra' => $record['extra']],
+                ['logger' => $record['channel'] ?? ''],
+                ['group' => $this->group]
+            )
+        );
+
+        return $this->bubble === false;
+    }
+}

--- a/src/sentry/src/SentryHandler.php
+++ b/src/sentry/src/SentryHandler.php
@@ -27,7 +27,7 @@ use Sentry\State\Scope;
 use Throwable;
 
 /**
- * @deprecated since v3.1, use `Sentry\Monolog\LogsHandler` instead, will remove in v3.2
+ * @deprecated since v3.1, use `FriendsOfHyperf\Sentry\Monolog\LogsHandler` instead, will remove in v3.2
  */
 class SentryHandler extends AbstractProcessingHandler
 {


### PR DESCRIPTION
## Summary
- Add custom `FriendsOfHyperf\Sentry\Monolog\LogsHandler` implementation
- Update documentation to reference the new custom handler
- Enhance Monolog integration with proper configuration parameters

## Changes
- **New**: `src/sentry/src/Monolog/LogsHandler.php` - Custom Monolog handler for Sentry integration
- **Updated**: `src/sentry/README.md` - Configuration example now uses custom handler with `group` and `bubble` parameters
- **Updated**: `src/sentry/src/SentryHandler.php` - Deprecation notice updated to point to new custom handler

## Configuration
The new handler supports additional configuration options:
- `group`: Sentry log group classification
- `bubble`: Whether to bubble the log record up the handler stack

## Test plan
- [ ] Verify the new Monolog handler integrates properly with Sentry
- [ ] Test log grouping functionality
- [ ] Ensure backward compatibility with existing configurations
- [ ] Validate that deprecation warnings guide users to the correct new handler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 新增日志处理器，将应用日志转发至监控平台，支持分组聚合与可配置的冒泡传播；兼容现有日志级别映射与记录结构。
- 文档
  - 更新注册示例以使用新的日志处理器。
  - 增加配置示例，包含 group 与 bubble 选项，并保留 level 配置。
  - 调整弃用说明以指向新的处理器。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->