### PR TITLE
Feat/sentry coroutine context propagation improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "psr/http-factory-implementation": "*",
         "psy/psysh": "^0.10.0 || ^0.11.0",
         "ramsey/uuid": "^4.7",
-        "sentry/sentry": "^4.15.0",
+        "sentry/sentry": "^4.16.0",
         "symfony/console": "^5.3 || ^6.0 || ^7.0",
         "symfony/http-foundation": "^5.3 || ^6.0 || ^7.0",
         "symfony/polyfill-php84": "^1.33",

--- a/src/sentry/composer.json
+++ b/src/sentry/composer.json
@@ -33,7 +33,7 @@
         "hyperf/http-server": "~3.1.0",
         "hyperf/support": "~3.1.0",
         "hyperf/tappable": "~3.1.0",
-        "sentry/sentry": "^4.15.0",
+        "sentry/sentry": "^4.16.0",
         "symfony/polyfill-php85": "^1.33"
     },
     "suggest": {

--- a/src/sentry/src/Aspect/CoroutineAspect.php
+++ b/src/sentry/src/Aspect/CoroutineAspect.php
@@ -25,7 +25,6 @@ class CoroutineAspect extends AbstractAspect
     ];
 
     protected array $keys = [
-        SentrySdk::class,
         \Psr\Http\Message\ServerRequestInterface::class,
     ];
 
@@ -40,7 +39,7 @@ class CoroutineAspect extends AbstractAspect
             $current = Co::getContextFor();
 
             foreach ($keys as $key) {
-                if (isset($from[$key])) {
+                if (isset($from[$key]) && ! isset($current[$key])) {
                     $current[$key] = $from[$key];
                 }
             }

--- a/src/sentry/src/Aspect/CoroutineAspect.php
+++ b/src/sentry/src/Aspect/CoroutineAspect.php
@@ -28,6 +28,11 @@ class CoroutineAspect extends AbstractAspect
         \Psr\Http\Message\ServerRequestInterface::class,
     ];
 
+    public function __construct()
+    {
+        $this->priority = PHP_INT_MAX - 1;
+    }
+
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
         $callable = $proceedingJoinPoint->arguments['keys']['callable'];

--- a/src/sentry/src/Aspect/CoroutineAspect.php
+++ b/src/sentry/src/Aspect/CoroutineAspect.php
@@ -15,6 +15,7 @@ use FriendsOfHyperf\Sentry\Integration;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Hyperf\Engine\Coroutine as Co;
+use Sentry\SentrySdk;
 use Throwable;
 
 class CoroutineAspect extends AbstractAspect

--- a/src/sentry/src/Aspect/CoroutineAspect.php
+++ b/src/sentry/src/Aspect/CoroutineAspect.php
@@ -25,7 +25,7 @@ class CoroutineAspect extends AbstractAspect
     ];
 
     protected array $keys = [
-        // \Sentry\SentrySdk::class,
+        SentrySdk::class,
         \Psr\Http\Message\ServerRequestInterface::class,
     ];
 

--- a/src/sentry/src/Aspect/CoroutineAspect.php
+++ b/src/sentry/src/Aspect/CoroutineAspect.php
@@ -15,7 +15,6 @@ use FriendsOfHyperf\Sentry\Integration;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Hyperf\Engine\Coroutine as Co;
-use Sentry\SentrySdk;
 use Throwable;
 
 class CoroutineAspect extends AbstractAspect
@@ -25,6 +24,7 @@ class CoroutineAspect extends AbstractAspect
     ];
 
     protected array $keys = [
+        // \Sentry\SentrySdk::class,
         \Psr\Http\Message\ServerRequestInterface::class,
     ];
 

--- a/src/sentry/src/Tracing/Aspect/AmqpProducerAspect.php
+++ b/src/sentry/src/Tracing/Aspect/AmqpProducerAspect.php
@@ -17,6 +17,7 @@ use FriendsOfHyperf\Sentry\Tracing\SpanStarter;
 use FriendsOfHyperf\Sentry\Util\Carrier;
 use Hyperf\Amqp\Annotation\Producer;
 use Hyperf\Amqp\Message\ProducerMessage;
+use Hyperf\Coroutine\Coroutine;
 use Hyperf\Di\Annotation\AnnotationCollector;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
