### PR TITLE
feat(sentry): add view rendering tracing support

### DIFF
--- a/src/sentry/publish/sentry.php
+++ b/src/sentry/publish/sentry.php
@@ -113,6 +113,7 @@ return [
             'grpc' => env('SENTRY_TRACING_SPANS_GRPC', true),
             'redis' => env('SENTRY_TRACING_SPANS_REDIS', true),
             'sql_queries' => env('SENTRY_TRACING_SPANS_SQL_QUERIES', true),
+            'view' => env('SENTRY_TRACING_SPANS_VIEW', true),
         ],
         'extra_tags' => [
             'exception.stack_trace' => true,

--- a/src/sentry/src/ConfigProvider.php
+++ b/src/sentry/src/ConfigProvider.php
@@ -41,6 +41,7 @@ class ConfigProvider
                 Tracing\Aspect\RpcAspect::class,
                 Tracing\Aspect\RedisAspect::class,
                 Tracing\Aspect\TraceAnnotationAspect::class,
+                Tracing\Aspect\ViewRenderAspect::class,
             ],
             'commands' => [
                 Command\AboutCommand::class,

--- a/src/sentry/src/Function.php
+++ b/src/sentry/src/Function.php
@@ -19,6 +19,14 @@ use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionContext;
 
 /**
+ * Get the Feature instance from the container.
+ */
+function feature(): Feature
+{
+    return ApplicationContext::getContainer()->get(Feature::class);
+}
+
+/**
  * Starts a new Transaction and returns it. This is the entry point to manual tracing instrumentation.
  */
 function startTransaction(TransactionContext $transactionContext, array $customSamplingContext = []): Transaction

--- a/src/sentry/src/Tracing/Aspect/ViewRenderAspect.php
+++ b/src/sentry/src/Tracing/Aspect/ViewRenderAspect.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of friendsofhyperf/components.
+ *
+ * @link     https://github.com/friendsofhyperf/components
+ * @document https://github.com/friendsofhyperf/components/blob/main/README.md
+ * @contact  huangdijia@gmail.com
+ */
+
+namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
+
+use FriendsOfHyperf\Sentry\Feature;
+use Hyperf\Di\Aop\AbstractAspect;
+use Hyperf\Di\Aop\ProceedingJoinPoint;
+use Sentry\State\Scope;
+use Sentry\Tracing\SpanContext;
+
+use function FriendsOfHyperf\Sentry\trace;
+
+class ViewRenderAspect extends AbstractAspect
+{
+    public array $classes = [
+        'Hyperf\View\Render::render',
+    ];
+
+    public function __construct(protected Feature $feature)
+    {
+    }
+
+    public function process(ProceedingJoinPoint $proceedingJoinPoint)
+    {
+        if (! $this->feature->isTracingSpanEnabled('view')) {
+            return $proceedingJoinPoint->process();
+        }
+
+        $arguments = $proceedingJoinPoint->arguments['keys'] ?? [];
+        $template = $arguments['template'] ?? 'unknown';
+        $data = $arguments['data'] ?? [];
+
+        return trace(
+            fn (Scope $scope) => $proceedingJoinPoint->process(),
+            SpanContext::make()
+                ->setOp('view.render')
+                ->setDescription($template)
+                ->setOrigin('auto.view')
+                ->setData($data)
+        );
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds view rendering tracing support to the Sentry component, allowing developers to monitor and trace Hyperf view rendering operations.

### Changes Made
- **Added ViewRenderAspect**: New aspect class that intercepts `Hyperf\View\Render::render` calls to create tracing spans
- **Updated sentry.php config**: Added `view` option to the tracing spans configuration with environment variable `SENTRY_TRACING_SPANS_VIEW`
- **Added feature() helper function**: Convenience function in Function.php to get the Feature instance from the container

### Features
- ✅ Configurable view tracing via environment variable
- ✅ Automatic span creation with template name and data
- ✅ Integration with existing Feature-based span enablement system
- ✅ Proper span context with operation type `view.render` and origin `auto.view`

### Technical Details
- The aspect captures the template name and data passed to the view renderer
- Spans are only created when `SENTRY_TRACING_SPANS_VIEW=true` (default: true)
- Uses the existing `trace()` function for consistent span handling
- Follows the same pattern as other tracing aspects in the codebase

### Configuration
```php
// In .env
SENTRY_TRACING_SPANS_VIEW=true
```

### Test Plan
- [x] View rendering operations generate appropriate spans
- [x] Configuration option correctly enables/disables tracing
- [x] Template names and data are properly captured in span context
- [x] No performance impact when tracing is disabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“视图”追踪跨度（tracing.spans.view，默认开启），可通过配置控制。
  * 对视图渲染自动追踪，记录模板名、渲染模式、引擎与渲染数据，便于在 Sentry 中分析性能与错误上下文。
  * 新增全局辅助函数 feature()，用于从容器访问 Feature 服务以便扩展与集成。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->