### PR TITLE
feat(sentry): add integer log level support to LogsHandler

### DIFF
--- a/src/sentry/src/Monolog/LogsHandler.php
+++ b/src/sentry/src/Monolog/LogsHandler.php
@@ -23,9 +23,13 @@ class LogsHandler extends \Sentry\Monolog\LogsHandler
 
     public function __construct(
         protected string $group = 'default',
-        ?LogLevel $logLevel = null,
+        int|LogLevel|null $logLevel = null,
         protected bool $bubble = true
     ) {
+        if (is_int($logLevel)) {
+            $logLevel = self::getSentryLogLevelFromMonologLevel($logLevel);
+        }
+
         parent::__construct($logLevel, $bubble);
     }
 


### PR DESCRIPTION
## Summary
- Enhanced LogsHandler constructor to accept integer log levels in addition to LogLevel objects
- Added automatic conversion from Monolog integer levels to Sentry LogLevel objects
- Maintains full backward compatibility with existing LogLevel usage

## Changes
- Modified constructor parameter type from `?LogLevel` to `int|LogLevel|null`
- Added logic to convert integer log levels using `getSentryLogLevelFromMonologLevel()`
- Improved flexibility for users working with Monolog's integer-based log levels

## Test plan
- [ ] Verify existing LogLevel objects continue to work
- [ ] Test integer log level conversion functionality
- [ ] Confirm backward compatibility is maintained
- [ ] Run existing test suite to ensure no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新特性
  - 日志级别配置更灵活：现支持以整数或枚举方式设置，并自动转换为 Sentry 日志级别。
  - 保持向后兼容：现有配置无需改动，默认行为不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->