@@ -101,6 +102,7 @@ class AmqpProducerAspect extends AbstractAspect
                 ->setDescription(sprintf('%s::%s()', $proceedingJoinPoint->className, $proceedingJoinPoint->methodName))
                 ->setOrigin('auto.amqp')
                 ->setData([
+                    'coroutine.id' => Coroutine::id(),
                     'messaging.system' => 'amqp',
                     'messaging.operation' => 'publish',
                     'messaging.message.id' => $messageId,

--- a/src/sentry/src/Tracing/Aspect/AmqpProducerAspect.php
+++ b/src/sentry/src/Tracing/Aspect/AmqpProducerAspect.php
@@ -21,8 +21,8 @@ use Hyperf\Di\Annotation\AnnotationCollector;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use PhpAmqpLib\Wire\AMQPTable;
-
-use function Hyperf\Tappable\tap;
+use Sentry\State\Scope;
+use Sentry\Tracing\SpanContext;
 
 /**
  * @property array{application_headers?:AMQPTable} $properties
@@ -60,16 +60,6 @@ class AmqpProducerAspect extends AbstractAspect
             return $proceedingJoinPoint->process();
         }
 
-        $span = $this->startSpan(
-            op: 'queue.publish',
-            description: sprintf('%s::%s()', $proceedingJoinPoint->className, $proceedingJoinPoint->methodName),
-            origin: 'auto.amqp'
-        );
-
-        if (! $span) {
-            return $proceedingJoinPoint->process();
-        }
-
         $routingKey = $producerMessage->getRoutingKey();
         $exchange = $producerMessage->getExchange();
         $poolName = $producerMessage->getPoolName();
@@ -87,30 +77,39 @@ class AmqpProducerAspect extends AbstractAspect
         $messageId = uniqid('amqp_', true);
         $destinationName = implode(', ', (array) $routingKey);
         $bodySize = strlen($producerMessage->payload());
-        $span->setData([
-            'messaging.system' => 'amqp',
-            'messaging.operation' => 'publish',
-            'messaging.message.id' => $messageId,
-            'messaging.message.body.size' => $bodySize,
-            'messaging.destination.name' => $destinationName,
-            // for amqp
-            'messaging.amqp.message.type' => $producerMessage->getTypeString(),
-            'messaging.amqp.message.routing_key' => $routingKey,
-            'messaging.amqp.message.exchange' => $exchange,
-            'messaging.amqp.message.pool_name' => $poolName,
-        ]);
-        $carrier = Carrier::fromSpan($span)->with([
-            'publish_time' => microtime(true),
-            'message_id' => $messageId,
-            'destination_name' => $destinationName,
-            'body_size' => $bodySize,
-        ]);
 
-        (function () use ($carrier) {
-            $this->properties['application_headers'] ??= new AMQPTable();
-            $this->properties['application_headers']->set(Constants::TRACE_CARRIER, $carrier->toJson());
-        })->call($producerMessage);
+        return $this->trace(
+            function (Scope $scope) use ($proceedingJoinPoint, $producerMessage, $messageId, $destinationName, $bodySize) {
+                $span = $scope->getSpan();
+                $carrier = Carrier::fromSpan($span)->with([
+                    'publish_time' => microtime(true),
+                    'message_id' => $messageId,
+                    'destination_name' => $destinationName,
+                    'body_size' => $bodySize,
+                ]);
+                (function () use ($carrier) {
+                    $this->properties['application_headers'] ??= new AMQPTable();
+                    $this->properties['application_headers']->set(Constants::TRACE_CARRIER, $carrier->toJson());
+                })->call($producerMessage);
 
-        return tap($proceedingJoinPoint->process(), fn () => $span->finish());
+                return $proceedingJoinPoint->process();
+            },
+            SpanContext::make()
+                ->setOp('queue.publish')
+                ->setDescription(sprintf('%s::%s()', $proceedingJoinPoint->className, $proceedingJoinPoint->methodName))
+                ->setOrigin('auto.amqp')
+                ->setData([
+                    'messaging.system' => 'amqp',
+                    'messaging.operation' => 'publish',
+                    'messaging.message.id' => $messageId,
+                    'messaging.message.body.size' => $bodySize,
+                    'messaging.destination.name' => $destinationName,
+                    // for amqp
+                    'messaging.amqp.message.type' => $producerMessage->getTypeString(),
+                    'messaging.amqp.message.routing_key' => $routingKey,
+                    'messaging.amqp.message.exchange' => $exchange,
+                    'messaging.amqp.message.pool_name' => $poolName,
+                ])
+        );
     }
 }

--- a/src/sentry/src/Tracing/Aspect/AsyncQueueJobMessageAspect.php
+++ b/src/sentry/src/Tracing/Aspect/AsyncQueueJobMessageAspect.php
@@ -17,6 +17,7 @@ use FriendsOfHyperf\Sentry\Tracing\SpanStarter;
 use FriendsOfHyperf\Sentry\Util\Carrier;
 use Hyperf\AsyncQueue\Driver\RedisDriver;
 use Hyperf\Context\Context;
+use Hyperf\Coroutine\Coroutine;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Sentry\State\Scope;
@@ -82,6 +83,7 @@ class AsyncQueueJobMessageAspect extends AbstractAspect
         $destinationName = Context::get('sentry.messaging.destination.name', 'default');
         $bodySize = (fn ($job) => strlen($this->packer->pack($job)))->call($driver, $job);
         $data = [
+            'coroutine.id' => Coroutine::id(),
             'messaging.system' => 'async_queue',
             'messaging.operation' => 'publish',
             'messaging.message.id' => $messageId,

--- a/src/sentry/src/Tracing/Aspect/AsyncQueueJobMessageAspect.php
+++ b/src/sentry/src/Tracing/Aspect/AsyncQueueJobMessageAspect.php
@@ -19,6 +19,8 @@ use Hyperf\AsyncQueue\Driver\RedisDriver;
 use Hyperf\Context\Context;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
+use Sentry\State\Scope;
+use Sentry\Tracing\SpanContext;
 
 use function Hyperf\Support\with;
 
@@ -73,46 +75,44 @@ class AsyncQueueJobMessageAspect extends AbstractAspect
     {
         /** @var \Hyperf\AsyncQueue\JobInterface $job */
         $job = $proceedingJoinPoint->arguments['keys']['job'] ?? null;
-        $span = $this->startSpan(
-            op: 'queue.publish',
-            description: $job::class,
-            origin: 'auto.queue'
+
+        /** @var \Hyperf\AsyncQueue\Driver\Driver $driver */
+        $driver = $proceedingJoinPoint->getInstance();
+        $messageId = method_exists($job, 'getId') ? $job->getId() : uniqid('async_queue_', true);
+        $destinationName = Context::get('sentry.messaging.destination.name', 'default');
+        $bodySize = (fn ($job) => strlen($this->packer->pack($job)))->call($driver, $job);
+        $data = [
+            'messaging.system' => 'async_queue',
+            'messaging.operation' => 'publish',
+            'messaging.message.id' => $messageId,
+            'messaging.message.body.size' => $bodySize,
+            'messaging.destination.name' => $destinationName,
+        ];
+
+        if ($driver instanceof RedisDriver) {
+            $data = array_merge($data, $this->buildSpanDataOfRedisDriver($driver));
+        }
+
+        return $this->trace(
+            function (Scope $scope) use ($proceedingJoinPoint, $messageId, $destinationName, $bodySize) {
+                $span = $scope->getSpan();
+                $carrier = Carrier::fromSpan($span)->with([
+                    'publish_time' => microtime(true),
+                    'message_id' => $messageId,
+                    'destination_name' => $destinationName,
+                    'body_size' => $bodySize,
+                ]);
+
+                Context::set(Constants::TRACE_CARRIER, $carrier);
+
+                return $proceedingJoinPoint->process();
+            },
+            SpanContext::make()
+                ->setOp('queue.publish')
+                ->setDescription($job::class)
+                ->setOrigin('auto.queue')
+                ->setData($data)
         );
-
-        if (! $span) {
-            return $proceedingJoinPoint->process();
-        }
-
-        try {
-            /** @var \Hyperf\AsyncQueue\Driver\Driver $driver */
-            $driver = $proceedingJoinPoint->getInstance();
-            $messageId = method_exists($job, 'getId') ? $job->getId() : uniqid('async_queue_', true);
-            $destinationName = Context::get('sentry.messaging.destination.name', 'default');
-            $bodySize = (fn ($job) => strlen($this->packer->pack($job)))->call($driver, $job);
-            $span->setData([
-                'messaging.system' => 'async_queue',
-                'messaging.operation' => 'publish',
-                'messaging.message.id' => $messageId,
-                'messaging.message.body.size' => $bodySize,
-                'messaging.destination.name' => $destinationName,
-            ]);
-            if ($driver instanceof RedisDriver) {
-                $span->setData($this->buildSpanDataOfRedisDriver($driver));
-            }
-
-            $carrier = Carrier::fromSpan($span)->with([
-                'publish_time' => microtime(true),
-                'message_id' => $messageId,
-                'destination_name' => $destinationName,
-                'body_size' => $bodySize,
-            ]);
-
-            Context::set(Constants::TRACE_CARRIER, $carrier);
-
-            return $proceedingJoinPoint->process();
-        } finally {
-            $span->finish();
-        }
     }
 
     protected function buildSpanDataOfRedisDriver(RedisDriver $driver): array

--- a/src/sentry/src/Tracing/Aspect/CacheAspect.php
+++ b/src/sentry/src/Tracing/Aspect/CacheAspect.php
@@ -15,7 +15,10 @@ use FriendsOfHyperf\Sentry\Switcher;
 use FriendsOfHyperf\Sentry\Tracing\SpanStarter;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
-use Sentry\SentrySdk;
+use Sentry\State\Scope;
+use Sentry\Tracing\SpanContext;
+use Sentry\Tracing\SpanStatus;
+use Throwable;
 
 use function Hyperf\Tappable\tap;
 
@@ -47,63 +50,77 @@ class CacheAspect extends AbstractAspect
             return $proceedingJoinPoint->process();
         }
 
-        $parent = SentrySdk::getCurrentHub()->getSpan();
+        $method = $proceedingJoinPoint->methodName;
+        $op = match ($method) {
+            'set', 'setMultiple' => 'cache.put',
+            'get', 'fetch', 'getMultiple' => 'cache.get',
+            'delete', 'deleteMultiple' => 'cache.remove',
+            'clear' => 'cache.flush',
+            default => 'cache',
+        };
 
-        try {
-            $method = $proceedingJoinPoint->methodName;
-            $op = match ($method) {
-                'set', 'setMultiple' => 'cache.put',
-                'get', 'fetch', 'getMultiple' => 'cache.get',
-                'delete', 'deleteMultiple' => 'cache.remove',
-                'clear' => 'cache.flush',
-                default => 'cache',
-            };
+        $arguments = $proceedingJoinPoint->arguments['keys'] ?? [];
 
-            $arguments = $proceedingJoinPoint->arguments['keys'] ?? [];
+        /** @var string[] $keys */
+        $keys = match ($method) {
+            'set', 'get', 'delete' => [$arguments['key'] ?? 'unknown'],
+            'setMultiple' => array_keys($arguments['values'] ?? []),
+            'getMultiple', 'deleteMultiple' => $arguments['keys'] ?? [],
+            default => [],
+        };
 
-            /** @var string[] $keys */
-            $keys = match ($method) {
-                'set', 'get', 'delete' => [$arguments['key'] ?? 'unknown'],
-                'setMultiple' => array_keys($arguments['values'] ?? []),
-                'getMultiple', 'deleteMultiple' => $arguments['keys'] ?? [],
-                default => [],
-            };
+        return $this->trace(
+            function (Scope $scope) use ($proceedingJoinPoint, $method) {
+                $span = $scope->getSpan();
 
-            $span = $this->startSpan(
-                op: $op,
-                description: implode(', ', $keys),
-                origin: 'auto.cache',
-                asParent: true
-            )?->setData([
-                'cache.key' => $keys,
-                'cache.ttl' => $arguments['ttl'] ?? null,
-                'item_size' => match (true) {
-                    isset($arguments['value']) => strlen(json_encode($arguments['value'])),
-                    isset($arguments['values']) && is_array($arguments['values']) => strlen(json_encode(array_values($arguments['values']))),
-                    default => 0,
-                },
-            ]);
-
-            return tap($proceedingJoinPoint->process(), function ($result) use ($span, $method) {
-                $data = match ($method) {
-                    'get' => [
-                        'cache.hit' => ! is_null($result),
-                        'cache.item_size' => strlen((string) json_encode($result)),
-                    ],
-                    'fetch' => [
-                        'cache.hit' => ($result[0] ?? false) !== false,
-                        'cache.item_size' => strlen((string) json_encode($result[1] ?? '')),
-                    ],
-                    'getMultiple' => [
-                        'cache.hit' => ! empty($result),
-                        'cache.item_size' => strlen((string) json_encode(array_values((array) $result))),
-                    ],
-                    default => [],
-                };
-                $span?->setData($data)->finish();
-            });
-        } finally {
-            SentrySdk::getCurrentHub()->setSpan($parent);
-        }
+                try {
+                    return tap($proceedingJoinPoint->process(), function ($result) use ($span, $method) {
+                        $data = match ($method) {
+                            'get' => [
+                                'cache.hit' => ! is_null($result),
+                                'cache.item_size' => strlen((string) json_encode($result)),
+                            ],
+                            'fetch' => [
+                                'cache.hit' => ($result[0] ?? false) !== false,
+                                'cache.item_size' => strlen((string) json_encode($result[1] ?? '')),
+                            ],
+                            'getMultiple' => [
+                                'cache.hit' => ! empty($result),
+                                'cache.item_size' => strlen((string) json_encode(array_values((array) $result))),
+                            ],
+                            default => [],
+                        };
+                        $span?->setData($data);
+                    });
+                } catch (Throwable $exception) {
+                    $span?->setStatus(SpanStatus::internalError())
+                        ->setTags([
+                            'error' => 'true',
+                            'exception.class' => $exception::class,
+                            'exception.message' => $exception->getMessage(),
+                            'exception.code' => (string) $exception->getCode(),
+                        ]);
+                    if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
+                        $span?->setData([
+                            'exception.stack_trace' => (string) $exception,
+                        ]);
+                    }
+                    throw $exception;
+                }
+            },
+            SpanContext::make()
+                ->setOp($op)
+                ->setDescription(implode(', ', $keys))
+                ->setOrigin('auto.cache')
+                ->setData([
+                    'cache.key' => $keys,
+                    'cache.ttl' => $arguments['ttl'] ?? null,
+                    'item_size' => match (true) {
+                        isset($arguments['value']) => strlen(json_encode($arguments['value'])),
+                        isset($arguments['values']) && is_array($arguments['values']) => strlen(json_encode(array_values($arguments['values']))),
+                        default => 0,
+                    },
+                ])
+        );
     }
 }

--- a/src/sentry/src/Tracing/Aspect/CacheAspect.php
+++ b/src/sentry/src/Tracing/Aspect/CacheAspect.php
@@ -13,6 +13,7 @@ namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
 use FriendsOfHyperf\Sentry\Switcher;
 use FriendsOfHyperf\Sentry\Tracing\SpanStarter;
