### PR TITLE
refactor(sentry): replace Switcher class with Feature class

### DIFF
--- a/src/sentry/src/Aspect/CacheAspect.php
+++ b/src/sentry/src/Aspect/CacheAspect.php
@@ -32,7 +32,7 @@ class CacheAspect extends AbstractAspect
         'Hyperf\Cache\Driver\*Driver::deleteMultiple',
     ];
 
-    public function __construct(protected Feature $switcher)
+    public function __construct(protected Feature $feature)
     {
     }
 
@@ -41,7 +41,7 @@ class CacheAspect extends AbstractAspect
         $startTime = microtime(true);
 
         return tap($proceedingJoinPoint->process(), function ($result) use ($proceedingJoinPoint, $startTime) {
-            if (! $this->switcher->isBreadcrumbEnabled('cache')) {
+            if (! $this->feature->isBreadcrumbEnabled('cache')) {
                 return;
             }
 

--- a/src/sentry/src/Aspect/CacheAspect.php
+++ b/src/sentry/src/Aspect/CacheAspect.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 namespace FriendsOfHyperf\Sentry\Aspect;
 
 use Closure;
+use FriendsOfHyperf\Sentry\Feature;
 use FriendsOfHyperf\Sentry\Integration;
-use FriendsOfHyperf\Sentry\Switcher;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Sentry\Breadcrumb;
@@ -32,7 +32,7 @@ class CacheAspect extends AbstractAspect
         'Hyperf\Cache\Driver\*Driver::deleteMultiple',
     ];
 
-    public function __construct(protected Switcher $switcher)
+    public function __construct(protected Feature $switcher)
     {
     }
 

--- a/src/sentry/src/Aspect/FilesystemAspect.php
+++ b/src/sentry/src/Aspect/FilesystemAspect.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Sentry\Aspect;
 
+use FriendsOfHyperf\Sentry\Feature;
 use FriendsOfHyperf\Sentry\Integration;
-use FriendsOfHyperf\Sentry\Switcher;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Sentry\Breadcrumb;
@@ -41,7 +41,7 @@ class FilesystemAspect extends AbstractAspect
         // More adapter methods can be added here
     ];
 
-    public function __construct(protected Switcher $switcher)
+    public function __construct(protected Feature $switcher)
     {
     }
 

--- a/src/sentry/src/Aspect/FilesystemAspect.php
+++ b/src/sentry/src/Aspect/FilesystemAspect.php
@@ -41,13 +41,13 @@ class FilesystemAspect extends AbstractAspect
         // More adapter methods can be added here
     ];
 
-    public function __construct(protected Feature $switcher)
+    public function __construct(protected Feature $feature)
     {
     }
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
-        if (! $this->switcher->isBreadcrumbEnabled('filesystem')) {
+        if (! $this->feature->isBreadcrumbEnabled('filesystem')) {
             return $proceedingJoinPoint->process();
         }
 

--- a/src/sentry/src/Aspect/GuzzleHttpClientAspect.php
+++ b/src/sentry/src/Aspect/GuzzleHttpClientAspect.php
@@ -29,14 +29,14 @@ class GuzzleHttpClientAspect extends AbstractAspect
         Client::class . '::transfer',
     ];
 
-    public function __construct(protected Feature $switcher)
+    public function __construct(protected Feature $feature)
     {
     }
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
         // If the guzzle aspect is disabled, we will not record the request.
-        if (! $this->switcher->isBreadcrumbEnabled('guzzle')) {
+        if (! $this->feature->isBreadcrumbEnabled('guzzle')) {
             return $proceedingJoinPoint->process();
         }
 

--- a/src/sentry/src/Aspect/GuzzleHttpClientAspect.php
+++ b/src/sentry/src/Aspect/GuzzleHttpClientAspect.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Sentry\Aspect;
 
+use FriendsOfHyperf\Sentry\Feature;
 use FriendsOfHyperf\Sentry\Integration;
-use FriendsOfHyperf\Sentry\Switcher;
 use GuzzleHttp\Client;
 use GuzzleHttp\TransferStats;
 use Hyperf\Di\Aop\AbstractAspect;
@@ -29,7 +29,7 @@ class GuzzleHttpClientAspect extends AbstractAspect
         Client::class . '::transfer',
     ];
 
-    public function __construct(protected Switcher $switcher)
+    public function __construct(protected Feature $switcher)
     {
     }
 

--- a/src/sentry/src/Aspect/LoggerAspect.php
+++ b/src/sentry/src/Aspect/LoggerAspect.php
@@ -32,14 +32,14 @@ class LoggerAspect extends AbstractAspect
         Logger::class . '::addRecord',
     ];
 
-    public function __construct(protected Feature $switcher)
+    public function __construct(protected Feature $feature)
     {
     }
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
         return tap($proceedingJoinPoint->process(), function ($result) use ($proceedingJoinPoint) {
-            if (! $this->switcher->isBreadcrumbEnabled('logs')) {
+            if (! $this->feature->isBreadcrumbEnabled('logs')) {
                 return;
             }
 

--- a/src/sentry/src/Aspect/LoggerAspect.php
+++ b/src/sentry/src/Aspect/LoggerAspect.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 namespace FriendsOfHyperf\Sentry\Aspect;
 
 use BackedEnum;
+use FriendsOfHyperf\Sentry\Feature;
 use FriendsOfHyperf\Sentry\Integration;
-use FriendsOfHyperf\Sentry\Switcher;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Monolog\DateTimeImmutable;
@@ -32,7 +32,7 @@ class LoggerAspect extends AbstractAspect
         Logger::class . '::addRecord',
     ];
 
-    public function __construct(protected Switcher $switcher)
+    public function __construct(protected Feature $switcher)
     {
     }
 

--- a/src/sentry/src/Aspect/RedisAspect.php
+++ b/src/sentry/src/Aspect/RedisAspect.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Sentry\Aspect;
 
+use FriendsOfHyperf\Sentry\Feature;
 use FriendsOfHyperf\Sentry\Integration;
-use FriendsOfHyperf\Sentry\Switcher;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Hyperf\Redis\Event\CommandExecuted;
@@ -30,7 +30,7 @@ class RedisAspect extends AbstractAspect
         RedisConnection::class . '::__call',
     ];
 
-    public function __construct(protected Switcher $switcher)
+    public function __construct(protected Feature $switcher)
     {
     }
 

--- a/src/sentry/src/Aspect/RedisAspect.php
+++ b/src/sentry/src/Aspect/RedisAspect.php
@@ -30,7 +30,7 @@ class RedisAspect extends AbstractAspect
         RedisConnection::class . '::__call',
     ];
 
-    public function __construct(protected Feature $switcher)
+    public function __construct(protected Feature $feature)
     {
     }
 
