### PR TITLE
refactor(sentry): simplify hub initialization in Tracer

### DIFF
--- a/src/sentry/src/Tracing/Tracer.php
+++ b/src/sentry/src/Tracing/Tracer.php
@@ -14,7 +14,6 @@ namespace FriendsOfHyperf\Sentry\Tracing;
 use FriendsOfHyperf\Sentry\Feature;
 use Hyperf\Engine\Coroutine;
 use Sentry\SentrySdk;
-use Sentry\State\HubInterface;
 use Sentry\State\Scope;
 use Sentry\Tracing\SpanContext;
 use Sentry\Tracing\SpanStatus;
@@ -23,7 +22,6 @@ use Sentry\Tracing\TransactionContext;
 use Sentry\Tracing\TransactionSource;
 use Throwable;
 
-use function Hyperf\Tappable\tap;
 use function Sentry\trace;
 
 class Tracer
@@ -37,9 +35,8 @@ class Tracer
      */
     public function startTransaction(TransactionContext $transactionContext, array $customSamplingContext = []): Transaction
     {
-        $hub = SentrySdk::setCurrentHub(
-            tap(clone SentrySdk::getCurrentHub(), fn (HubInterface $hub) => $hub->pushScope())
-        );
+        $hub = SentrySdk::init();
+        $hub->pushScope();
 
         $transactionContext->setData(['coroutine.id' => Coroutine::id()] + $transactionContext->getData());
 


### PR DESCRIPTION
## Summary
- Simplifies hub initialization in the Sentry Tracer class by replacing complex tap-based hub cloning with direct SentrySdk::init()
- Removes unused imports: HubInterface and tap function
- Maintains the same functionality while improving code readability

## Changes
- Replace `tap(clone SentrySdk::getCurrentHub(), fn (HubInterface $hub) => $hub->pushScope())` with simpler `SentrySdk::init()` and `$hub->pushScope()`
- Remove unused imports: `Sentry\State\HubInterface` and `function Hyperf\Tappable\tap`
- Clean up the startTransaction method implementation

## Test plan
- [ ] Verify existing Sentry tracing functionality still works
- [ ] Ensure no regression in transaction handling
- [ ] Confirm coroutine context isolation is maintained

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新特性
  - 无
- Bug 修复
  - 改善启动事务时的上下文管理，降低偶发性错误与追踪中断风险，提升稳定性。
- 重构
  - 精简追踪器初始化流程，减少不必要依赖，带来更可预测的行为与更轻量的开销。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->