+use Hyperf\Coroutine\Coroutine;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Sentry\State\Scope;
@@ -93,6 +94,7 @@ class CacheAspect extends AbstractAspect
                 ->setDescription(implode(', ', $keys))
                 ->setOrigin('auto.cache')
                 ->setData([
+                    'coroutine.id' => Coroutine::id(),
                     'cache.key' => $keys,
                     'cache.ttl' => $arguments['ttl'] ?? null,
                     'item_size' => match (true) {

--- a/src/sentry/src/Tracing/Aspect/CoroutineAspect.php
+++ b/src/sentry/src/Tracing/Aspect/CoroutineAspect.php
@@ -37,6 +37,7 @@ class CoroutineAspect extends AbstractAspect
 
     public function __construct(protected Switcher $switcher)
     {
+        $this->priority = PHP_INT_MAX;
     }
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint)

--- a/src/sentry/src/Tracing/Aspect/CoroutineAspect.php
+++ b/src/sentry/src/Tracing/Aspect/CoroutineAspect.php
@@ -111,8 +111,10 @@ class CoroutineAspect extends AbstractAspect
                     ->setTags([
                         'error' => 'true',
                         'exception.class' => $exception::class,
-                        'exception.message' => $exception->getMessage(),
                         'exception.code' => (string) $exception->getCode(),
+                    ])
+                    ->setData([
+                        'exception.message' => $exception->getMessage(),
                     ]);
                 if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
                     $transaction->setData([

--- a/src/sentry/src/Tracing/Aspect/CoroutineAspect.php
+++ b/src/sentry/src/Tracing/Aspect/CoroutineAspect.php
@@ -32,6 +32,7 @@ class CoroutineAspect extends AbstractAspect
     ];
 
     protected array $keys = [
+        // \Sentry\SentrySdk::class,
         \Psr\Http\Message\ServerRequestInterface::class,
     ];
 

--- a/src/sentry/src/Tracing/Aspect/CoroutineAspect.php
+++ b/src/sentry/src/Tracing/Aspect/CoroutineAspect.php
@@ -32,7 +32,7 @@ class CoroutineAspect extends AbstractAspect
     ];
 
     protected array $keys = [
-        // \Sentry\SentrySdk::class,
+        SentrySdk::class,
         \Psr\Http\Message\ServerRequestInterface::class,
     ];
 

--- a/src/sentry/src/Tracing/Aspect/DbAspect.php
+++ b/src/sentry/src/Tracing/Aspect/DbAspect.php
@@ -20,7 +20,6 @@ use Hyperf\DB\Pool\PoolFactory;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Psr\Container\ContainerInterface;
-use Sentry\SentrySdk;
 use Sentry\State\Scope;
 use Sentry\Tracing\SpanContext;
 use Sentry\Tracing\SpanStatus;
@@ -46,10 +45,6 @@ class DbAspect extends AbstractAspect
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
         if (! $this->switcher->isTracingSpanEnabled('db')) {
-            return $proceedingJoinPoint->process();
-        }
-
-        if (! SentrySdk::getCurrentHub()->getSpan()) {
             return $proceedingJoinPoint->process();
         }
 

--- a/src/sentry/src/Tracing/Aspect/DbAspect.php
+++ b/src/sentry/src/Tracing/Aspect/DbAspect.php
@@ -71,7 +71,6 @@ class DbAspect extends AbstractAspect
         $sqlParse = SqlParser::parse($sql);
         $table = $sqlParse['table'];
         $operation = $sqlParse['operation'];
-
         $data = [
             'coroutine.id' => Coroutine::id(),
             'db.system' => $driver,

--- a/src/sentry/src/Tracing/Aspect/DbAspect.php
+++ b/src/sentry/src/Tracing/Aspect/DbAspect.php
@@ -22,8 +22,6 @@ use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Psr\Container\ContainerInterface;
 use Sentry\State\Scope;
 use Sentry\Tracing\SpanContext;
-use Sentry\Tracing\SpanStatus;
-use Throwable;
 
 /**
  * @property string $poolName
@@ -90,31 +88,13 @@ class DbAspect extends AbstractAspect
 
         return $this->trace(
             function (Scope $scope) use ($proceedingJoinPoint) {
-                $span = $scope->getSpan();
-                try {
-                    $result = $proceedingJoinPoint->process();
-                    if ($this->switcher->isTracingExtraTagEnabled('db.result')) {
-                        $span?->setData([
-                            'db.result' => json_encode($result, JSON_UNESCAPED_UNICODE),
-                        ]);
-                    }
-                    return $result;
-                } catch (Throwable $exception) {
-                    $span?->setStatus(SpanStatus::internalError())
-                        ->setTags([
-                            'error' => 'true',
-                            'exception.class' => $exception::class,
-                            'exception.message' => $exception->getMessage(),
-                            'exception.code' => (string) $exception->getCode(),
-                        ]);
-                    if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
-                        $span?->setData([
-                            'exception.stack_trace' => (string) $exception,
-                        ]);
-                    }
-
-                    throw $exception;
+                $result = $proceedingJoinPoint->process();
+                if ($this->switcher->isTracingExtraTagEnabled('db.result')) {
+                    $scope->getSpan()?->setData([
+                        'db.result' => json_encode($result, JSON_UNESCAPED_UNICODE),
+                    ]);
                 }
+                return $result;
             },
             SpanContext::make()
                 ->setOp('db.sql.query')

--- a/src/sentry/src/Tracing/Aspect/ElasticsearchAspect.php
+++ b/src/sentry/src/Tracing/Aspect/ElasticsearchAspect.php
@@ -80,7 +80,7 @@ class ElasticsearchAspect extends AbstractAspect
                     'coroutine.id' => Coroutine::id(),
                     'db.system' => 'elasticsearch',
                     'db.operation.name' => $proceedingJoinPoint->methodName,
-                    'arguments' => json_encode($proceedingJoinPoint->arguments['keys'], JSON_UNESCAPED_UNICODE),
+                    'arguments' => (string) json_encode($proceedingJoinPoint->arguments['keys'], JSON_UNESCAPED_UNICODE),
                     // TODO
                     // 'http.request.method' => '',
                     // 'url.full' => '',

--- a/src/sentry/src/Tracing/Aspect/ElasticsearchAspect.php
+++ b/src/sentry/src/Tracing/Aspect/ElasticsearchAspect.php
@@ -67,7 +67,7 @@ class ElasticsearchAspect extends AbstractAspect
                 $result = $proceedingJoinPoint->process();
                 if ($this->switcher->isTracingExtraTagEnabled('elasticsearch.result')) {
                     $scope->getSpan()?->setData([
-                        'elasticsearch.result' => json_encode($result, JSON_UNESCAPED_UNICODE),
+                        'elasticsearch.result' => (string) json_encode($result, JSON_UNESCAPED_UNICODE),
                     ]);
                 }
                 return $result;

--- a/src/sentry/src/Tracing/Aspect/FilesystemAspect.php
+++ b/src/sentry/src/Tracing/Aspect/FilesystemAspect.php
@@ -17,8 +17,6 @@ use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Override;
 use Sentry\State\Scope;
 use Sentry\Tracing\SpanContext;
-use Sentry\Tracing\SpanStatus;
-use Throwable;
 
 class FilesystemAspect extends BaseFilesystemAspect
 {
@@ -34,26 +32,7 @@ class FilesystemAspect extends BaseFilesystemAspect
         [$op, $description, $data] = $this->getSentryMetadata($proceedingJoinPoint);
 
         return $this->trace(
-            function (Scope $scope) use ($proceedingJoinPoint) {
-                $span = $scope->getSpan();
-                try {
-                    return $proceedingJoinPoint->process();
-                } catch (Throwable $exception) {
-                    $span->setStatus(SpanStatus::internalError())
-                        ->setTags([
-                            'error' => 'true',
-                            'exception.class' => $exception::class,
-                            'exception.message' => $exception->getMessage(),
-                            'exception.code' => (string) $exception->getCode(),
-                        ]);
-                    if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
-                        $span->setData([
-                            'exception.stack_trace' => (string) $exception,
-                        ]);
-                    }
-                    throw $exception;
-                }
-            },
+            fn (Scope $scope) => $proceedingJoinPoint->process(),
             SpanContext::make()
                 ->setOp($op)
                 ->setDescription($description)

--- a/src/sentry/src/Tracing/Aspect/FilesystemAspect.php
+++ b/src/sentry/src/Tracing/Aspect/FilesystemAspect.php
@@ -13,6 +13,7 @@ namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
 use FriendsOfHyperf\Sentry\Aspect\FilesystemAspect as BaseFilesystemAspect;
 use FriendsOfHyperf\Sentry\Tracing\SpanStarter;
+use Hyperf\Coroutine\Coroutine;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Override;
 use Sentry\State\Scope;
@@ -37,7 +38,7 @@ class FilesystemAspect extends BaseFilesystemAspect
                 ->setOp($op)
                 ->setDescription($description)
                 ->setOrigin('auto.filesystem')
-                ->setData($data)
+                ->setData(['coroutine.id' => Coroutine::id()] + $data)
         );
     }
 }

--- a/src/sentry/src/Tracing/Aspect/GrpcAspect.php
+++ b/src/sentry/src/Tracing/Aspect/GrpcAspect.php
@@ -42,9 +42,9 @@ class GrpcAspect extends AbstractAspect
         $method = $proceedingJoinPoint->arguments['keys']['method'];
         $options = $proceedingJoinPoint->arguments['keys']['options'];
         $data = [
+            'coroutine.id' => Coroutine::id(),
             'grpc.method' => $method,
             'grpc.options' => $options,
-            'coroutine.id' => Coroutine::id(),
         ];
 
         $parent = SentrySdk::getCurrentHub()->getSpan();

--- a/src/sentry/src/Tracing/Aspect/GuzzleHttpClientAspect.php
+++ b/src/sentry/src/Tracing/Aspect/GuzzleHttpClientAspect.php
@@ -22,6 +22,8 @@ use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\RequestInterface;
+use Sentry\State\Scope;
+use Sentry\Tracing\SpanContext;
 use Sentry\Tracing\SpanStatus;
 use Throwable;
 
@@ -70,117 +72,118 @@ class GuzzleHttpClientAspect extends AbstractAspect
             return $proceedingJoinPoint->process();
         }
 
-        // Inject trace context && Start span
-        $span = $this->startSpan(
-            op: 'http.client',
-            description: $request->getMethod() . ' ' . (string) $request->getUri(),
-            origin: 'auto.http.client',
-        );
+        return $this->trace(
+            function (Scope $scope) use ($proceedingJoinPoint, $options, $guzzleConfig) {
+                $span = $scope->getSpan();
 
-        if (! $span) {
-            return $proceedingJoinPoint->process();
-        }
+                if (! $span) {
+                    return $proceedingJoinPoint->process();
+                }
 
-        // Inject trace context
-        $options['headers'] = array_replace($options['headers'] ?? [], [
-            'sentry-trace' => $span->toTraceparent(),
-            'baggage' => $span->toBaggage(),
-            'traceparent' => $span->toW3CTraceparent(),
-        ]);
-
-        // Override the headers
-        $proceedingJoinPoint->arguments['keys']['options']['headers'] = $options['headers'];
-        $onStats = $options['on_stats'] ?? null;
-
-        // Add or override the on_stats option to record the request duration.
-        $proceedingJoinPoint->arguments['keys']['options']['on_stats'] = function (TransferStats $stats) use ($options, $guzzleConfig, $onStats, $span) {
-            $request = $stats->getRequest();
-            $uri = $request->getUri();
-            $span->setData([
-                // See: https://develop.sentry.dev/sdk/performance/span-data-conventions/#http
-                'http.query' => $uri->getQuery(),
-                'http.fragment' => $uri->getFragment(),
-                'http.request.method' => $request->getMethod(),
-                'http.request.body.size' => strlen($options['body'] ?? ''),
-                'http.request.full_url' => (string) $request->getUri(),
-                'http.request.path' => $request->getUri()->getPath(),
-                'http.request.scheme' => $request->getUri()->getScheme(),
-                'http.request.host' => $request->getUri()->getHost(),
-                'http.request.port' => $request->getUri()->getPort(),
-                'http.request.user_agent' => $request->getHeaderLine('User-Agent'), // updated key for consistency
-                'http.request.headers' => $request->getHeaders(),
-                // Other
-                'coroutine.id' => Coroutine::id(),
-                'http.system' => 'guzzle',
-                'http.guzzle.config' => $guzzleConfig,
-                'http.guzzle.options' => $options ?? [],
-                'duration' => $stats->getTransferTime() * 1000, // in milliseconds
-            ]);
-
-            if ($response = $stats->getResponse()) {
-                $span->setData([
-                    'http.response.status_code' => $response->getStatusCode(),
-                    'http.response.reason' => $response->getReasonPhrase(),
-                    'http.response.headers' => $response->getHeaders(),
-                    'http.response.body.size' => $response->getBody()->getSize() ?? 0,
-                    'http.response_content_length' => $response->getHeaderLine('Content-Length'),
-                    'http.decoded_response_content_length' => $response->getHeaderLine('X-Decoded-Content-Length'),
-                    'http.response_transfer_size' => $response->getHeaderLine('Content-Length'),
+                // Inject trace context
+                $options['headers'] = array_replace($options['headers'] ?? [], [
+                    'sentry-trace' => $span->toTraceparent(),
+                    'baggage' => $span->toBaggage(),
+                    'traceparent' => $span->toW3CTraceparent(),
                 ]);
 
-                if ($this->switcher->isTracingExtraTagEnabled('http.response.body.contents')) {
-                    $isTextual = \preg_match(
-                        '/^(text\/|application\/(json|xml|x-www-form-urlencoded))/i',
-                        $response->getHeaderLine('Content-Type')
-                    ) === 1;
-                    $body = $response->getBody();
+                // Override the headers
+                $proceedingJoinPoint->arguments['keys']['options']['headers'] = $options['headers'];
+                $onStats = $options['on_stats'] ?? null;
 
-                    if ($isTextual && $body->isSeekable()) {
-                        $pos = $body->tell();
-                        $span->setData([
-                            'http.response.body.contents' => \GuzzleHttp\Psr7\Utils::copyToString($body, 8192), // 8KB 上限
-                        ]);
-                        $body->seek($pos);
-                    } else {
-                        $span->setData(['http.response.body.contents' => '[binary omitted]']);
-                    }
-                }
-
-                $span->setStatus(SpanStatus::createFromHttpStatusCode($response->getStatusCode()));
-
-                if ($response->getStatusCode() >= 400 && $response->getStatusCode() < 600) {
-                    $span->setTags([
-                        'error' => 'true',
-                        'http.response.reason' => $response->getReasonPhrase(),
-                    ]);
-                }
-            }
-
-            if ($stats->getHandlerErrorData()) {
-                $exception = $stats->getHandlerErrorData() instanceof Throwable
-                    ? $stats->getHandlerErrorData()
-                    : new Error();
-                $span->setStatus(SpanStatus::internalError())
-                    ->setTags([
-                        'error' => 'true',
-                        'exception.class' => $exception::class,
-                        'exception.code' => (string) $exception->getCode(),
-                    ]);
-                if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
+                // Add or override the on_stats option to record the request duration.
+                $proceedingJoinPoint->arguments['keys']['options']['on_stats'] = function (TransferStats $stats) use ($options, $guzzleConfig, $onStats, $span) {
+                    $request = $stats->getRequest();
+                    $uri = $request->getUri();
                     $span->setData([
-                        'exception.message' => $exception->getMessage(),
-                        'exception.stack_trace' => (string) $exception,
+                        // See: https://develop.sentry.dev/sdk/performance/span-data-conventions/#http
+                        'http.query' => $uri->getQuery(),
+                        'http.fragment' => $uri->getFragment(),
+                        'http.request.method' => $request->getMethod(),
+                        'http.request.body.size' => strlen($options['body'] ?? ''),
+                        'http.request.full_url' => (string) $request->getUri(),
+                        'http.request.path' => $request->getUri()->getPath(),
+                        'http.request.scheme' => $request->getUri()->getScheme(),
+                        'http.request.host' => $request->getUri()->getHost(),
+                        'http.request.port' => $request->getUri()->getPort(),
+                        'http.request.user_agent' => $request->getHeaderLine('User-Agent'), // updated key for consistency
+                        'http.request.headers' => $request->getHeaders(),
+                        // Other
+                        'coroutine.id' => Coroutine::id(),
+                        'http.system' => 'guzzle',
+                        'http.guzzle.config' => $guzzleConfig,
+                        'http.guzzle.options' => $options ?? [],
+                        'duration' => $stats->getTransferTime() * 1000, // in milliseconds
                     ]);
-                }
-            }
 
-            $span->finish();
+                    if ($response = $stats->getResponse()) {
+                        $span->setData([
+                            'http.response.status_code' => $response->getStatusCode(),
+                            'http.response.reason' => $response->getReasonPhrase(),
+                            'http.response.headers' => $response->getHeaders(),
+                            'http.response.body.size' => $response->getBody()->getSize() ?? 0,
+                            'http.response_content_length' => $response->getHeaderLine('Content-Length'),
+                            'http.decoded_response_content_length' => $response->getHeaderLine('X-Decoded-Content-Length'),
+                            'http.response_transfer_size' => $response->getHeaderLine('Content-Length'),
+                        ]);
 
-            if (is_callable($onStats)) {
-                ($onStats)($stats);
-            }
-        };
+                        if ($this->switcher->isTracingExtraTagEnabled('http.response.body.contents')) {
+                            $isTextual = \preg_match(
+                                '/^(text\/|application\/(json|xml|x-www-form-urlencoded))/i',
+                                $response->getHeaderLine('Content-Type')
+                            ) === 1;
+                            $body = $response->getBody();
 
-        return $proceedingJoinPoint->process();
+                            if ($isTextual && $body->isSeekable()) {
+                                $pos = $body->tell();
+                                $span->setData([
+                                    'http.response.body.contents' => \GuzzleHttp\Psr7\Utils::copyToString($body, 8192), // 8KB 上限
+                                ]);
+                                $body->seek($pos);
+                            } else {
+                                $span->setData(['http.response.body.contents' => '[binary omitted]']);
+                            }
+                        }
+
+                        $span->setStatus(SpanStatus::createFromHttpStatusCode($response->getStatusCode()));
+
+                        if ($response->getStatusCode() >= 400 && $response->getStatusCode() < 600) {
+                            $span->setTags([
+                                'error' => 'true',
+                                'http.response.reason' => $response->getReasonPhrase(),
+                            ]);
+                        }
+                    }
+
+                    if ($stats->getHandlerErrorData()) {
+                        $exception = $stats->getHandlerErrorData() instanceof Throwable
+                            ? $stats->getHandlerErrorData()
+                            : new Error();
+                        $span->setStatus(SpanStatus::internalError())
+                            ->setTags([
+                                'error' => 'true',
+                                'exception.class' => $exception::class,
+                                'exception.code' => (string) $exception->getCode(),
+                            ]);
+                        if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
+                            $span->setData([
+                                'exception.message' => $exception->getMessage(),
+                                'exception.stack_trace' => (string) $exception,
+                            ]);
+                        }
+                    }
+
+                    if (is_callable($onStats)) {
+                        ($onStats)($stats);
+                    }
+                };
+
+                return $proceedingJoinPoint->process();
+            },
+            SpanContext::make()
+                ->setOp('http.client')
+                ->setDescription($request->getMethod() . ' ' . (string) $request->getUri())
+                ->setOrigin('auto.http.client')
+        );
     }
 }

--- a/src/sentry/src/Tracing/Aspect/GuzzleHttpClientAspect.php
+++ b/src/sentry/src/Tracing/Aspect/GuzzleHttpClientAspect.php
@@ -185,6 +185,7 @@ class GuzzleHttpClientAspect extends AbstractAspect
                 ->setOp('http.client')
                 ->setDescription($request->getMethod() . ' ' . (string) $request->getUri())
                 ->setOrigin('auto.http.client')
+                ->setData(['coroutine.id' => Coroutine::id()])
         );
     }
 }

--- a/src/sentry/src/Tracing/Aspect/GuzzleHttpClientAspect.php
+++ b/src/sentry/src/Tracing/Aspect/GuzzleHttpClientAspect.php
@@ -162,8 +162,10 @@ class GuzzleHttpClientAspect extends AbstractAspect
                             ->setTags([
                                 'error' => 'true',
                                 'exception.class' => $exception::class,
-                                'exception.message' => $exception->getMessage(),
                                 'exception.code' => (string) $exception->getCode(),
+                            ])
+                            ->setData([
+                                'exception.message' => $exception->getMessage(),
                             ]);
                         if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
                             $span->setData([

--- a/src/sentry/src/Tracing/Aspect/GuzzleHttpClientAspect.php
+++ b/src/sentry/src/Tracing/Aspect/GuzzleHttpClientAspect.php
@@ -47,7 +47,7 @@ class GuzzleHttpClientAspect extends AbstractAspect
     {
         if (
             ! $this->switcher->isTracingSpanEnabled('guzzle')
-            || Context::get(RpcAspect::SPAN) // If the parent span is not exists or the parent span is belongs to rpc, then skip.
+            || Context::get(RpcAspect::SPAN_CONTEXT) // If the parent span is not exists or the parent span is belongs to rpc, then skip.
         ) {
             return $proceedingJoinPoint->process();
         }

--- a/src/sentry/src/Tracing/Aspect/GuzzleHttpClientAspect.php
+++ b/src/sentry/src/Tracing/Aspect/GuzzleHttpClientAspect.php
@@ -47,10 +47,7 @@ class GuzzleHttpClientAspect extends AbstractAspect
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
-        if (
-            ! $this->switcher->isTracingSpanEnabled('guzzle')
-            || Context::get(RpcAspect::SPAN_CONTEXT) // If the parent span is not exists or the parent span is belongs to rpc, then skip.
-        ) {
+        if (! $this->switcher->isTracingSpanEnabled('guzzle')) {
             return $proceedingJoinPoint->process();
         }
 

--- a/src/sentry/src/Tracing/Aspect/GuzzleHttpClientAspect.php
+++ b/src/sentry/src/Tracing/Aspect/GuzzleHttpClientAspect.php
@@ -160,11 +160,11 @@ class GuzzleHttpClientAspect extends AbstractAspect
                             ->setTags([
                                 'error' => 'true',
                                 'exception.class' => $exception::class,
+                                'exception.message' => $exception->getMessage(),
                                 'exception.code' => (string) $exception->getCode(),
                             ]);
                         if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
                             $span->setData([
-                                'exception.message' => $exception->getMessage(),
                                 'exception.stack_trace' => (string) $exception,
                             ]);
                         }

--- a/src/sentry/src/Tracing/Aspect/GuzzleHttpClientAspect.php
+++ b/src/sentry/src/Tracing/Aspect/GuzzleHttpClientAspect.php
@@ -142,7 +142,9 @@ class GuzzleHttpClientAspect extends AbstractAspect
                             }
                         }
 
-                        $span->setStatus(SpanStatus::createFromHttpStatusCode($response->getStatusCode()));
+                        $span->setStatus(
+                            SpanStatus::createFromHttpStatusCode($response->getStatusCode())
+                        );
 
                         if ($response->getStatusCode() >= 400 && $response->getStatusCode() < 600) {
                             $span->setTags([

--- a/src/sentry/src/Tracing/Aspect/KafkaProducerAspect.php
+++ b/src/sentry/src/Tracing/Aspect/KafkaProducerAspect.php
@@ -15,6 +15,7 @@ use FriendsOfHyperf\Sentry\Constants;
 use FriendsOfHyperf\Sentry\Switcher;
 use FriendsOfHyperf\Sentry\Tracing\SpanStarter;
 use FriendsOfHyperf\Sentry\Util\Carrier;
+use Hyperf\Coroutine\Coroutine;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use longlang\phpkafka\Producer\ProduceMessage;
@@ -84,6 +85,7 @@ class KafkaProducerAspect extends AbstractAspect
                 ->setDescription(sprintf('%s::%s()', $proceedingJoinPoint->className, $proceedingJoinPoint->methodName))
                 ->setOrigin('auto.kafka')
                 ->setData([
+                    'coroutine.id' => Coroutine::id(),
                     'messaging.system' => 'kafka',
                     'messaging.operation' => 'publish',
                     'messaging.message.id' => $messageId,
@@ -123,6 +125,7 @@ class KafkaProducerAspect extends AbstractAspect
                 ->setOp('queue.publish')
                 ->setDescription(sprintf('%s::%s()', $proceedingJoinPoint->className, $proceedingJoinPoint->methodName))
                 ->setOrigin('auto.kafka')
+                ->setData(['coroutine.id' => Coroutine::id()])
         );
     }
 }

--- a/src/sentry/src/Tracing/Aspect/KafkaProducerAspect.php
+++ b/src/sentry/src/Tracing/Aspect/KafkaProducerAspect.php
@@ -84,13 +84,11 @@ class KafkaProducerAspect extends AbstractAspect
                 ->setDescription(sprintf('%s::%s()', $proceedingJoinPoint->className, $proceedingJoinPoint->methodName))
                 ->setOrigin('auto.kafka')
                 ->setData([
-                    [
-                        'messaging.system' => 'kafka',
-                        'messaging.operation' => 'publish',
-                        'messaging.message.id' => $messageId,
-                        'messaging.message.body.size' => $bodySize,
-                        'messaging.destination.name' => $destinationName,
-                    ],
+                    'messaging.system' => 'kafka',
+                    'messaging.operation' => 'publish',
+                    'messaging.message.id' => $messageId,
+                    'messaging.message.body.size' => $bodySize,
+                    'messaging.destination.name' => $destinationName,
                 ])
         );
     }

--- a/src/sentry/src/Tracing/Aspect/KafkaProducerAspect.php
+++ b/src/sentry/src/Tracing/Aspect/KafkaProducerAspect.php
@@ -19,8 +19,8 @@ use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use longlang\phpkafka\Producer\ProduceMessage;
 use longlang\phpkafka\Protocol\RecordBatch\RecordHeader;
-
-use function Hyperf\Tappable\tap;
+use Sentry\State\Scope;
+use Sentry\Tracing\SpanContext;
 
 /**
  * @property array $headers
@@ -55,71 +55,76 @@ class KafkaProducerAspect extends AbstractAspect
 
     protected function sendAsync(ProceedingJoinPoint $proceedingJoinPoint)
     {
-        $span = $this->startSpan(
-            op: 'queue.publish',
-            description: sprintf('%s::%s()', $proceedingJoinPoint->className, $proceedingJoinPoint->methodName),
-            origin: 'auto.kafka'
-        );
-
-        if (! $span) {
-            return $proceedingJoinPoint->process();
-        }
-
         $messageId = uniqid('kafka_', true);
         $destinationName = $proceedingJoinPoint->arguments['keys']['topic'] ?? 'unknown';
         $bodySize = strlen($proceedingJoinPoint->arguments['keys']['value'] ?? '');
 
-        $span->setData([
-            'messaging.system' => 'kafka',
-            'messaging.operation' => 'publish',
-            'messaging.message.id' => $messageId,
-            'messaging.message.body.size' => $bodySize,
-            'messaging.destination.name' => $destinationName,
-        ]);
+        return $this->trace(
+            function (Scope $scope) use ($proceedingJoinPoint, $messageId, $destinationName, $bodySize) {
+                $span = $scope->getSpan();
+                if ($span) {
+                    $carrier = Carrier::fromSpan($span)
+                        ->with([
+                            'publish_time' => microtime(true),
+                            'message_id' => $messageId,
+                            'destination_name' => $destinationName,
+                            'body_size' => $bodySize,
+                        ]);
+                    $headers = $proceedingJoinPoint->arguments['keys']['headers'] ?? [];
+                    $headers[] = (new RecordHeader())
+                        ->setHeaderKey(Constants::TRACE_CARRIER)
+                        ->setValue($carrier->toJson());
+                    $proceedingJoinPoint->arguments['keys']['headers'] = $headers;
+                }
 
-        $carrier = Carrier::fromSpan($span)
-            ->with([
-                'publish_time' => microtime(true),
-                'message_id' => $messageId,
-                'destination_name' => $destinationName,
-                'body_size' => $bodySize,
-            ]);
-        $headers = $proceedingJoinPoint->arguments['keys']['headers'] ?? [];
-        $headers[] = (new RecordHeader())
-            ->setHeaderKey(Constants::TRACE_CARRIER)
-            ->setValue($carrier->toJson());
-        $proceedingJoinPoint->arguments['keys']['headers'] = $headers;
-
-        return tap($proceedingJoinPoint->process(), fn () => $span->finish());
+                return $proceedingJoinPoint->process();
+            },
+            SpanContext::make()
+                ->setOp('queue.publish')
+                ->setDescription(sprintf('%s::%s()', $proceedingJoinPoint->className, $proceedingJoinPoint->methodName))
+                ->setOrigin('auto.kafka')
+                ->setData([
+                    [
+                        'messaging.system' => 'kafka',
+                        'messaging.operation' => 'publish',
+                        'messaging.message.id' => $messageId,
+                        'messaging.message.body.size' => $bodySize,
+                        'messaging.destination.name' => $destinationName,
+                    ],
+                ])
+        );
     }
 
     protected function sendBatchAsync(ProceedingJoinPoint $proceedingJoinPoint)
     {
         /** @var ProduceMessage[] $messages */
         $messages = $proceedingJoinPoint->arguments['keys']['messages'] ?? [];
-        $span = $this->startSpan(
-            'queue.publish',
-            sprintf('%s::%s', $proceedingJoinPoint->className, $proceedingJoinPoint->methodName),
-            origin: 'auto.kafka'
+
+        return $this->trace(
+            function (Scope $scope) use ($proceedingJoinPoint, $messages) {
+                $span = $scope->getSpan();
+
+                if ($span) {
+                    foreach ($messages as $message) {
+                        (function () use ($span) {
+                            $carrier = Carrier::fromSpan($span)
+                                ->with([
+                                    'publish_time' => microtime(true),
+                                    'message_id' => uniqid('kafka_', true),
+                                    'destination_name' => $this->getTopic(),
+                                    'body_size' => strlen((string) $this->getValue()),
+                                ]);
+                            $this->headers[] = (new RecordHeader())->setHeaderKey(Constants::TRACE_CARRIER)->setValue($carrier->toJson());
+                        })->call($message);
+                    }
+                }
+
+                return $proceedingJoinPoint->process();
+            },
+            SpanContext::make()
+                ->setOp('queue.publish')
+                ->setDescription(sprintf('%s::%s()', $proceedingJoinPoint->className, $proceedingJoinPoint->methodName))
+                ->setOrigin('auto.kafka')
         );
-
-        if (! $span) {
-            return $proceedingJoinPoint->process();
-        }
-
-        foreach ($messages as $message) {
-            (function () use ($span) {
-                $carrier = Carrier::fromSpan($span)
-                    ->with([
-                        'publish_time' => microtime(true),
-                        'message_id' => uniqid('kafka_', true),
-                        'destination_name' => $this->getTopic(),
-                        'body_size' => strlen((string) $this->getValue()),
-                    ]);
-                $this->headers[] = (new RecordHeader())->setHeaderKey(Constants::TRACE_CARRIER)->setValue($carrier->toJson());
-            })->call($message);
-        }
-
-        return tap($proceedingJoinPoint->process(), fn () => $span->finish());
     }
 }

--- a/src/sentry/src/Tracing/Aspect/RedisAspect.php
+++ b/src/sentry/src/Tracing/Aspect/RedisAspect.php
@@ -21,8 +21,10 @@ use Hyperf\Redis\Event\CommandExecuted;
 use Hyperf\Redis\Pool\PoolFactory;
 use Hyperf\Redis\Redis;
 use Psr\Container\ContainerInterface;
-use Sentry\Tracing\SpanStatus;
-use Throwable;
+use Sentry\State\Scope;
+use Sentry\Tracing\SpanContext;
+
+use function Hyperf\Tappable\tap;
 
 /**
  * @deprecated since v3.1, will be removed in v3.2.
@@ -72,44 +74,26 @@ class RedisAspect extends AbstractAspect
             'db.redis.pool.using' => $pool->getCurrentConnections(),
         ];
 
-        // rule: operation db.table
-        // $op = sprintf('%s %s', $arguments['name'], $arguments['arguments']['key'] ?? '');
-        // $description = sprintf('%s::%s()', $proceedingJoinPoint->className, $arguments['name']);
         $key = $arguments['arguments'][0] ?? '';
         $description = sprintf(
             '%s %s',
             strtoupper($arguments['name'] ?? ''),
             is_array($key) ? implode(',', $key) : $key
         );
-        $span = $this->startSpan(
-            op: 'db.redis',
-            description: $description,
-            origin: 'auto.cache.redis',
-        )?->setData($data);
 
-        try {
-            $result = $proceedingJoinPoint->process();
-
-            if ($this->switcher->isTracingExtraTagEnabled('redis.result')) {
-                $span?->setData(['redis.result' => $result]);
-            }
-
-            return $result;
-        } catch (Throwable $e) {
-            $span?->setStatus(SpanStatus::internalError())
-                ->setTags([
-                    'error' => 'true',
-                    'exception.class' => $e::class,
-                    'exception.message' => $e->getMessage(),
-                    'exception.code' => (string) $e->getCode(),
-                ]);
-            if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
-                $span?->setData(['exception.stack_trace' => (string) $e]);
-            }
-
-            throw $e;
-        } finally {
-            $span?->finish();
-        }
+        return $this->trace(
+            function (Scope $scope) use ($proceedingJoinPoint) {
+                tap($proceedingJoinPoint->process(), function ($result) use ($scope) {
+                    if ($this->switcher->isTracingExtraTagEnabled('redis.result')) {
+                        $scope->getSpan()?->setData(['redis.result' => $result]);
+                    }
+                });
+            },
+            SpanContext::make()
+                ->setOp('db.redis')
+                ->setDescription($description)
+                ->setOrigin('auto.cache.redis')
+                ->setData($data)
+        );
     }
 }

--- a/src/sentry/src/Tracing/Aspect/RedisAspect.php
+++ b/src/sentry/src/Tracing/Aspect/RedisAspect.php
@@ -83,7 +83,7 @@ class RedisAspect extends AbstractAspect
 
         return $this->trace(
             function (Scope $scope) use ($proceedingJoinPoint) {
-                tap($proceedingJoinPoint->process(), function ($result) use ($scope) {
+                return tap($proceedingJoinPoint->process(), function ($result) use ($scope) {
                     if ($this->switcher->isTracingExtraTagEnabled('redis.result')) {
                         $scope->getSpan()?->setData(['redis.result' => $result]);
                     }

--- a/src/sentry/src/Tracing/Aspect/RpcAspect.php
+++ b/src/sentry/src/Tracing/Aspect/RpcAspect.php
@@ -115,8 +115,8 @@ class RpcAspect extends AbstractAspect
                             ->set(Constants::TRACE_CARRIER, Carrier::fromSpan($span)->toJson());
                     }
                     return tap($proceedingJoinPoint->process(), function ($result) use ($span) {
-                        if ($this->switcher->isTracingExtraTagEnabled('rpc.result')) {
-                            $span?->setData(['rpc.result' => $result]);
+                        if ($span && $this->switcher->isTracingExtraTagEnabled('rpc.result')) {
+                            $span->setData(['rpc.result' => $result]);
                         }
                     });
                 },

--- a/src/sentry/src/Tracing/Aspect/RpcAspect.php
+++ b/src/sentry/src/Tracing/Aspect/RpcAspect.php
@@ -24,9 +24,11 @@ use Hyperf\Rpc;
 use Hyperf\RpcClient;
 use Hyperf\Stringable\Str;
 use Psr\Container\ContainerInterface;
+use Sentry\State\Scope;
 use Sentry\Tracing\Span;
-use Sentry\Tracing\SpanStatus;
-use Throwable;
+use Sentry\Tracing\SpanContext;
+
+use function Hyperf\Tappable\tap;
 
 /**
  * @property string $prototype
@@ -35,9 +37,11 @@ class RpcAspect extends AbstractAspect
 {
     use SpanStarter;
 
-    public const SPAN = 'sentry.tracing.rpc.span';
+    // public const SPAN = 'sentry.tracing.rpc.span';
 
-    protected const DATA = 'sentry.tracing.rpc.data';
+    // protected const DATA = 'sentry.tracing.rpc.data';
+
+    protected const SPAN_CONTEXT = 'sentry.tracing.rpc.span_context';
 
     public array $classes = [
         RpcClient\AbstractServiceClient::class . '::__generateRpcPath',
@@ -79,79 +83,43 @@ class RpcAspect extends AbstractAspect
             default => 'rpc',
         };
 
-        // $package.$service/$path
-        $op = sprintf('%s.%s/%s', $package, $service, $path);
-        $span = $this->startSpan(
-            op: $op,
-            description: $path,
-            origin: 'auto.rpc',
-        );
-
-        if (! $span) {
-            return $path;
-        }
-
-        $data = [
-            'coroutine.id' => Coroutine::id(),
-            'rpc.system' => $system,
-            'rpc.method' => $proceedingJoinPoint->arguments['keys']['methodName'] ?? '',
-            'rpc.service' => $service,
-        ];
-
-        $span->setData($data);
-
-        Context::set(static::DATA, $data); // @deprecated since v3.1, will be removed in v3.2
-        Context::set(static::SPAN, $span);
-
-        if ($this->container->has(Rpc\Context::class)) {
-            $this->container->get(Rpc\Context::class)
-                ->set(Constants::TRACE_CARRIER, Carrier::fromSpan($span)->toJson());
-        }
+        Context::set(static::SPAN_CONTEXT, SpanContext::make()
+            ->setOp(sprintf('%s.%s/%s', $package, $service, $path))
+            ->setDescription($path)
+            ->setOrigin('auto.rpc')
+            ->setData([
+                'coroutine.id' => Coroutine::id(),
+                'rpc.system' => $system,
+                'rpc.service' => $service,
+                'rpc.method' => $proceedingJoinPoint->arguments['keys']['methodName'] ?? '',
+            ]));
 
         return $path;
     }
 
     private function handleSend(ProceedingJoinPoint $proceedingJoinPoint)
     {
-        // TODO
-        // 'server.address' => '',
-        // 'server.port' => '',
+        /** @var null|SpanContext $spanContext */
+        $spanContext = Context::get(static::SPAN_CONTEXT);
 
-        /** @var null|Span $span */
-        $span = Context::get(static::SPAN);
-
-        $span?->setData((array) Context::get(static::DATA, []));
-
-        if ($this->container->has(Rpc\Context::class)) {
-            $span?->setData(['rpc.context' => $this->container->get(Rpc\Context::class)->getData()]);
+        if (! $spanContext) {
+            return $proceedingJoinPoint->process();
         }
 
-        try {
-            $result = $proceedingJoinPoint->process();
-
-            if ($this->switcher->isTracingExtraTagEnabled('rpc.result')) {
-                $span?->setData(['rpc.result' => $result]);
-            }
-
-            return $result;
-        } catch (Throwable $exception) {
-            $span?->setStatus(SpanStatus::internalError())
-                ->setTags([
-                    'error' => 'true',
-                    'exception.class' => $exception::class,
-                    'exception.message' => $exception->getMessage(),
-                    'exception.code' => (string) $exception->getCode(),
-                ]);
-            if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
-                $span?->setData(['exception.stack_trace' => (string) $exception]);
-            }
-
-            throw $exception;
-        } finally {
-            $span?->finish();
-
-            Context::destroy(static::SPAN);
-            Context::destroy(static::DATA);
-        }
+        return $this->trace(
+            function (Scope $scope) use ($proceedingJoinPoint) {
+                $span = $scope->getSpan();
+                if ($span && $this->container->has(Rpc\Context::class)) {
+                    $this->container->get(Rpc\Context::class)
+                        ->set(Constants::TRACE_CARRIER, Carrier::fromSpan($span)->toJson());
+                }
+                return tap($proceedingJoinPoint->process(), function ($result) use ($span) {
+                    if ($this->switcher->isTracingExtraTagEnabled('rpc.result')) {
+                        $span?->setData(['rpc.result' => $result]);
+                    }
+                });
+            },
+            $spanContext
+        );
     }
 }

