### PR TITLE
refactor(sentry): centralize coroutine ID handling in tracing system

### DIFF
--- a/src/sentry/src/Tracing/Aspect/AmqpProducerAspect.php
+++ b/src/sentry/src/Tracing/Aspect/AmqpProducerAspect.php
@@ -16,7 +16,6 @@ use FriendsOfHyperf\Sentry\Switcher;
 use FriendsOfHyperf\Sentry\Util\Carrier;
 use Hyperf\Amqp\Annotation\Producer;
 use Hyperf\Amqp\Message\ProducerMessage;
-use Hyperf\Coroutine\Coroutine;
 use Hyperf\Di\Annotation\AnnotationCollector;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
@@ -101,7 +100,6 @@ class AmqpProducerAspect extends AbstractAspect
                 ->setDescription(sprintf('%s::%s()', $proceedingJoinPoint->className, $proceedingJoinPoint->methodName))
                 ->setOrigin('auto.amqp')
                 ->setData([
-                    'coroutine.id' => Coroutine::id(),
                     'messaging.system' => 'amqp',
                     'messaging.operation' => 'publish',
                     'messaging.message.id' => $messageId,

--- a/src/sentry/src/Tracing/Aspect/AsyncQueueJobMessageAspect.php
+++ b/src/sentry/src/Tracing/Aspect/AsyncQueueJobMessageAspect.php
@@ -16,7 +16,6 @@ use FriendsOfHyperf\Sentry\Switcher;
 use FriendsOfHyperf\Sentry\Util\Carrier;
 use Hyperf\AsyncQueue\Driver\RedisDriver;
 use Hyperf\Context\Context;
-use Hyperf\Coroutine\Coroutine;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Sentry\State\Scope;
@@ -81,7 +80,6 @@ class AsyncQueueJobMessageAspect extends AbstractAspect
         $destinationName = Context::get('sentry.messaging.destination.name', 'default');
         $bodySize = (fn ($job) => strlen($this->packer->pack($job)))->call($driver, $job);
         $data = [
-            'coroutine.id' => Coroutine::id(),
             'messaging.system' => 'async_queue',
             'messaging.operation' => 'publish',
             'messaging.message.id' => $messageId,

--- a/src/sentry/src/Tracing/Aspect/CacheAspect.php
+++ b/src/sentry/src/Tracing/Aspect/CacheAspect.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
 use FriendsOfHyperf\Sentry\Switcher;
-use Hyperf\Coroutine\Coroutine;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Sentry\State\Scope;
@@ -92,7 +91,6 @@ class CacheAspect extends AbstractAspect
                 ->setDescription(implode(', ', $keys))
                 ->setOrigin('auto.cache')
                 ->setData([
-                    'coroutine.id' => Coroutine::id(),
                     'cache.key' => $keys,
                     'cache.ttl' => $arguments['ttl'] ?? null,
                     'item_size' => match (true) {

--- a/src/sentry/src/Tracing/Aspect/CoordinatorAspect.php
+++ b/src/sentry/src/Tracing/Aspect/CoordinatorAspect.php
@@ -13,7 +13,6 @@ namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
 use FriendsOfHyperf\Sentry\Switcher;
 use Hyperf\Coordinator\Coordinator;
-use Hyperf\Coroutine\Coroutine;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Sentry\State\Scope;
@@ -46,7 +45,6 @@ class CoordinatorAspect extends AbstractAspect
                 ->setDescription(sprintf('%s::%s(%s)', $proceedingJoinPoint->className, $proceedingJoinPoint->methodName, $timeout))
                 ->setOrigin('auto.coordinator')
                 ->setData([
-                    'coroutine.id' => Coroutine::id(),
                     'timeout' => $timeout,
                 ])
         );

--- a/src/sentry/src/Tracing/Aspect/CoroutineAspect.php
+++ b/src/sentry/src/Tracing/Aspect/CoroutineAspect.php
@@ -96,7 +96,6 @@ class CoroutineAspect extends AbstractAspect
                     ->setOp('coroutine.execute')
                     ->setDescription($callingOnFunction)
                     ->setOrigin('auto.coroutine')
-                    ->setData(['coroutine.id' => Co::id()])
             );
 
             defer(function () use ($coTransaction) {

--- a/src/sentry/src/Tracing/Aspect/DbAspect.php
+++ b/src/sentry/src/Tracing/Aspect/DbAspect.php
@@ -13,7 +13,6 @@ namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
 use FriendsOfHyperf\Sentry\Switcher;
 use FriendsOfHyperf\Sentry\Util\SqlParser;
-use Hyperf\Coroutine\Coroutine;
 use Hyperf\DB\DB;
 use Hyperf\DB\Pool\PoolFactory;
 use Hyperf\Di\Aop\AbstractAspect;
@@ -64,7 +63,6 @@ class DbAspect extends AbstractAspect
         $table = $sqlParse['table'];
         $operation = $sqlParse['operation'];
         $data = [
-            'coroutine.id' => Coroutine::id(),
             'db.system' => $driver,
             'db.name' => $database,
             'db.collection.name' => $table,

--- a/src/sentry/src/Tracing/Aspect/ElasticsearchAspect.php
+++ b/src/sentry/src/Tracing/Aspect/ElasticsearchAspect.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
 use FriendsOfHyperf\Sentry\Switcher;
-use Hyperf\Coroutine\Coroutine;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Sentry\State\Scope;
@@ -76,7 +75,6 @@ class ElasticsearchAspect extends AbstractAspect
                 ->setDescription(sprintf('%s::%s()', $proceedingJoinPoint->className, $proceedingJoinPoint->methodName))
                 ->setOrigin('auto.elasticsearch')
                 ->setData([
-                    'coroutine.id' => Coroutine::id(),
                     'db.system' => 'elasticsearch',
                     'db.operation.name' => $proceedingJoinPoint->methodName,
                     'arguments' => (string) json_encode($proceedingJoinPoint->arguments['keys'], JSON_UNESCAPED_UNICODE),

--- a/src/sentry/src/Tracing/Aspect/FilesystemAspect.php
+++ b/src/sentry/src/Tracing/Aspect/FilesystemAspect.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
 use FriendsOfHyperf\Sentry\Aspect\FilesystemAspect as BaseFilesystemAspect;
-use Hyperf\Coroutine\Coroutine;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Override;
 use Sentry\State\Scope;
@@ -37,7 +36,7 @@ class FilesystemAspect extends BaseFilesystemAspect
                 ->setOp($op)
                 ->setDescription($description)
                 ->setOrigin('auto.filesystem')
-                ->setData(['coroutine.id' => Coroutine::id()] + $data)
+                ->setData($data)
         );
     }
 }

--- a/src/sentry/src/Tracing/Aspect/GrpcAspect.php
+++ b/src/sentry/src/Tracing/Aspect/GrpcAspect.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
 use FriendsOfHyperf\Sentry\Switcher;
-use Hyperf\Coroutine\Coroutine;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Sentry\SentrySdk;
@@ -41,7 +40,6 @@ class GrpcAspect extends AbstractAspect
         $method = $proceedingJoinPoint->arguments['keys']['method'];
         $options = $proceedingJoinPoint->arguments['keys']['options'];
         $data = [
-            'coroutine.id' => Coroutine::id(),
             'grpc.method' => $method,
             'grpc.options' => $options,
         ];

--- a/src/sentry/src/Tracing/Aspect/GuzzleHttpClientAspect.php
+++ b/src/sentry/src/Tracing/Aspect/GuzzleHttpClientAspect.php
@@ -105,7 +105,6 @@ class GuzzleHttpClientAspect extends AbstractAspect
                         'http.request.user_agent' => $request->getHeaderLine('User-Agent'), // updated key for consistency
                         'http.request.headers' => $request->getHeaders(),
                         // Other
-                        'coroutine.id' => Coroutine::id(),
                         'http.system' => 'guzzle',
                         'http.guzzle.config' => $guzzleConfig,
                         'http.guzzle.options' => $options ?? [],

--- a/src/sentry/src/Tracing/Aspect/KafkaProducerAspect.php
+++ b/src/sentry/src/Tracing/Aspect/KafkaProducerAspect.php
@@ -14,7 +14,6 @@ namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 use FriendsOfHyperf\Sentry\Constants;
 use FriendsOfHyperf\Sentry\Switcher;
 use FriendsOfHyperf\Sentry\Util\Carrier;
-use Hyperf\Coroutine\Coroutine;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use longlang\phpkafka\Producer\ProduceMessage;
@@ -84,7 +83,6 @@ class KafkaProducerAspect extends AbstractAspect
                 ->setDescription(sprintf('%s::%s()', $proceedingJoinPoint->className, $proceedingJoinPoint->methodName))
                 ->setOrigin('auto.kafka')
                 ->setData([
-                    'coroutine.id' => Coroutine::id(),
                     'messaging.system' => 'kafka',
                     'messaging.operation' => 'publish',
                     'messaging.message.id' => $messageId,
@@ -124,7 +122,7 @@ class KafkaProducerAspect extends AbstractAspect
                 ->setOp('queue.publish')
                 ->setDescription(sprintf('%s::%s()', $proceedingJoinPoint->className, $proceedingJoinPoint->methodName))
                 ->setOrigin('auto.kafka')
-                ->setData(['coroutine.id' => Coroutine::id()])
+                ->setData(['message.count' => count($messages)])
         );
     }
 }

--- a/src/sentry/src/Tracing/Aspect/RedisAspect.php
+++ b/src/sentry/src/Tracing/Aspect/RedisAspect.php
@@ -13,7 +13,6 @@ namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
 use FriendsOfHyperf\Sentry\Switcher;
 use FriendsOfHyperf\Support\RedisCommand;
-use Hyperf\Coroutine\Coroutine;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Hyperf\Redis\Event\CommandExecuted;
@@ -59,7 +58,6 @@ class RedisAspect extends AbstractAspect
         $pool = $this->container->get(PoolFactory::class)->getPool($poolName);
         $config = (fn () => $this->config ?? [])->call($pool);
         $data = [
-            'coroutine.id' => Coroutine::id(),
             'db.system' => 'redis',
             'db.statement' => (new RedisCommand($arguments['name'], $arguments['arguments']))->__toString(),
             'db.redis.connection' => $poolName,

--- a/src/sentry/src/Tracing/Aspect/RpcAspect.php
+++ b/src/sentry/src/Tracing/Aspect/RpcAspect.php
@@ -16,7 +16,6 @@ use FriendsOfHyperf\Sentry\Switcher;
 use FriendsOfHyperf\Sentry\Util\Carrier;
 use Hyperf\Context\Context;
 use Hyperf\Contract\ConfigInterface;
-use Hyperf\Coroutine\Coroutine;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Hyperf\Rpc;
@@ -81,7 +80,6 @@ class RpcAspect extends AbstractAspect
             ->setDescription($path)
             ->setOrigin('auto.rpc')
             ->setData([
-                'coroutine.id' => Coroutine::id(),
                 'rpc.system' => $system,
                 'rpc.service' => $service,
                 'rpc.method' => $proceedingJoinPoint->arguments['keys']['methodName'] ?? '',

--- a/src/sentry/src/Tracing/Aspect/TraceAnnotationAspect.php
+++ b/src/sentry/src/Tracing/Aspect/TraceAnnotationAspect.php
@@ -13,7 +13,6 @@ namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
 use FriendsOfHyperf\Sentry\Switcher;
 use FriendsOfHyperf\Sentry\Tracing\Annotation\Trace;
-use Hyperf\Coroutine\Coroutine;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Sentry\State\Scope;
@@ -42,7 +41,7 @@ class TraceAnnotationAspect extends AbstractAspect
             return $proceedingJoinPoint->process();
         }
 
-        $data = ['coroutine.id' => Coroutine::id()];
+        $data = [];
         $methodName = $proceedingJoinPoint->methodName;
 
         if (in_array($methodName, ['__call', '__callStatic'])) {

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -171,7 +171,6 @@ class EventHandleListener implements ListenerInterface
         }
 
         $data = [
-            'coroutine.id' => Coroutine::id(),
             'db.system' => $event->connection->getDriverName(),
             'db.name' => $event->connection->getDatabaseName(),
         ];
@@ -228,7 +227,6 @@ class EventHandleListener implements ListenerInterface
                 ->setOrigin('auto.db')
                 ->setStartTimestamp(microtime(true))
                 ->setData([
-                    'coroutine.id' => Coroutine::id(),
                     'db.system' => $event->connection->getDriverName(),
                     'db.name' => $event->connection->getDatabaseName(),
                     'db.pool.name' => $event->connectionName,
@@ -394,8 +392,6 @@ class EventHandleListener implements ListenerInterface
                 ->setOp('console.command')
                 ->setDescription($command->getDescription())
                 ->setOrigin('auto.command')
-                ->setSource(TransactionSource::custom())
-                ->setData(['coroutine.id' => Coroutine::id()])
         );
     }
 
@@ -484,7 +480,6 @@ class EventHandleListener implements ListenerInterface
                 ->setOp('db.redis')
                 ->setDescription($redisStatement)
                 ->setData([
-                    'coroutine.id' => Coroutine::id(),
                     'db.system' => 'redis',
                     'db.statement' => $redisStatement,
                     'db.redis.connection' => $event->connectionName,
@@ -516,7 +511,6 @@ class EventHandleListener implements ListenerInterface
                 ->setDescription($crontab->getMemo())
                 ->setOrigin('auto.crontab')
                 ->setSource(TransactionSource::task())
-                ->setData(['coroutine.id' => Coroutine::id()])
         );
     }
 
@@ -584,8 +578,6 @@ class EventHandleListener implements ListenerInterface
                 ->setOp('queue.process')
                 ->setDescription($message::class)
                 ->setOrigin('auto.amqp')
-                ->setSource(TransactionSource::custom())
-                ->setData(['coroutine.id' => Coroutine::id()])
         );
     }
 
@@ -666,8 +658,6 @@ class EventHandleListener implements ListenerInterface
                 ->setOp('queue.process')
                 ->setDescription($consumer::class)
                 ->setOrigin('auto.kafka')
-                ->setSource(TransactionSource::custom())
-                ->setData(['coroutine.id' => Coroutine::id()])
         );
     }
 
@@ -732,8 +722,6 @@ class EventHandleListener implements ListenerInterface
                 ->setOp('queue.process')
                 ->setDescription('async_queue: ' . $job::class)
                 ->setOrigin('auto.async_queue')
-                ->setSource(TransactionSource::custom())
-                ->setData(['coroutine.id' => Coroutine::id()])
         );
     }
 

--- a/src/sentry/src/Tracing/Tracer.php
+++ b/src/sentry/src/Tracing/Tracer.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace FriendsOfHyperf\Sentry\Tracing;
 
 use FriendsOfHyperf\Sentry\Switcher;
+use Hyperf\Engine\Coroutine;
 use Sentry\SentrySdk;
 use Sentry\State\HubInterface;
 use Sentry\State\Scope;
@@ -19,6 +20,7 @@ use Sentry\Tracing\SpanContext;
 use Sentry\Tracing\SpanStatus;
 use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionContext;
+use Sentry\Tracing\TransactionSource;
 use Throwable;
 
 use function Hyperf\Tappable\tap;
@@ -38,6 +40,20 @@ class Tracer
         $hub = SentrySdk::setCurrentHub(
             tap(clone SentrySdk::getCurrentHub(), fn (HubInterface $hub) => $hub->pushScope())
         );
+
+        $transactionContext->setData(['coroutine.id' => Coroutine::id()] + $transactionContext->getData());
+
+        if ($transactionContext->getStartTimestamp() === null) {
+            $transactionContext->setStartTimestamp(microtime(true));
+        }
+
+        if ($transactionContext->getStatus() === null) {
+            $transactionContext->setStatus(SpanStatus::ok());
+        }
+
+        if ($transactionContext->getMetadata()->getSource() === null) {
+            $transactionContext->setSource(TransactionSource::custom());
+        }
 
         $transaction = $hub->startTransaction($transactionContext, $customSamplingContext);
 
@@ -66,6 +82,8 @@ class Tracer
         if ($context->getStartTimestamp() === null) {
             $context->setStartTimestamp(microtime(true));
         }
+
+        $context->setData(['coroutine.id' => Coroutine::id()] + $context->getData());
 
         return trace(
             function (Scope $scope) use ($trace, $isTracingExtraTagEnabled) {


### PR DESCRIPTION
## Summary

- Centralized coroutine ID handling in the `Tracer` class to improve consistency and reduce code duplication
- Removed duplicate `coroutine.id` data setting from individual tracing aspects
- Added default transaction metadata (status, source, start timestamp) initialization in `Tracer`
- Cleaned up unused `Coroutine` imports from aspect files
- Improved overall maintainability by consolidating coroutine ID logic

## Changes

### Core Changes
- **Tracer.php**: Added centralized coroutine ID handling for both transactions and spans
- **Tracer.php**: Added default metadata initialization for transactions (status, source, start timestamp)

### Aspect Files Updated
- Removed `coroutine.id` data setting from all tracing aspects:
  - `AmqpProducerAspect.php`
  - `AsyncQueueJobMessageAspect.php` 
  - `CacheAspect.php`
  - `CoordinatorAspect.php`
  - `CoroutineAspect.php`
  - `DbAspect.php`
  - `ElasticsearchAspect.php`
  - `FilesystemAspect.php`
  - `GrpcAspect.php`
  - `GuzzleHttpClientAspect.php`
  - `KafkaProducerAspect.php`
  - `RedisAspect.php`
  - `RpcAspect.php`
  - `TraceAnnotationAspect.php`

### Event Listener Updates
- **EventHandleListener.php**: Removed duplicate coroutine ID data and unused source/data settings

## Benefits

1. **Consistency**: All transactions and spans now consistently include coroutine IDs
2. **DRY Principle**: Eliminates code duplication across multiple aspect files
3. **Maintainability**: Single point of control for coroutine ID handling
4. **Future-proof**: Makes it easier to modify coroutine handling logic in the future

## Test Plan

- [ ] Verify all existing tracing functionality continues to work
- [ ] Confirm coroutine IDs are still present in trace data
- [ ] Test various traced operations (DB, Redis, HTTP, etc.)
- [ ] Validate transaction metadata is properly set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 事务与跟踪自动填充默认值（开始时间、状态、来源），统一在事务/跟踪层记录协程上下文。
  - Kafka 批量发布新增 message.count 指标，便于统计批量大小。
- 重构
  - 移除多处集成中的协程 ID 元数据（数据库、缓存、RPC、HTTP、消息队列、文件系统等），减少噪声并提升数据一致性。
  - 精简事件监听中的来源设置与逐 Span 协程标记，降低冗余。
- 其他
  - 无破坏性变更；对外接口保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->