@@ -42,7 +42,7 @@ class RedisAspect extends AbstractAspect
         return tap($proceedingJoinPoint->process(), function ($result) use ($arguments, $startTime) {
             if (
                 class_exists(CommandExecuted::class)
-                || ! $this->switcher->isBreadcrumbEnabled('redis')
+                || ! $this->feature->isBreadcrumbEnabled('redis')
             ) {
                 return;
             }

--- a/src/sentry/src/Crons/Listener/EventHandleListener.php
+++ b/src/sentry/src/Crons/Listener/EventHandleListener.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace FriendsOfHyperf\Sentry\Crons\Listener;
 
 use FriendsOfHyperf\Sentry\Constants;
-use FriendsOfHyperf\Sentry\Switcher;
+use FriendsOfHyperf\Sentry\Feature;
 use Hyperf\Context\Context;
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Contract\StdoutLoggerInterface;
@@ -25,7 +25,7 @@ class EventHandleListener implements ListenerInterface
 {
     public function __construct(
         protected ConfigInterface $config,
-        protected Switcher $switcher,
+        protected Feature $switcher,
         protected StdoutLoggerInterface $logger
     ) {
     }

--- a/src/sentry/src/Crons/Listener/EventHandleListener.php
+++ b/src/sentry/src/Crons/Listener/EventHandleListener.php
@@ -25,7 +25,7 @@ class EventHandleListener implements ListenerInterface
 {
     public function __construct(
         protected ConfigInterface $config,
-        protected Feature $switcher,
+        protected Feature $feature,
         protected StdoutLoggerInterface $logger
     ) {
     }
@@ -44,7 +44,7 @@ class EventHandleListener implements ListenerInterface
      */
     public function process(object $event): void
     {
-        if (! $this->switcher->isCronsEnabled()) {
+        if (! $this->feature->isCronsEnabled()) {
             return;
         }
 

--- a/src/sentry/src/Feature.php
+++ b/src/sentry/src/Feature.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of friendsofhyperf/components.
+ *
+ * @link     https://github.com/friendsofhyperf/components
+ * @document https://github.com/friendsofhyperf/components/blob/main/README.md
+ * @contact  huangdijia@gmail.com
+ */
+
+namespace FriendsOfHyperf\Sentry;
+
+use Hyperf\Context\Context;
+use Hyperf\Contract\ConfigInterface;
+use Sentry\SentrySdk;
+
+class Feature
+{
+    public function __construct(protected ConfigInterface $config)
+    {
+    }
+
+    public function isEnabled(string $key, bool $default = true): bool
+    {
+        return (bool) $this->config->get('sentry.enable.' . $key, $default);
+    }
+
+    public function isBreadcrumbEnabled(string $key, bool $default = true): bool
+    {
+        return (bool) $this->config->get('sentry.breadcrumbs.' . $key, $default);
+    }
+
+    public function isTracingEnabled(string $key, bool $default = true): bool
+    {
+        if (! $this->config->get('sentry.enable_tracing', true)) {
+            return false;
+        }
+
+        return (bool) $this->config->get('sentry.tracing.enable.' . $key, $default);
+    }
+
+    public function isTracingSpanEnabled(string $key, bool $default = true): bool
+    {
+        if (! SentrySdk::getCurrentHub()->getSpan()) {
+            return false;
+        }
+
+        return (bool) $this->config->get('sentry.tracing.spans.' . $key, $default);
+    }
+
+    public function isTracingExtraTagEnabled(string $key, bool $default = false): bool
+    {
+        return (bool) ($this->config->get('sentry.tracing.extra_tags', [])[$key] ?? $default);
+    }
+
+    public function isCronsEnabled(): bool
+    {
+        return (bool) $this->config->get('sentry.crons.enable', true);
+    }
+
+    public static function disableCoroutineTracing(): void
+    {
+        Context::set(Constants::DISABLE_COROUTINE_TRACING, true);
+    }
+
+    public static function isDisableCoroutineTracing(): bool
+    {
+        return (bool) Context::get(Constants::DISABLE_COROUTINE_TRACING);
+    }
+}

--- a/src/sentry/src/Listener/EventHandleListener.php
+++ b/src/sentry/src/Listener/EventHandleListener.php
@@ -85,7 +85,7 @@ class EventHandleListener implements ListenerInterface
 
     public function __construct(
         protected ContainerInterface $container,
-        protected Feature $switcher,
+        protected Feature $feature,
         protected ConfigInterface $config,
         protected StdoutLoggerInterface $logger
     ) {
@@ -239,8 +239,8 @@ class EventHandleListener implements ListenerInterface
         }
 
         if (
-            ! $this->switcher->isEnabled('request')
-            && ! $this->switcher->isTracingEnabled('request')
+            ! $this->feature->isEnabled('request')
+            && ! $this->feature->isTracingEnabled('request')
         ) {
             return;
         }
@@ -283,7 +283,7 @@ class EventHandleListener implements ListenerInterface
      */
     protected function handleDbQueryExecuted(object $event): void
     {
-        if (! $this->switcher->isBreadcrumbEnabled('sql_queries')) {
+        if (! $this->feature->isBreadcrumbEnabled('sql_queries')) {
             return;
         }
 
@@ -293,7 +293,7 @@ class EventHandleListener implements ListenerInterface
             $data['executionTimeMs'] = $event->time;
         }
 
-        if ($this->switcher->isBreadcrumbEnabled('sql_bindings')) {
+        if ($this->feature->isBreadcrumbEnabled('sql_bindings')) {
             $data['bindings'] = $event->bindings;
         }
 
@@ -311,7 +311,7 @@ class EventHandleListener implements ListenerInterface
      */
     protected function handleDbTransaction(object $event): void
     {
-        if (! $this->switcher->isBreadcrumbEnabled('sql_transaction')) {
+        if (! $this->feature->isBreadcrumbEnabled('sql_transaction')) {
             return;
         }
 
@@ -331,7 +331,7 @@ class EventHandleListener implements ListenerInterface
      */
     protected function handleRedisCommandExecuted(object $event): void
     {
-        if (! $this->switcher->isBreadcrumbEnabled('redis')) {
+        if (! $this->feature->isBreadcrumbEnabled('redis')) {
             return;
         }
 
@@ -353,7 +353,7 @@ class EventHandleListener implements ListenerInterface
      */
     protected function handleRequestReceived(object $event): void
     {
-        if (! $this->switcher->isEnabled('request')) {
+        if (! $this->feature->isEnabled('request')) {
             return;
         }
 
@@ -365,7 +365,7 @@ class EventHandleListener implements ListenerInterface
      */
     protected function handleRequestTerminated(object $event): void
     {
-        if (! $this->switcher->isEnabled('request')) {
+        if (! $this->feature->isEnabled('request')) {
             return;
         }
 
@@ -378,7 +378,7 @@ class EventHandleListener implements ListenerInterface
      */
     protected function handleCommandStarting(object $event): void
     {
-        if (! $this->switcher->isEnabled('command')) {
+        if (! $this->feature->isEnabled('command')) {
             return;
         }
 
@@ -388,9 +388,9 @@ class EventHandleListener implements ListenerInterface
             $scope->setTag('command', $event->getCommand()->getName());
         });
 
-        if ($this->switcher->isBreadcrumbEnabled('command')) {
+        if ($this->feature->isBreadcrumbEnabled('command')) {
             $data = [];
-            if ($this->switcher->isBreadcrumbEnabled('command_input')) {
+            if ($this->feature->isBreadcrumbEnabled('command_input')) {
                 /** @var InputInterface $input */
                 $input = (fn () => $this->input)->call($event->getCommand());
                 $data['input'] = $this->extractConsoleCommandInput($input);
@@ -411,11 +411,11 @@ class EventHandleListener implements ListenerInterface
      */
     protected function handleCommandFinished(object $event): void
     {
-        if (! $this->switcher->isEnabled('command')) {
+        if (! $this->feature->isEnabled('command')) {
             return;
         }
 
-        if ($this->switcher->isBreadcrumbEnabled('command')) {
+        if ($this->feature->isBreadcrumbEnabled('command')) {
             /** @var InputInterface $input */
             /** @var int $exitCode */
             [$input, $exitCode] = (function () {
@@ -426,7 +426,7 @@ class EventHandleListener implements ListenerInterface
             })->call($event->getCommand());
             $data = ['exit' => $exitCode];
 
-            if ($this->switcher->isBreadcrumbEnabled('command_input')) {
+            if ($this->feature->isBreadcrumbEnabled('command_input')) {
                 $data['input'] = $this->extractConsoleCommandInput($input);
             }
 
@@ -452,13 +452,13 @@ class EventHandleListener implements ListenerInterface
      */
     protected function handleAsyncQueueJobProcessing(object $event): void
     {
-        if (! $this->switcher->isEnabled('async_queue')) {
+        if (! $this->feature->isEnabled('async_queue')) {
             return;
         }
 
         $this->setupSentrySdk();
 
-        if ($this->switcher->isBreadcrumbEnabled('async_queue')) {
+        if ($this->feature->isBreadcrumbEnabled('async_queue')) {
             $job = [
                 'job' => $event->getMessage()->job()::class,
                 'attempts' => $event->getMessage()->getAttempts(),
@@ -479,7 +479,7 @@ class EventHandleListener implements ListenerInterface
      */
     protected function handleAsyncQueueJobProcessed(object $event): void
     {
-        if (! $this->switcher->isEnabled('async_queue')) {
+        if (! $this->feature->isEnabled('async_queue')) {
             return;
         }
 
@@ -491,7 +491,7 @@ class EventHandleListener implements ListenerInterface
      */
     protected function handleAsyncQueueJobRetryOrFailed(object $event): void
     {
-        if (! $this->switcher->isEnabled('async_queue')) {
+        if (! $this->feature->isEnabled('async_queue')) {
             return;
         }
 
@@ -504,7 +504,7 @@ class EventHandleListener implements ListenerInterface
      */
     protected function handleCrontabTaskStarting(object $event): void
     {
-        if (! $this->switcher->isEnabled('crontab')) {
+        if (! $this->feature->isEnabled('crontab')) {
             return;
         }
 
@@ -516,7 +516,7 @@ class EventHandleListener implements ListenerInterface
      */
     protected function handleCrontabTaskFinished(object $event): void
     {
-        if (! $this->switcher->isEnabled('crontab')) {
+        if (! $this->feature->isEnabled('crontab')) {
             return;
         }
 
@@ -528,7 +528,7 @@ class EventHandleListener implements ListenerInterface
      */
     protected function handleCrontabTaskFailed(object $event): void
     {
-        if (! $this->switcher->isEnabled('crontab')) {
+        if (! $this->feature->isEnabled('crontab')) {
             return;
         }
 
@@ -541,7 +541,7 @@ class EventHandleListener implements ListenerInterface
      */
     protected function handleAmqpMessageProcessing(object $event): void
     {
-        if (! $this->switcher->isEnabled('amqp')) {
+        if (! $this->feature->isEnabled('amqp')) {
             return;
         }
 
@@ -553,7 +553,7 @@ class EventHandleListener implements ListenerInterface
      */
     protected function handleAmqpMessageProcessed(object $event): void
     {
-        if (! $this->switcher->isEnabled('amqp')) {
+        if (! $this->feature->isEnabled('amqp')) {
             return;
         }
 
@@ -565,7 +565,7 @@ class EventHandleListener implements ListenerInterface
      */
     protected function handleAmqpMessageFailed(object $event): void
     {
-        if (! $this->switcher->isEnabled('amqp')) {
+        if (! $this->feature->isEnabled('amqp')) {
             return;
         }
 
@@ -578,7 +578,7 @@ class EventHandleListener implements ListenerInterface
      */
     protected function handleKafkaMessageProcessing(object $event): void
     {
-        if (! $this->switcher->isEnabled('kafka')) {
+        if (! $this->feature->isEnabled('kafka')) {
             return;
         }
 
@@ -590,7 +590,7 @@ class EventHandleListener implements ListenerInterface
      */
     protected function handleKafkaMessageProcessed(object $event): void
     {
-        if (! $this->switcher->isEnabled('kafka')) {
+        if (! $this->feature->isEnabled('kafka')) {
             return;
         }
 
@@ -602,7 +602,7 @@ class EventHandleListener implements ListenerInterface
      */
     protected function handleKafkaMessageFailed(object $event): void
     {
-        if (! $this->switcher->isEnabled('kafka')) {
+        if (! $this->feature->isEnabled('kafka')) {
             return;
         }
 

--- a/src/sentry/src/Listener/EventHandleListener.php
+++ b/src/sentry/src/Listener/EventHandleListener.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Sentry\Listener;
 
+use FriendsOfHyperf\Sentry\Feature;
 use FriendsOfHyperf\Sentry\Integration;
-use FriendsOfHyperf\Sentry\Switcher;
 use Hyperf\Amqp\Event as AmqpEvent;
 use Hyperf\AsyncQueue\Event as AsyncQueueEvent;
 use Hyperf\Command\Event as CommandEvent;
@@ -85,7 +85,7 @@ class EventHandleListener implements ListenerInterface
 
     public function __construct(
         protected ContainerInterface $container,
-        protected Switcher $switcher,
+        protected Feature $switcher,
         protected ConfigInterface $config,
         protected StdoutLoggerInterface $logger
     ) {

--- a/src/sentry/src/Switcher.php
+++ b/src/sentry/src/Switcher.php
@@ -11,84 +11,47 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Sentry;
 
-use Hyperf\Context\Context;
-use Hyperf\Contract\ConfigInterface;
-use Sentry\SentrySdk;
 use Throwable;
 
-class Switcher
+/**
+ * @deprecated since v3.1, use Feature instead, will be removed in v3.2
+ */
+class Switcher extends Feature
 {
-    public function __construct(protected ConfigInterface $config)
-    {
-    }
-
-    public function isEnabled(string $key, bool $default = true): bool
-    {
-        return (bool) $this->config->get('sentry.enable.' . $key, $default);
-    }
-
     /**
-     * @deprecated since v3.1, use isEnabled instead, will be removed in v3.2
+     * @deprecated since v3.1, use Feature::isEnabled() instead, will be removed in v3.2
      */
     public function isEnable(string $key, bool $default = true): bool
     {
         return $this->isEnabled($key, $default);
     }
 
-    public function isBreadcrumbEnabled(string $key, bool $default = true): bool
-    {
-        return (bool) $this->config->get('sentry.breadcrumbs.' . $key, $default);
-    }
-
     /**
-     * @deprecated since v3.1, use isBreadcrumbEnabled instead, will be removed in v3.2
+     * @deprecated since v3.1, use Feature::isBreadcrumbEnabled() instead, will be removed in v3.2
      */
     public function isBreadcrumbEnable(string $key, bool $default = true): bool
     {
         return $this->isBreadcrumbEnabled($key, $default);
     }
 
-    public function isTracingEnabled(string $key, bool $default = true): bool
-    {
-        if (! $this->config->get('sentry.enable_tracing', true)) {
-            return false;
-        }
-
-        return (bool) $this->config->get('sentry.tracing.enable.' . $key, $default);
-    }
-
     /**
-     * @deprecated since v3.1, use isTracingEnabled instead, will be removed in v3.2
+     * @deprecated since v3.1, use Feature::isTracingEnabled() instead, will be removed in v3.2
      */
     public function isTracingEnable(string $key, bool $default = true): bool
     {
         return $this->isTracingEnabled($key, $default);
     }
 
-    public function isTracingSpanEnabled(string $key, bool $default = true): bool
-    {
-        if (! SentrySdk::getCurrentHub()->getSpan()) {
-            return false;
-        }
-
-        return (bool) $this->config->get('sentry.tracing.spans.' . $key, $default);
-    }
-
     /**
-     * @deprecated since v3.1, use isTracingSpanEnabled instead, will be removed in v3.2
+     * @deprecated since v3.1, use Feature::isTracingSpanEnabled() instead, will be removed in v3.2
      */
     public function isTracingSpanEnable(string $key, bool $default = true): bool
     {
         return $this->isTracingSpanEnabled($key, $default);
     }
 
-    public function isTracingExtraTagEnabled(string $key, bool $default = false): bool
-    {
-        return (bool) ($this->config->get('sentry.tracing.extra_tags', [])[$key] ?? $default);
-    }
-
     /**
-     * @deprecated since v3.1, use isTracingExtraTagEnabled instead, will be removed in v3.2
+     * @deprecated since v3.1, use Feature::isTracingExtraTagEnabled() instead, will be removed in v3.2
      */
     public function isTracingExtraTagEnable(string $key, bool $default = false): bool
     {
@@ -112,26 +75,11 @@ class Switcher
         return false;
     }
 
-    public function isCronsEnabled(): bool
-    {
-        return (bool) $this->config->get('sentry.crons.enable', true);
-    }
-
     /**
-     * @deprecated since v3.1, use isCronsEnabled instead, will be removed in v3.2
+     * @deprecated since v3.1, use Feature::isCronsEnabled() instead, will be removed in v3.2
      */
     public function isCronsEnable(): bool
     {
         return $this->isCronsEnabled();
-    }
-
-    public static function disableCoroutineTracing(): void
-    {
-        Context::set(Constants::DISABLE_COROUTINE_TRACING, true);
-    }
-
-    public static function isDisableCoroutineTracing(): bool
-    {
-        return (bool) Context::get(Constants::DISABLE_COROUTINE_TRACING);
     }
 }

--- a/src/sentry/src/Tracing/Aspect/AmqpProducerAspect.php
+++ b/src/sentry/src/Tracing/Aspect/AmqpProducerAspect.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
 use FriendsOfHyperf\Sentry\Constants;
-use FriendsOfHyperf\Sentry\Switcher;
+use FriendsOfHyperf\Sentry\Feature;
 use FriendsOfHyperf\Sentry\Util\Carrier;
 use Hyperf\Amqp\Annotation\Producer;
 use Hyperf\Amqp\Message\ProducerMessage;
@@ -34,7 +34,7 @@ class AmqpProducerAspect extends AbstractAspect
         'Hyperf\Amqp\Producer::produceMessage',
     ];
 
-    public function __construct(protected Switcher $switcher)
+    public function __construct(protected Feature $switcher)
     {
     }
 

--- a/src/sentry/src/Tracing/Aspect/AmqpProducerAspect.php
+++ b/src/sentry/src/Tracing/Aspect/AmqpProducerAspect.php
@@ -34,13 +34,13 @@ class AmqpProducerAspect extends AbstractAspect
         'Hyperf\Amqp\Producer::produceMessage',
     ];
 
-    public function __construct(protected Feature $switcher)
+    public function __construct(protected Feature $feature)
     {
     }
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
-        if (! $this->switcher->isTracingEnabled('amqp')) {
+        if (! $this->feature->isTracingEnabled('amqp')) {
             return $proceedingJoinPoint->process();
         }
 

--- a/src/sentry/src/Tracing/Aspect/AsyncQueueJobMessageAspect.php
+++ b/src/sentry/src/Tracing/Aspect/AsyncQueueJobMessageAspect.php
@@ -40,13 +40,13 @@ class AsyncQueueJobMessageAspect extends AbstractAspect
     ];
 
     public function __construct(
-        protected Feature $switcher
+        protected Feature $feature
     ) {
     }
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
-        if (! $this->switcher->isTracingEnabled('async_queue')) {
+        if (! $this->feature->isTracingEnabled('async_queue')) {
             return $proceedingJoinPoint->process();
         }
 

--- a/src/sentry/src/Tracing/Aspect/AsyncQueueJobMessageAspect.php
+++ b/src/sentry/src/Tracing/Aspect/AsyncQueueJobMessageAspect.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
 use FriendsOfHyperf\Sentry\Constants;
-use FriendsOfHyperf\Sentry\Switcher;
+use FriendsOfHyperf\Sentry\Feature;
 use FriendsOfHyperf\Sentry\Util\Carrier;
 use Hyperf\AsyncQueue\Driver\RedisDriver;
 use Hyperf\Context\Context;
@@ -40,7 +40,7 @@ class AsyncQueueJobMessageAspect extends AbstractAspect
     ];
 
     public function __construct(
-        protected Switcher $switcher
+        protected Feature $switcher
     ) {
     }
 

--- a/src/sentry/src/Tracing/Aspect/CacheAspect.php
+++ b/src/sentry/src/Tracing/Aspect/CacheAspect.php
@@ -36,13 +36,13 @@ class CacheAspect extends AbstractAspect
         'Hyperf\Cache\Driver\*Driver::clear',
     ];
 
-    public function __construct(protected Feature $switcher)
+    public function __construct(protected Feature $feature)
     {
     }
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
-        if (! $this->switcher->isTracingSpanEnabled('cache')) {
+        if (! $this->feature->isTracingSpanEnabled('cache')) {
             return $proceedingJoinPoint->process();
         }
 

--- a/src/sentry/src/Tracing/Aspect/CacheAspect.php
+++ b/src/sentry/src/Tracing/Aspect/CacheAspect.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
-use FriendsOfHyperf\Sentry\Switcher;
+use FriendsOfHyperf\Sentry\Feature;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Sentry\State\Scope;
@@ -36,7 +36,7 @@ class CacheAspect extends AbstractAspect
         'Hyperf\Cache\Driver\*Driver::clear',
     ];
 
-    public function __construct(protected Switcher $switcher)
+    public function __construct(protected Feature $switcher)
     {
     }
 

--- a/src/sentry/src/Tracing/Aspect/CoordinatorAspect.php
+++ b/src/sentry/src/Tracing/Aspect/CoordinatorAspect.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
-use FriendsOfHyperf\Sentry\Switcher;
+use FriendsOfHyperf\Sentry\Feature;
 use Hyperf\Coordinator\Coordinator;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
@@ -26,7 +26,7 @@ class CoordinatorAspect extends AbstractAspect
         Coordinator::class . '::yield',
     ];
 
-    public function __construct(protected Switcher $switcher)
+    public function __construct(protected Feature $switcher)
     {
     }
 

--- a/src/sentry/src/Tracing/Aspect/CoordinatorAspect.php
+++ b/src/sentry/src/Tracing/Aspect/CoordinatorAspect.php
@@ -26,13 +26,13 @@ class CoordinatorAspect extends AbstractAspect
         Coordinator::class . '::yield',
     ];
 
-    public function __construct(protected Feature $switcher)
+    public function __construct(protected Feature $feature)
     {
     }
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
-        if (! $this->switcher->isTracingSpanEnabled('coordinator')) {
+        if (! $this->feature->isTracingSpanEnabled('coordinator')) {
             return $proceedingJoinPoint->process();
         }
 

--- a/src/sentry/src/Tracing/Aspect/CoroutineAspect.php
+++ b/src/sentry/src/Tracing/Aspect/CoroutineAspect.php
@@ -36,7 +36,7 @@ class CoroutineAspect extends AbstractAspect
         \Psr\Http\Message\ServerRequestInterface::class,
     ];
 
-    public function __construct(protected Feature $switcher)
+    public function __construct(protected Feature $feature)
     {
         $this->priority = PHP_INT_MAX;
     }
@@ -44,7 +44,7 @@ class CoroutineAspect extends AbstractAspect
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
         if (
-            ! $this->switcher->isTracingSpanEnabled('coroutine')
+            ! $this->feature->isTracingSpanEnabled('coroutine')
             || Feature::isDisableCoroutineTracing()
         ) {
             return $proceedingJoinPoint->process();
@@ -115,7 +115,7 @@ class CoroutineAspect extends AbstractAspect
                     ->setData([
                         'exception.message' => $exception->getMessage(),
                     ]);
-                if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
+                if ($this->feature->isTracingExtraTagEnabled('exception.stack_trace')) {
                     $coTransaction->setData([
                         'exception.stack_trace' => (string) $exception,
                     ]);

--- a/src/sentry/src/Tracing/Aspect/CoroutineAspect.php
+++ b/src/sentry/src/Tracing/Aspect/CoroutineAspect.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
-use FriendsOfHyperf\Sentry\Switcher;
+use FriendsOfHyperf\Sentry\Feature;
 use FriendsOfHyperf\Sentry\Util\CoroutineBacktraceHelper;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
@@ -36,7 +36,7 @@ class CoroutineAspect extends AbstractAspect
         \Psr\Http\Message\ServerRequestInterface::class,
     ];
 
-    public function __construct(protected Switcher $switcher)
+    public function __construct(protected Feature $switcher)
     {
         $this->priority = PHP_INT_MAX;
     }
@@ -45,7 +45,7 @@ class CoroutineAspect extends AbstractAspect
     {
         if (
             ! $this->switcher->isTracingSpanEnabled('coroutine')
-            || Switcher::isDisableCoroutineTracing()
+            || Feature::isDisableCoroutineTracing()
         ) {
             return $proceedingJoinPoint->process();
         }

--- a/src/sentry/src/Tracing/Aspect/DbAspect.php
+++ b/src/sentry/src/Tracing/Aspect/DbAspect.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
-use FriendsOfHyperf\Sentry\Switcher;
+use FriendsOfHyperf\Sentry\Feature;
 use FriendsOfHyperf\Sentry\Util\SqlParser;
 use Hyperf\DB\DB;
 use Hyperf\DB\Pool\PoolFactory;
@@ -34,7 +34,7 @@ class DbAspect extends AbstractAspect
 
     public function __construct(
         protected ContainerInterface $container,
-        protected Switcher $switcher
+        protected Feature $switcher
     ) {
     }
 

--- a/src/sentry/src/Tracing/Aspect/DbAspect.php
+++ b/src/sentry/src/Tracing/Aspect/DbAspect.php
@@ -34,13 +34,13 @@ class DbAspect extends AbstractAspect
 
     public function __construct(
         protected ContainerInterface $container,
-        protected Feature $switcher
+        protected Feature $feature
     ) {
     }
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
-        if (! $this->switcher->isTracingSpanEnabled('db')) {
+        if (! $this->feature->isTracingSpanEnabled('db')) {
             return $proceedingJoinPoint->process();
         }
 
@@ -76,7 +76,7 @@ class DbAspect extends AbstractAspect
             // 'server.port' => '',
         ];
 
-        if ($this->switcher->isTracingExtraTagEnabled('db.sql.bindings', true)) {
+        if ($this->feature->isTracingExtraTagEnabled('db.sql.bindings', true)) {
             $data['db.sql.bindings'] = $arguments['arguments']['bindings'] ?? [];
             foreach ($arguments['arguments']['bindings'] as $key => $value) {
                 $data['db.parameter.' . $key] = $value;
@@ -86,7 +86,7 @@ class DbAspect extends AbstractAspect
         return trace(
             function (Scope $scope) use ($proceedingJoinPoint) {
                 $result = $proceedingJoinPoint->process();
-                if ($this->switcher->isTracingExtraTagEnabled('db.result')) {
+                if ($this->feature->isTracingExtraTagEnabled('db.result')) {
                     $scope->getSpan()?->setData([
                         'db.result' => json_encode($result, JSON_UNESCAPED_UNICODE),
                     ]);

--- a/src/sentry/src/Tracing/Aspect/ElasticsearchAspect.php
+++ b/src/sentry/src/Tracing/Aspect/ElasticsearchAspect.php
@@ -50,20 +50,20 @@ class ElasticsearchAspect extends AbstractAspect
         'Elastic\Elasticsearch\Traits\ClientEndpointsTrait::updateByQuery',
     ];
 
-    public function __construct(protected Feature $switcher)
+    public function __construct(protected Feature $feature)
     {
     }
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
-        if (! $this->switcher->isTracingSpanEnabled('elasticsearch')) {
+        if (! $this->feature->isTracingSpanEnabled('elasticsearch')) {
             return $proceedingJoinPoint->process();
         }
 
         return trace(
             function (Scope $scope) use ($proceedingJoinPoint) {
                 $result = $proceedingJoinPoint->process();
-                if ($this->switcher->isTracingExtraTagEnabled('elasticsearch.result')) {
+                if ($this->feature->isTracingExtraTagEnabled('elasticsearch.result')) {
                     $scope->getSpan()?->setData([
                         'elasticsearch.result' => (string) json_encode($result, JSON_UNESCAPED_UNICODE),
                     ]);

--- a/src/sentry/src/Tracing/Aspect/ElasticsearchAspect.php
+++ b/src/sentry/src/Tracing/Aspect/ElasticsearchAspect.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
-use FriendsOfHyperf\Sentry\Switcher;
+use FriendsOfHyperf\Sentry\Feature;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Sentry\State\Scope;
@@ -50,7 +50,7 @@ class ElasticsearchAspect extends AbstractAspect
         'Elastic\Elasticsearch\Traits\ClientEndpointsTrait::updateByQuery',
     ];
 
-    public function __construct(protected Switcher $switcher)
+    public function __construct(protected Feature $switcher)
     {
     }
 

--- a/src/sentry/src/Tracing/Aspect/FilesystemAspect.php
+++ b/src/sentry/src/Tracing/Aspect/FilesystemAspect.php
@@ -24,7 +24,7 @@ class FilesystemAspect extends BaseFilesystemAspect
     #[Override]
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
-        if (! $this->switcher->isTracingEnabled('filesystem')) {
+        if (! $this->feature->isTracingEnabled('filesystem')) {
             return $proceedingJoinPoint->process();
         }
 

--- a/src/sentry/src/Tracing/Aspect/GrpcAspect.php
+++ b/src/sentry/src/Tracing/Aspect/GrpcAspect.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
-use FriendsOfHyperf\Sentry\Switcher;
+use FriendsOfHyperf\Sentry\Feature;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Sentry\SentrySdk;
@@ -27,7 +27,7 @@ class GrpcAspect extends AbstractAspect
         'Grpc\BaseStub::_simpleRequest',
     ];
 
-    public function __construct(protected Switcher $switcher)
+    public function __construct(protected Feature $switcher)
     {
     }
 

--- a/src/sentry/src/Tracing/Aspect/GrpcAspect.php
+++ b/src/sentry/src/Tracing/Aspect/GrpcAspect.php
@@ -27,13 +27,13 @@ class GrpcAspect extends AbstractAspect
         'Grpc\BaseStub::_simpleRequest',
     ];
 
-    public function __construct(protected Feature $switcher)
+    public function __construct(protected Feature $feature)
     {
     }
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
-        if (! $this->switcher->isTracingSpanEnabled('grpc')) {
+        if (! $this->feature->isTracingSpanEnabled('grpc')) {
             return $proceedingJoinPoint->process();
         }
 

--- a/src/sentry/src/Tracing/Aspect/GuzzleHttpClientAspect.php
+++ b/src/sentry/src/Tracing/Aspect/GuzzleHttpClientAspect.php
@@ -40,13 +40,13 @@ class GuzzleHttpClientAspect extends AbstractAspect
 
     public function __construct(
         protected ContainerInterface $container,
-        protected Feature $switcher
+        protected Feature $feature
     ) {
     }
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
-        if (! $this->switcher->isTracingSpanEnabled('guzzle')) {
+        if (! $this->feature->isTracingSpanEnabled('guzzle')) {
             return $proceedingJoinPoint->process();
         }
 
@@ -122,7 +122,7 @@ class GuzzleHttpClientAspect extends AbstractAspect
                             'http.response_transfer_size' => $response->getHeaderLine('Content-Length'),
                         ]);
 
-                        if ($this->switcher->isTracingExtraTagEnabled('http.response.body.contents')) {
+                        if ($this->feature->isTracingExtraTagEnabled('http.response.body.contents')) {
                             $isTextual = \preg_match(
                                 '/^(text\/|application\/(json|xml|x-www-form-urlencoded))/i',
                                 $response->getHeaderLine('Content-Type')
@@ -165,7 +165,7 @@ class GuzzleHttpClientAspect extends AbstractAspect
                             ->setData([
                                 'exception.message' => $exception->getMessage(),
                             ]);
-                        if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
+                        if ($this->feature->isTracingExtraTagEnabled('exception.stack_trace')) {
                             $span->setData([
                                 'exception.stack_trace' => (string) $exception,
                             ]);

--- a/src/sentry/src/Tracing/Aspect/GuzzleHttpClientAspect.php
+++ b/src/sentry/src/Tracing/Aspect/GuzzleHttpClientAspect.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
 use Error;
-use FriendsOfHyperf\Sentry\Switcher;
+use FriendsOfHyperf\Sentry\Feature;
 use GuzzleHttp\Client;
 use GuzzleHttp\TransferStats;
 use Hyperf\Context\Context;
@@ -40,7 +40,7 @@ class GuzzleHttpClientAspect extends AbstractAspect
 
     public function __construct(
         protected ContainerInterface $container,
-        protected Switcher $switcher
+        protected Feature $switcher
     ) {
     }
 

--- a/src/sentry/src/Tracing/Aspect/KafkaProducerAspect.php
+++ b/src/sentry/src/Tracing/Aspect/KafkaProducerAspect.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
 use FriendsOfHyperf\Sentry\Constants;
-use FriendsOfHyperf\Sentry\Switcher;
+use FriendsOfHyperf\Sentry\Feature;
 use FriendsOfHyperf\Sentry\Util\Carrier;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
@@ -35,7 +35,7 @@ class KafkaProducerAspect extends AbstractAspect
         'Hyperf\Kafka\Producer::sendBatchAsync',
     ];
 
-    public function __construct(protected Switcher $switcher)
+    public function __construct(protected Feature $switcher)
     {
     }
 

--- a/src/sentry/src/Tracing/Aspect/KafkaProducerAspect.php
+++ b/src/sentry/src/Tracing/Aspect/KafkaProducerAspect.php
@@ -35,13 +35,13 @@ class KafkaProducerAspect extends AbstractAspect
         'Hyperf\Kafka\Producer::sendBatchAsync',
     ];
 
-    public function __construct(protected Feature $switcher)
+    public function __construct(protected Feature $feature)
     {
     }
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
-        if (! $this->switcher->isTracingEnabled('kafka')) {
+        if (! $this->feature->isTracingEnabled('kafka')) {
             return $proceedingJoinPoint->process();
         }
 

--- a/src/sentry/src/Tracing/Aspect/RedisAspect.php
+++ b/src/sentry/src/Tracing/Aspect/RedisAspect.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
-use FriendsOfHyperf\Sentry\Switcher;
+use FriendsOfHyperf\Sentry\Feature;
 use FriendsOfHyperf\Support\RedisCommand;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
@@ -40,7 +40,7 @@ class RedisAspect extends AbstractAspect
 
     public function __construct(
         protected ContainerInterface $container,
-        protected Switcher $switcher
+        protected Feature $switcher
     ) {
     }
 

--- a/src/sentry/src/Tracing/Aspect/RedisAspect.php
+++ b/src/sentry/src/Tracing/Aspect/RedisAspect.php
@@ -40,7 +40,7 @@ class RedisAspect extends AbstractAspect
 
     public function __construct(
         protected ContainerInterface $container,
-        protected Feature $switcher
+        protected Feature $feature
     ) {
     }
 
@@ -48,7 +48,7 @@ class RedisAspect extends AbstractAspect
     {
         if (
             class_exists(CommandExecuted::class)
-            || ! $this->switcher->isTracingSpanEnabled('redis')
+            || ! $this->feature->isTracingSpanEnabled('redis')
         ) {
             return $proceedingJoinPoint->process();
         }
@@ -80,7 +80,7 @@ class RedisAspect extends AbstractAspect
         return trace(
             function (Scope $scope) use ($proceedingJoinPoint) {
                 return tap($proceedingJoinPoint->process(), function ($result) use ($scope) {
-                    if ($this->switcher->isTracingExtraTagEnabled('redis.result')) {
+                    if ($this->feature->isTracingExtraTagEnabled('redis.result')) {
                         $scope->getSpan()?->setData(['redis.result' => $result]);
                     }
                 });

--- a/src/sentry/src/Tracing/Aspect/RpcAspect.php
+++ b/src/sentry/src/Tracing/Aspect/RpcAspect.php
@@ -42,13 +42,13 @@ class RpcAspect extends AbstractAspect
 
     public function __construct(
         protected ContainerInterface $container,
-        protected Feature $switcher
+        protected Feature $feature
     ) {
     }
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
-        if (! $this->switcher->isTracingSpanEnabled('rpc')) {
+        if (! $this->feature->isTracingSpanEnabled('rpc')) {
             return $proceedingJoinPoint->process();
         }
 
@@ -111,7 +111,7 @@ class RpcAspect extends AbstractAspect
                             ->set(Constants::TRACE_CARRIER, Carrier::fromSpan($span)->toJson());
                     }
                     return tap($proceedingJoinPoint->process(), function ($result) use ($span) {
-                        if ($span && $this->switcher->isTracingExtraTagEnabled('rpc.result')) {
+                        if ($span && $this->feature->isTracingExtraTagEnabled('rpc.result')) {
                             $span->setData(['rpc.result' => $result]);
                         }
                     });

--- a/src/sentry/src/Tracing/Aspect/RpcAspect.php
+++ b/src/sentry/src/Tracing/Aspect/RpcAspect.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
 use FriendsOfHyperf\Sentry\Constants;
-use FriendsOfHyperf\Sentry\Switcher;
+use FriendsOfHyperf\Sentry\Feature;
 use FriendsOfHyperf\Sentry\Util\Carrier;
 use Hyperf\Context\Context;
 use Hyperf\Contract\ConfigInterface;
@@ -42,7 +42,7 @@ class RpcAspect extends AbstractAspect
 
     public function __construct(
         protected ContainerInterface $container,
-        protected Switcher $switcher
+        protected Feature $switcher
     ) {
     }
 

--- a/src/sentry/src/Tracing/Aspect/TraceAnnotationAspect.php
+++ b/src/sentry/src/Tracing/Aspect/TraceAnnotationAspect.php
@@ -27,7 +27,7 @@ class TraceAnnotationAspect extends AbstractAspect
         Trace::class,
     ];
 
-    public function __construct(protected Feature $switcher)
+    public function __construct(protected Feature $feature)
     {
     }
 
@@ -54,7 +54,7 @@ class TraceAnnotationAspect extends AbstractAspect
         return trace(
             function (Scope $scope) use ($proceedingJoinPoint) {
                 return tap($proceedingJoinPoint->process(), function ($result) use ($scope) {
-                    if ($this->switcher->isTracingExtraTagEnabled('annotation.result')) {
+                    if ($this->feature->isTracingExtraTagEnabled('annotation.result')) {
                         $scope->getSpan()?->setData(['annotation.result' => $result]);
                     }
                 });

--- a/src/sentry/src/Tracing/Aspect/TraceAnnotationAspect.php
+++ b/src/sentry/src/Tracing/Aspect/TraceAnnotationAspect.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
-use FriendsOfHyperf\Sentry\Switcher;
+use FriendsOfHyperf\Sentry\Feature;
 use FriendsOfHyperf\Sentry\Tracing\Annotation\Trace;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
@@ -27,7 +27,7 @@ class TraceAnnotationAspect extends AbstractAspect
         Trace::class,
     ];
 
-    public function __construct(protected Switcher $switcher)
+    public function __construct(protected Feature $switcher)
     {
     }
 

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -13,7 +13,7 @@ namespace FriendsOfHyperf\Sentry\Tracing\Listener;
 
 use Closure;
 use FriendsOfHyperf\Sentry\Constants;
-use FriendsOfHyperf\Sentry\Switcher;
+use FriendsOfHyperf\Sentry\Feature;
 use FriendsOfHyperf\Sentry\Util\Carrier;
 use FriendsOfHyperf\Sentry\Util\SqlParser;
 use FriendsOfHyperf\Support\RedisCommand;
@@ -67,7 +67,7 @@ class EventHandleListener implements ListenerInterface
     public function __construct(
         protected ContainerInterface $container,
         protected ConfigInterface $config,
-        protected Switcher $switcher
+        protected Feature $switcher
     ) {
         $this->ignoreCommands = (array) $this->config->get('sentry.ignore_commands', []);
     }

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -67,7 +67,7 @@ class EventHandleListener implements ListenerInterface
     public function __construct(
         protected ContainerInterface $container,
         protected ConfigInterface $config,
-        protected Feature $switcher
+        protected Feature $feature
     ) {
         $this->ignoreCommands = (array) $this->config->get('sentry.ignore_commands', []);
     }
@@ -166,7 +166,7 @@ class EventHandleListener implements ListenerInterface
 
     protected function handleDbQueryExecuted(DbEvent\QueryExecuted $event): void
     {
-        if (! $this->switcher->isTracingSpanEnabled('sql_queries')) {
+        if (! $this->feature->isTracingSpanEnabled('sql_queries')) {
             return;
         }
 
@@ -192,7 +192,7 @@ class EventHandleListener implements ListenerInterface
             'db.pool.using' => $pool->getCurrentConnections(),
         ];
 
-        if ($this->switcher->isTracingExtraTagEnabled('db.sql.bindings', true)) {
+        if ($this->feature->isTracingExtraTagEnabled('db.sql.bindings', true)) {
             $data['db.sql.bindings'] = $event->bindings;
             foreach ($event->bindings as $key => $value) {
                 $data['db.parameter.' . $key] = $value;
@@ -215,7 +215,7 @@ class EventHandleListener implements ListenerInterface
 
     protected function handleDbTransactionBeginning(DbEvent\TransactionBeginning $event): void
     {
-        if (! $this->switcher->isTracingSpanEnabled('sql_transactions')) {
+        if (! $this->feature->isTracingSpanEnabled('sql_transactions')) {
             return;
         }
 
@@ -236,7 +236,7 @@ class EventHandleListener implements ListenerInterface
 
     protected function handleDbTransactionCommitted(DbEvent\TransactionCommitted $event): void
     {
-        if (! $this->switcher->isTracingSpanEnabled('sql_transactions')) {
+        if (! $this->feature->isTracingSpanEnabled('sql_transactions')) {
             return;
         }
         if (! $span = SentrySdk::getCurrentHub()->getSpan()) {
@@ -250,7 +250,7 @@ class EventHandleListener implements ListenerInterface
 
     protected function handleDbTransactionRolledBack(DbEvent\TransactionRolledBack $event): void
     {
-        if (! $this->switcher->isTracingSpanEnabled('sql_transactions')) {
+        if (! $this->feature->isTracingSpanEnabled('sql_transactions')) {
             return;
         }
         if (! $span = SentrySdk::getCurrentHub()->getSpan()) {
@@ -264,7 +264,7 @@ class EventHandleListener implements ListenerInterface
 
     protected function handleRequestReceived(HttpEvent\RequestReceived|RpcEvent\RequestReceived $event): void
     {
-        if (! $this->switcher->isTracingEnabled('request')) {
+        if (! $this->feature->isTracingEnabled('request')) {
             return;
         }
 
@@ -272,7 +272,7 @@ class EventHandleListener implements ListenerInterface
         /** @var Dispatched $dispatched */
         $dispatched = $request->getAttribute(Dispatched::class);
 
-        if (! $dispatched->isFound() && ! $this->switcher->isTracingEnabled('missing_routes')) {
+        if (! $dispatched->isFound() && ! $this->feature->isTracingEnabled('missing_routes')) {
             return;
         }
 
@@ -367,7 +367,7 @@ class EventHandleListener implements ListenerInterface
                 ->setData([
                     'exception.message' => $exception->getMessage(),
                 ]);
-            if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
+            if ($this->feature->isTracingExtraTagEnabled('exception.stack_trace')) {
                 $span->setData([
                     'exception.stack_trace' => (string) $exception,
                 ]);
@@ -378,7 +378,7 @@ class EventHandleListener implements ListenerInterface
     protected function handleCommandStarting(CommandEvent\BeforeHandle $event): void
     {
         if (
-            ! $this->switcher->isTracingEnabled('command')
+            ! $this->feature->isTracingEnabled('command')
             || Str::is($this->ignoreCommands, $event->getCommand()->getName())
         ) {
             return;
@@ -432,7 +432,7 @@ class EventHandleListener implements ListenerInterface
                     ->setData([
                         'exception.message' => $exception->getMessage(),
                     ]);
-                if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
+                if ($this->feature->isTracingExtraTagEnabled('exception.stack_trace')) {
                     $transaction->setData([
                         'exception.stack_trace' => (string) $exception,
                     ]);
@@ -453,7 +453,7 @@ class EventHandleListener implements ListenerInterface
 
     protected function handleRedisCommandExecuted(RedisEvent\CommandExecuted $event): void
     {
-        if (! $this->switcher->isTracingSpanEnabled('redis')) {
+        if (! $this->feature->isTracingSpanEnabled('redis')) {
             return;
         }
 
@@ -467,7 +467,7 @@ class EventHandleListener implements ListenerInterface
                     return;
                 }
 
-                if ($this->switcher->isTracingExtraTagEnabled('redis.result')) {
+                if ($this->feature->isTracingExtraTagEnabled('redis.result')) {
                     $span->setData(['db.redis.result' => $event->result]);
                 }
 
@@ -481,7 +481,7 @@ class EventHandleListener implements ListenerInterface
                         ->setData([
                             'exception.message' => $exception->getMessage(),
                         ]);
-                    if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
+                    if ($this->feature->isTracingExtraTagEnabled('exception.stack_trace')) {
                         $span->setData(['exception.stack_trace' => (string) $exception]);
                     }
                 }
@@ -508,7 +508,7 @@ class EventHandleListener implements ListenerInterface
 
     protected function handleCrontabTaskStarting(CrontabEvent\BeforeExecute $event): void
     {
-        if (! $this->switcher->isTracingEnabled('crontab')) {
+        if (! $this->feature->isTracingEnabled('crontab')) {
             return;
         }
 
@@ -558,7 +558,7 @@ class EventHandleListener implements ListenerInterface
                 ->setData([
                     'exception.message' => $exception->getMessage(),
                 ]);
-            if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
+            if ($this->feature->isTracingExtraTagEnabled('exception.stack_trace')) {
                 $transaction->setData(['exception.stack_trace' => (string) $exception]);
             }
         }
@@ -566,7 +566,7 @@ class EventHandleListener implements ListenerInterface
 
     protected function handleAmqpMessageProcessing(AmqpEvent\BeforeConsume $event): void
     {
-        if (! $this->switcher->isTracingEnabled('amqp')) {
+        if (! $this->feature->isTracingEnabled('amqp')) {
             return;
         }
 
@@ -640,7 +640,7 @@ class EventHandleListener implements ListenerInterface
                 ->setData([
                     'exception.message' => $exception->getMessage(),
                 ]);
-            if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
+            if ($this->feature->isTracingExtraTagEnabled('exception.stack_trace')) {
                 $transaction->setData(['exception.stack_trace' => (string) $exception]);
             }
         }
@@ -648,7 +648,7 @@ class EventHandleListener implements ListenerInterface
 
     protected function handleKafkaMessageProcessing(KafkaEvent\BeforeConsume $event): void
     {
-        if (! $this->switcher->isTracingEnabled('kafka')) {
+        if (! $this->feature->isTracingEnabled('kafka')) {
             return;
         }
 
@@ -716,7 +716,7 @@ class EventHandleListener implements ListenerInterface
                 ->setData([
                     'exception.message' => $exception->getMessage(),
                 ]);
-            if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
+            if ($this->feature->isTracingExtraTagEnabled('exception.stack_trace')) {
                 $transaction->setData(['exception.stack_trace' => (string) $exception]);
             }
         }
@@ -724,7 +724,7 @@ class EventHandleListener implements ListenerInterface
 
     protected function handleAsyncQueueJobProcessing(AsyncQueueEvent\BeforeHandle $event): void
     {
-        if (! $this->switcher->isTracingEnabled('async_queue')) {
+        if (! $this->feature->isTracingEnabled('async_queue')) {
             return;
         }
 
@@ -779,7 +779,7 @@ class EventHandleListener implements ListenerInterface
                 ->setData([
                     'exception.message' => $exception->getMessage(),
                 ]);
-            if ($this->switcher->isTracingExtraTagEnabled('exception.stack_trace')) {
+            if ($this->feature->isTracingExtraTagEnabled('exception.stack_trace')) {
                 $transaction->setData(['exception.stack_trace' => (string) $exception]);
             }
         }

--- a/src/sentry/src/Tracing/Tracer.php
+++ b/src/sentry/src/Tracing/Tracer.php
@@ -28,7 +28,7 @@ use function Sentry\trace;
 
 class Tracer
 {
-    public function __construct(protected Feature $switcher)
+    public function __construct(protected Feature $feature)
     {
     }
 
@@ -73,7 +73,7 @@ class Tracer
      */
     public function trace(callable $trace, SpanContext $context)
     {
-        $isTracingExtraTagEnabled = $this->switcher->isTracingExtraTagEnabled('exception.stack_trace');
+        $isTracingExtraTagEnabled = $this->feature->isTracingExtraTagEnabled('exception.stack_trace');
 
         if ($context->getStatus() === null) {
             $context->setStatus(SpanStatus::ok());

--- a/src/sentry/src/Tracing/Tracer.php
+++ b/src/sentry/src/Tracing/Tracer.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Sentry\Tracing;
 
-use FriendsOfHyperf\Sentry\Switcher;
+use FriendsOfHyperf\Sentry\Feature;
 use Hyperf\Engine\Coroutine;
 use Sentry\SentrySdk;
 use Sentry\State\HubInterface;
@@ -28,7 +28,7 @@ use function Sentry\trace;
 
 class Tracer
 {
-    public function __construct(protected Switcher $switcher)
+    public function __construct(protected Feature $switcher)
     {
     }
 

--- a/tests/Sentry/FeatureTest.php
+++ b/tests/Sentry/FeatureTest.php
@@ -26,11 +26,11 @@ beforeEach(function () {
             ],
         ],
     ]);
-    $this->switcher = new Feature($config);
+    $this->feature = new Feature($config);
 });
 
 test('test is tracing tag enable', function ($key, $expected) {
-    expect($this->switcher->isTracingExtraTagEnabled($key))->toBe($expected);
+    expect($this->feature->isTracingExtraTagEnabled($key))->toBe($expected);
 })->with([
     ['foo.bar', true],
     ['foo.baz', true],

--- a/tests/Sentry/SwitcherTest.php
+++ b/tests/Sentry/SwitcherTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Tests\Sentry;
 
-use FriendsOfHyperf\Sentry\Switcher;
+use FriendsOfHyperf\Sentry\Feature;
 use Hyperf\Config\Config;
 
 beforeEach(function () {
@@ -26,7 +26,7 @@ beforeEach(function () {
             ],
         ],
     ]);
-    $this->switcher = new Switcher($config);
+    $this->switcher = new Feature($config);
 });
 
 test('test is tracing tag enable', function ($key, $expected) {


### PR DESCRIPTION
## Summary

This PR refactors the Sentry integration by introducing a new `Feature` class to replace the existing `Switcher` class. The changes improve code clarity and naming conventions while maintaining full backward compatibility.

### Changes Made:

- **New `Feature` class**: Introduces a new class with the same functionality as `Switcher` but with a more descriptive name
- **Backward compatibility**: The `Switcher` class now extends `Feature` and maintains all existing methods with proper deprecation warnings
- **Updated dependencies**: All aspect classes, listeners, and tracers now use the `Feature` class instead of `Switcher`
- **Test updates**: Updated the test suite to use the new `Feature` class
- **Proper deprecation**: All methods in `Switcher` are marked as deprecated with clear migration paths

### Breaking Changes:

⚠️ **Deprecation Notice**: The `Switcher` class is deprecated as of v3.1 and will be removed in v3.2. Users should migrate to the `Feature` class.

### Migration Guide:

```php
// Old way (deprecated)
use FriendsOfHyperf\Sentry\Switcher;

public function __construct(protected Switcher $switcher) {}

// New way (recommended)  
use FriendsOfHyperf\Sentry\Feature;

public function __construct(protected Feature $switcher) {}
```

All method calls remain the same - only the class name changes.

## Test Plan

- [x] All existing tests pass with the new `Feature` class
- [x] Backward compatibility maintained - existing code using `Switcher` continues to work
- [x] Deprecation warnings are properly shown when using deprecated methods
- [x] All aspect classes and listeners successfully use the new `Feature` class
- [x] Static methods on `Switcher` continue to work through inheritance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 新增“Feature”用于统一控制 Sentry 功能开关：启用、面包屑、Tracing、Span、额外标签、Crons，并支持禁用协程追踪标记。
- 重构
  - 全面将各 Aspect/监听器/Tracer 依赖从 Switcher 切换为 Feature，保持现有行为与配置兼容。
- 维护
  - 标记 Switcher 为弃用，保留向后兼容包装，后续版本将移除。
- 测试
  - 更新测试用例以覆盖 Feature 的开关逻辑与配置读取。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->