--- a/src/sentry/src/Tracing/Aspect/RpcAspect.php
+++ b/src/sentry/src/Tracing/Aspect/RpcAspect.php
@@ -25,7 +25,6 @@ use Hyperf\RpcClient;
 use Hyperf\Stringable\Str;
 use Psr\Container\ContainerInterface;
 use Sentry\State\Scope;
-use Sentry\Tracing\Span;
 use Sentry\Tracing\SpanContext;
 
 use function Hyperf\Tappable\tap;
@@ -37,11 +36,7 @@ class RpcAspect extends AbstractAspect
 {
     use SpanStarter;
 
-    // public const SPAN = 'sentry.tracing.rpc.span';
-
-    // protected const DATA = 'sentry.tracing.rpc.data';
-
-    protected const SPAN_CONTEXT = 'sentry.tracing.rpc.span_context';
+    public const SPAN_CONTEXT = 'sentry.tracing.rpc.span_context';
 
     public array $classes = [
         RpcClient\AbstractServiceClient::class . '::__generateRpcPath',

--- a/src/sentry/src/Tracing/Aspect/RpcAspect.php
+++ b/src/sentry/src/Tracing/Aspect/RpcAspect.php
@@ -106,6 +106,11 @@ class RpcAspect extends AbstractAspect
                 function (Scope $scope) use ($proceedingJoinPoint) {
                     $span = $scope->getSpan();
                     if ($span && $this->container->has(Rpc\Context::class)) {
+                        // Inject the RPC context data into span.
+                        $span->setData([
+                            'rpc.context' => $this->container->get(Rpc\Context::class)->getData(),
+                        ]);
+                        // Inject the tracing carrier into RPC context.
                         $this->container->get(Rpc\Context::class)
                             ->set(Constants::TRACE_CARRIER, Carrier::fromSpan($span)->toJson());
                     }

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -374,6 +374,8 @@ class EventHandleListener implements ListenerInterface
                     'error' => 'true',
                     'exception.class' => $exception::class,
                     'exception.code' => (string) $exception->getCode(),
+                ])
+                ->setData([
                     'exception.message' => $exception->getMessage(),
                 ]);
             if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
@@ -427,8 +429,10 @@ class EventHandleListener implements ListenerInterface
                 ->setTags([
                     'error' => 'true',
                     'exception.class' => $exception::class,
-                    'exception.message' => $exception->getMessage(),
                     'exception.code' => (string) $exception->getCode(),
+                ])
+                ->setData([
+                    'exception.message' => $exception->getMessage(),
                 ]);
             if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
                 $transaction->setData([
@@ -469,8 +473,10 @@ class EventHandleListener implements ListenerInterface
                         ->setTags([
                             'error' => 'true',
                             'exception.class' => $exception::class,
-                            'exception.message' => $exception->getMessage(),
                             'exception.code' => (string) $exception->getCode(),
+                        ])
+                        ->setData([
+                            'exception.message' => $exception->getMessage(),
                         ]);
                     if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
                         $span?->setData(['exception.stack_trace' => (string) $exception]);
@@ -536,8 +542,10 @@ class EventHandleListener implements ListenerInterface
                 ->setTags([
                     'error' => 'true',
                     'exception.class' => $exception::class,
-                    'exception.message' => $exception->getMessage(),
                     'exception.code' => (string) $exception->getCode(),
+                ])
+                ->setData([
+                    'exception.message' => $exception->getMessage(),
                 ]);
             if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
                 $transaction->setData(['exception.stack_trace' => (string) $exception]);
@@ -614,8 +622,10 @@ class EventHandleListener implements ListenerInterface
                 ->setTags([
                     'error' => 'true',
                     'exception.class' => $exception::class,
-                    'exception.message' => $exception->getMessage(),
                     'exception.code' => (string) $exception->getCode(),
+                ])
+                ->setData([
+                    'exception.message' => $exception->getMessage(),
                 ]);
             if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
                 $transaction->setData(['exception.stack_trace' => (string) $exception]);
@@ -686,8 +696,10 @@ class EventHandleListener implements ListenerInterface
                 ->setTags([
                     'error' => 'true',
                     'exception.class' => $exception::class,
-                    'exception.message' => $exception->getMessage(),
                     'exception.code' => (string) $exception->getCode(),
+                ])
+                ->setData([
+                    'exception.message' => $exception->getMessage(),
                 ]);
             if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
                 $transaction->setData(['exception.stack_trace' => (string) $exception]);
@@ -745,8 +757,10 @@ class EventHandleListener implements ListenerInterface
                 ->setTags([
                     'error' => 'true',
                     'exception.class' => $exception::class,
-                    'exception.message' => $exception->getMessage(),
                     'exception.code' => (string) $exception->getCode(),
+                ])
+                ->setData([
+                    'exception.message' => $exception->getMessage(),
                 ]);
             if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
                 $transaction->setData(['exception.stack_trace' => (string) $exception]);

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -347,11 +347,7 @@ class EventHandleListener implements ListenerInterface
     {
         $span = SentrySdk::getCurrentHub()->getSpan();
 
-        if (
-            ! $span
-            || ! $span->getSampled()
-            || ! $traceId = (string) $span->getTraceId()
-        ) {
+        if (! $span || ! $traceId = (string) $span->getTraceId()) {
             return;
         }
 
@@ -363,7 +359,6 @@ class EventHandleListener implements ListenerInterface
             $event->response->setHeader('sentry-trace-id', $traceId);
         }
 
-        // $span->setHttpStatus($event->response->getStatusCode());
         $span->setStatus(
             SpanStatus::createFromHttpStatusCode($event->response->getStatusCode())
         );

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -317,16 +317,16 @@ class EventHandleListener implements ListenerInterface
             return;
         }
 
-        $spanContext = SpanContext::make()
-            ->setOp('request.received')
-            ->setDescription('request.received')
-            ->setData([
-                'coroutine.id' => Coroutine::id(),
-            ])
-            ->setStatus(SpanStatus::ok())
-            ->setStartTimestamp(microtime(true));
-
-        $span = $transaction->startChild($spanContext);
+        $span = $transaction->startChild(
+            SpanContext::make()
+                ->setOp('request.received')
+                ->setDescription('request.received')
+                ->setData([
+                    'coroutine.id' => Coroutine::id(),
+                ])
+                ->setStatus(SpanStatus::ok())
+                ->setStartTimestamp(microtime(true))
+        );
 
         SentrySdk::getCurrentHub()->setSpan($span);
 

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -163,7 +163,7 @@ class EventHandleListener implements ListenerInterface
         };
     }
 
-    private function handleDbQueryExecuted(DbEvent\QueryExecuted $event): void
+    protected function handleDbQueryExecuted(DbEvent\QueryExecuted $event): void
     {
         if (! $this->switcher->isTracingSpanEnabled('sql_queries')) {
             return;
@@ -213,7 +213,7 @@ class EventHandleListener implements ListenerInterface
         );
     }
 
-    private function handleDbTransactionBeginning(DbEvent\TransactionBeginning $event): void
+    protected function handleDbTransactionBeginning(DbEvent\TransactionBeginning $event): void
     {
         if (! $this->switcher->isTracingSpanEnabled('sql_transactions')) {
             return;
@@ -235,7 +235,7 @@ class EventHandleListener implements ListenerInterface
         );
     }
 
-    private function handleDbTransactionCommitted(DbEvent\TransactionCommitted $event): void
+    protected function handleDbTransactionCommitted(DbEvent\TransactionCommitted $event): void
     {
         if (! $this->switcher->isTracingSpanEnabled('sql_transactions')) {
             return;
@@ -249,7 +249,7 @@ class EventHandleListener implements ListenerInterface
             ->finish();
     }
 
-    private function handleDbTransactionRolledBack(DbEvent\TransactionRolledBack $event): void
+    protected function handleDbTransactionRolledBack(DbEvent\TransactionRolledBack $event): void
     {
         if (! $this->switcher->isTracingSpanEnabled('sql_transactions')) {
             return;
@@ -263,7 +263,7 @@ class EventHandleListener implements ListenerInterface
             ->finish();
     }
 
-    private function handleRequestReceived(HttpEvent\RequestReceived|RpcEvent\RequestReceived $event): void
+    protected function handleRequestReceived(HttpEvent\RequestReceived|RpcEvent\RequestReceived $event): void
     {
         if (! $this->switcher->isTracingEnabled('request')) {
             return;
@@ -343,7 +343,7 @@ class EventHandleListener implements ListenerInterface
         });
     }
 
-    private function handleRequestHandled(HttpEvent\RequestHandled|RpcEvent\RequestHandled $event): void
+    protected function handleRequestHandled(HttpEvent\RequestHandled|RpcEvent\RequestHandled $event): void
     {
         $span = SentrySdk::getCurrentHub()->getSpan();
 
@@ -386,7 +386,7 @@ class EventHandleListener implements ListenerInterface
         }
     }
 
-    private function handleCommandStarting(CommandEvent\BeforeHandle $event): void
+    protected function handleCommandStarting(CommandEvent\BeforeHandle $event): void
     {
         if (
             ! $this->switcher->isTracingEnabled('command')
@@ -406,7 +406,7 @@ class EventHandleListener implements ListenerInterface
         );
     }
 
-    private function handleCommandFinished(CommandEvent\AfterExecute $event): void
+    protected function handleCommandFinished(CommandEvent\AfterExecute $event): void
     {
         $transaction = SentrySdk::getCurrentHub()->getTransaction();
 
@@ -450,7 +450,7 @@ class EventHandleListener implements ListenerInterface
         $transaction->finish();
     }
 
-    private function handleRedisCommandExecuted(RedisEvent\CommandExecuted $event): void
+    protected function handleRedisCommandExecuted(RedisEvent\CommandExecuted $event): void
     {
         if (! $this->switcher->isTracingSpanEnabled('redis')) {
             return;
@@ -506,7 +506,7 @@ class EventHandleListener implements ListenerInterface
         );
     }
 
-    private function handleCrontabTaskStarting(CrontabEvent\BeforeExecute $event): void
+    protected function handleCrontabTaskStarting(CrontabEvent\BeforeExecute $event): void
     {
         if (! $this->switcher->isTracingEnabled('crontab')) {
             return;
@@ -523,7 +523,7 @@ class EventHandleListener implements ListenerInterface
         );
     }
 
-    private function handleCrontabTaskFinished(CrontabEvent\FailToExecute|CrontabEvent\AfterExecute $event): void
+    protected function handleCrontabTaskFinished(CrontabEvent\FailToExecute|CrontabEvent\AfterExecute $event): void
     {
         $transaction = SentrySdk::getCurrentHub()->getTransaction();
 
@@ -559,7 +559,7 @@ class EventHandleListener implements ListenerInterface
         $transaction->finish();
     }
 
-    private function handleAmqpMessageProcessing(AmqpEvent\BeforeConsume $event): void
+    protected function handleAmqpMessageProcessing(AmqpEvent\BeforeConsume $event): void
     {
         if (! $this->switcher->isTracingEnabled('amqp')) {
             return;
@@ -590,7 +590,7 @@ class EventHandleListener implements ListenerInterface
         );
     }
 
-    private function handleAmqpMessageProcessed(AmqpEvent\AfterConsume|AmqpEvent\FailToConsume $event): void
+    protected function handleAmqpMessageProcessed(AmqpEvent\AfterConsume|AmqpEvent\FailToConsume $event): void
     {
         $transaction = SentrySdk::getCurrentHub()->getTransaction();
 
@@ -639,7 +639,7 @@ class EventHandleListener implements ListenerInterface
         $transaction->finish();
     }
 
-    private function handleKafkaMessageProcessing(KafkaEvent\BeforeConsume $event): void
+    protected function handleKafkaMessageProcessing(KafkaEvent\BeforeConsume $event): void
     {
         if (! $this->switcher->isTracingEnabled('kafka')) {
             return;
@@ -670,7 +670,7 @@ class EventHandleListener implements ListenerInterface
         );
     }
 
-    private function handleKafkaMessageProcessed(KafkaEvent\AfterConsume|KafkaEvent\FailToConsume $event): void
+    protected function handleKafkaMessageProcessed(KafkaEvent\AfterConsume|KafkaEvent\FailToConsume $event): void
     {
         $transaction = SentrySdk::getCurrentHub()->getTransaction();
 
@@ -713,7 +713,7 @@ class EventHandleListener implements ListenerInterface
         $transaction->finish();
     }
 
-    private function handleAsyncQueueJobProcessing(AsyncQueueEvent\BeforeHandle $event): void
+    protected function handleAsyncQueueJobProcessing(AsyncQueueEvent\BeforeHandle $event): void
     {
         if (! $this->switcher->isTracingEnabled('async_queue')) {
             return;
@@ -734,7 +734,7 @@ class EventHandleListener implements ListenerInterface
         );
     }
 
-    private function handleAsyncQueueJobProcessed(AsyncQueueEvent\AfterHandle|AsyncQueueEvent\RetryHandle|AsyncQueueEvent\FailedHandle $event): void
+    protected function handleAsyncQueueJobProcessed(AsyncQueueEvent\AfterHandle|AsyncQueueEvent\RetryHandle|AsyncQueueEvent\FailedHandle $event): void
     {
         $transaction = SentrySdk::getCurrentHub()->getTransaction();
 

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -301,6 +301,7 @@ class EventHandleListener implements ListenerInterface
         if ($this->container->has(RpcContext::class)) {
             $data['rpc.context'] = $this->container->get(RpcContext::class)->getData();
         }
+
         $carrier = Carrier::fromRequest($request);
         $transaction = $this->startTransaction(
             continueTrace($carrier->getSentryTrace(), $carrier->getBaggage())

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -333,7 +333,7 @@ class EventHandleListener implements ListenerInterface
 
         defer(function () use ($transaction, $span) {
             // Make sure the span is finished after the request is handled
-            $span?->finish();
+            $span->finish();
 
             // Make sure the transaction is finished after the request is handled
             SentrySdk::getCurrentHub()->setSpan($transaction);

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -462,14 +462,16 @@ class EventHandleListener implements ListenerInterface
 
         $this->trace(
             function (Scope $scope) use ($event) {
-                $span = $scope->getSpan();
+                if (! $span = $scope->getSpan()) {
+                    return;
+                }
 
                 if ($this->switcher->isTracingExtraTagEnabled('redis.result')) {
-                    $span?->setData(['db.redis.result' => $event->result]);
+                    $span->setData(['db.redis.result' => $event->result]);
                 }
 
                 if ($exception = $event->throwable) {
-                    $span?->setStatus(SpanStatus::internalError())
+                    $span->setStatus(SpanStatus::internalError())
                         ->setTags([
                             'error' => 'true',
                             'exception.class' => $exception::class,
@@ -479,7 +481,7 @@ class EventHandleListener implements ListenerInterface
                             'exception.message' => $exception->getMessage(),
                         ]);
                     if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
-                        $span?->setData(['exception.stack_trace' => (string) $exception]);
+                        $span->setData(['exception.stack_trace' => (string) $exception]);
                     }
                 }
             },

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -289,6 +289,7 @@ class EventHandleListener implements ListenerInterface
             default => [$route, TransactionSource::route()],
         };
         $data = [
+            'coroutine.id' => Coroutine::id(),
             'url.scheme' => $request->getUri()->getScheme(),
             'url.path' => $path,
             'http.request.method' => $method,
@@ -395,6 +396,7 @@ class EventHandleListener implements ListenerInterface
                 ->setDescription($command->getDescription())
                 ->setOrigin('auto.command')
                 ->setSource(TransactionSource::custom())
+                ->setData(['coroutine.id' => Coroutine::id()])
         );
     }
 
@@ -515,6 +517,7 @@ class EventHandleListener implements ListenerInterface
                 ->setDescription($crontab->getMemo())
                 ->setOrigin('auto.crontab')
                 ->setSource(TransactionSource::task())
+                ->setData(['coroutine.id' => Coroutine::id()])
         );
     }
 
@@ -583,6 +586,7 @@ class EventHandleListener implements ListenerInterface
                 ->setDescription($message::class)
                 ->setOrigin('auto.amqp')
                 ->setSource(TransactionSource::custom())
+                ->setData(['coroutine.id' => Coroutine::id()])
         );
     }
 
@@ -664,6 +668,7 @@ class EventHandleListener implements ListenerInterface
                 ->setDescription($consumer::class)
                 ->setOrigin('auto.kafka')
                 ->setSource(TransactionSource::custom())
+                ->setData(['coroutine.id' => Coroutine::id()])
         );
     }
 
@@ -729,6 +734,7 @@ class EventHandleListener implements ListenerInterface
                 ->setDescription('async_queue: ' . $job::class)
                 ->setOrigin('auto.async_queue')
                 ->setSource(TransactionSource::custom())
+                ->setData(['coroutine.id' => Coroutine::id()])
         );
     }
 

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -363,7 +363,10 @@ class EventHandleListener implements ListenerInterface
             $event->response->setHeader('sentry-trace-id', $traceId);
         }
 
-        $span->setHttpStatus($event->response->getStatusCode());
+        // $span->setHttpStatus($event->response->getStatusCode());
+        $span->setStatus(
+            SpanStatus::createFromHttpStatusCode($event->response->getStatusCode())
+        );
 
         if ($exception = $event->getThrowable()) {
             $span->setStatus(SpanStatus::internalError())

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -348,14 +348,13 @@ class EventHandleListener implements ListenerInterface
             return;
         }
 
-        if ($traceId = $span->getTraceId()) {
-            if ($event instanceof RpcEvent\RequestHandled) {
-                if ($this->container->has(RpcContext::class)) {
-                    $this->container->get(RpcContext::class)->set('sentry-trace-id', $traceId);
-                }
-            } elseif ($event->response instanceof ResponsePlusInterface) {
-                $event->response->setHeader('sentry-trace-id', $traceId);
+        $traceId = (string) $span->getTraceId();
+        if ($event instanceof RpcEvent\RequestHandled) {
+            if ($this->container->has(RpcContext::class)) {
+                $this->container->get(RpcContext::class)->set('sentry-trace-id', $traceId);
             }
+        } elseif ($event->response instanceof ResponsePlusInterface) {
+            $event->response->setHeader('sentry-trace-id', $traceId);
         }
 
         $span->setStatus(

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -432,6 +432,9 @@ class EventHandleListener implements ListenerInterface
         SentrySdk::getCurrentHub()->setSpan($transaction);
 
         $transaction->finish();
+
+        // Make sure all spans are flushed before the command exits
+        msleep(100);
     }
 
     private function handleRedisCommandExecuted(RedisEvent\CommandExecuted $event): void

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -432,9 +432,6 @@ class EventHandleListener implements ListenerInterface
         SentrySdk::getCurrentHub()->setSpan($transaction);
 
         $transaction->finish();
-
-        // Make sure all spans are flushed before the command exits
-        msleep(100);
     }
 
     private function handleRedisCommandExecuted(RedisEvent\CommandExecuted $event): void

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -349,10 +349,8 @@ class EventHandleListener implements ListenerInterface
         }
 
         $traceId = (string) $span->getTraceId();
-        if ($event instanceof RpcEvent\RequestHandled) {
-            if ($this->container->has(RpcContext::class)) {
-                $this->container->get(RpcContext::class)->set('sentry-trace-id', $traceId);
-            }
+        if ($event instanceof RpcEvent\RequestHandled && $this->container->has(RpcContext::class)) {
+            $this->container->get(RpcContext::class)->set('sentry-trace-id', $traceId);
         } elseif ($event->response instanceof ResponsePlusInterface) {
             $event->response->setHeader('sentry-trace-id', $traceId);
         }

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -777,6 +777,9 @@ class EventHandleListener implements ListenerInterface
         }
     }
 
+    /**
+     * @return array{0:string,1:array,2:string}
+     */
     private function parseRoute(Dispatched $dispatched): array
     {
         $route = '<missing route>';

--- a/src/sentry/src/Tracing/SpanStarter.php
+++ b/src/sentry/src/Tracing/SpanStarter.php
@@ -44,13 +44,9 @@ trait SpanStarter
      */
     protected function trace(callable $trace, SpanContext $context)
     {
-        static $isTracingExtraTagEnabled = null;
-
-        if ($isTracingExtraTagEnabled === null) {
-            $isTracingExtraTagEnabled = isset($this->switcher)
-            && $this->switcher instanceof Switcher
-            && $this->switcher->isTracingExtraTagEnabled('exception.stack_trace');
-        }
+        $isTracingExtraTagEnabled = isset($this->switcher)
+        && $this->switcher instanceof Switcher
+        && $this->switcher->isTracingExtraTagEnabled('exception.stack_trace');
 
         if ($context->getStatus() === null) {
             $context->setStatus(SpanStatus::ok());

--- a/src/sentry/src/Tracing/SpanStarter.php
+++ b/src/sentry/src/Tracing/SpanStarter.php
@@ -56,6 +56,10 @@ trait SpanStarter
             $context->setStatus(SpanStatus::ok());
         }
 
+        if ($context->getStartTimestamp() === null) {
+            $context->setStartTimestamp(microtime(true));
+        }
+
         return trace(
             function (Scope $scope) use ($trace, $isTracingExtraTagEnabled) {
                 try {

--- a/src/sentry/src/Tracing/SpanStarter.php
+++ b/src/sentry/src/Tracing/SpanStarter.php
@@ -40,7 +40,7 @@ trait SpanStarter
      */
     protected function trace(callable $trace, SpanContext $context)
     {
-        return SentrySdk::getCurrentHub()->withScope(function (Scope $scope) use ($trace, $context) {
+        return SentrySdk::getCurrentHub()->withScope(function (Scope $scope) use ($context, $trace) {
             $parentSpan = $scope->getSpan();
 
             if ($parentSpan !== null && $parentSpan->getSampled()) {

--- a/src/sentry/src/Tracing/SpanStarter.php
+++ b/src/sentry/src/Tracing/SpanStarter.php
@@ -45,6 +45,7 @@ trait SpanStarter
 
             if ($parentSpan !== null && $parentSpan->getSampled()) {
                 $span = $parentSpan->startChild($context);
+                $scope->setSpan($span);
             }
 
             try {

--- a/src/sentry/src/Tracing/SpanStarter.php
+++ b/src/sentry/src/Tracing/SpanStarter.php
@@ -32,7 +32,10 @@ use function Sentry\trace;
 trait SpanStarter
 {
     /**
-     * @param callable(null|Span):mixed $callback
+     * @template T
+     *
+     * @param callable(null|Span):T $callback
+     * @return T
      */
     protected function trace(callable $callback, SpanContext $spanContext): mixed
     {

--- a/src/sentry/src/Tracing/SpanStarter.php
+++ b/src/sentry/src/Tracing/SpanStarter.php
@@ -33,6 +33,9 @@ use function Sentry\trace;
 trait SpanStarter
 {
     /**
+     * Execute the given callable while wrapping it in a span added as a child to the current transaction and active span.
+     * If there is no transaction active this is a no-op and the scope passed to the trace callable will be unused.
+     *
      * @template T
      *
      * @param callable(Scope):T $trace

--- a/src/sentry/src/Tracing/SpanStarter.php
+++ b/src/sentry/src/Tracing/SpanStarter.php
@@ -46,7 +46,7 @@ trait SpanStarter
     {
         static $isTracingExtraTagEnabled = null;
 
-        if ($isTracingExtraTagEnabled !== null) {
+        if ($isTracingExtraTagEnabled === null) {
             $isTracingExtraTagEnabled = isset($this->switcher)
             && $this->switcher instanceof Switcher
             && $this->switcher->isTracingExtraTagEnabled('exception.stack_trace');

--- a/src/sentry/src/Tracing/SpanStarter.php
+++ b/src/sentry/src/Tracing/SpanStarter.php
@@ -56,8 +56,10 @@ trait SpanStarter
                         ->setTags([
                             'error' => 'true',
                             'exception.class' => $exception::class,
-                            'exception.message' => $exception->getMessage(),
                             'exception.code' => (string) $exception->getCode(),
+                        ])
+                        ->setData([
+                            'exception.message' => $exception->getMessage(),
                         ]);
                     if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
                         $span->setData([

--- a/src/sentry/src/Tracing/SpanStarter.php
+++ b/src/sentry/src/Tracing/SpanStarter.php
@@ -76,6 +76,9 @@ trait SpanStarter
         });
     }
 
+    /**
+     * @deprecated since v3.1, will be removed in v3.2, use trace() instead.
+     */
     protected function startSpan(
         ?string $op = null,
         ?string $description = null,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 引入以 trace（Scope+SpanContext）为核心的统一追踪流，扩展到协程、HTTP、DB、缓存、队列、RPC、gRPC、Redis、Kafka、AMQP、Elasticsearch、文件系统等场景；新增事务/子跨度与上下文传播机制；支持从请求重建追踪载体。

- 修复
  - 传递协程/子任务上下文时避免覆盖父上下文已有键；若父事务未采样则跳过子跨度；异常信息更可靠地记录到跨度数据中。

- 重构
  - 大量手动 span 生命周期与异常处理统一为 trace 驱动，简化生命周期并增强可复用性与可继承性。

- 维护
  - 升级 sentry/sentry 依赖至 ^4.16.0。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->