### PR TITLE
refactor(sentry): remove exception message and stack trace data from tracing spans

### DIFF
--- a/src/sentry/publish/sentry.php
+++ b/src/sentry/publish/sentry.php
@@ -117,7 +117,6 @@ return [
             'view' => env('SENTRY_TRACING_SPANS_VIEW', true),
         ],
         'extra_tags' => [
-            'exception.stack_trace' => true,
             'amqp.result' => false,
             'annotation.result' => false,
             'db.sql.bindings' => true,

--- a/src/sentry/src/Tracing/Aspect/CoroutineAspect.php
+++ b/src/sentry/src/Tracing/Aspect/CoroutineAspect.php
@@ -111,15 +111,7 @@ class CoroutineAspect extends AbstractAspect
                         'error' => 'true',
                         'exception.class' => $exception::class,
                         'exception.code' => (string) $exception->getCode(),
-                    ])
-                    ->setData([
-                        'exception.message' => $exception->getMessage(),
                     ]);
-                if ($this->feature->isTracingExtraTagEnabled('exception.stack_trace')) {
-                    $coTransaction->setData([
-                        'exception.stack_trace' => (string) $exception,
-                    ]);
-                }
 
                 throw $exception;
             }

--- a/src/sentry/src/Tracing/Aspect/GuzzleHttpClientAspect.php
+++ b/src/sentry/src/Tracing/Aspect/GuzzleHttpClientAspect.php
@@ -161,15 +161,7 @@ class GuzzleHttpClientAspect extends AbstractAspect
                                 'error' => 'true',
                                 'exception.class' => $exception::class,
                                 'exception.code' => (string) $exception->getCode(),
-                            ])
-                            ->setData([
-                                'exception.message' => $exception->getMessage(),
                             ]);
-                        if ($this->feature->isTracingExtraTagEnabled('exception.stack_trace')) {
-                            $span->setData([
-                                'exception.stack_trace' => (string) $exception,
-                            ]);
-                        }
                     }
 
                     if (is_callable($onStats)) {

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -363,15 +363,7 @@ class EventHandleListener implements ListenerInterface
                     'error' => 'true',
                     'exception.class' => $exception::class,
                     'exception.code' => (string) $exception->getCode(),
-                ])
-                ->setData([
-                    'exception.message' => $exception->getMessage(),
                 ]);
-            if ($this->feature->isTracingExtraTagEnabled('exception.stack_trace')) {
-                $span->setData([
-                    'exception.stack_trace' => (string) $exception,
-                ]);
-            }
         }
     }
 
@@ -429,15 +421,7 @@ class EventHandleListener implements ListenerInterface
                         'error' => 'true',
                         'exception.class' => $exception::class,
                         'exception.code' => (string) $exception->getCode(),
-                    ])
-                    ->setData([
-                        'exception.message' => $exception->getMessage(),
                     ]);
-                if ($this->feature->isTracingExtraTagEnabled('exception.stack_trace')) {
-                    $transaction->setData([
-                        'exception.stack_trace' => (string) $exception,
-                    ]);
-                }
             }
 
             $transaction->setStatus(
@@ -478,13 +462,7 @@ class EventHandleListener implements ListenerInterface
                             'error' => 'true',
                             'exception.class' => $exception::class,
                             'exception.code' => (string) $exception->getCode(),
-                        ])
-                        ->setData([
-                            'exception.message' => $exception->getMessage(),
                         ]);
-                    if ($this->feature->isTracingExtraTagEnabled('exception.stack_trace')) {
-                        $span->setData(['exception.stack_trace' => (string) $exception]);
-                    }
                 }
             },
             SpanContext::make()
@@ -555,13 +533,7 @@ class EventHandleListener implements ListenerInterface
                     'error' => 'true',
                     'exception.class' => $exception::class,
                     'exception.code' => (string) $exception->getCode(),
-                ])
-                ->setData([
-                    'exception.message' => $exception->getMessage(),
                 ]);
-            if ($this->feature->isTracingExtraTagEnabled('exception.stack_trace')) {
-                $transaction->setData(['exception.stack_trace' => (string) $exception]);
-            }
         }
     }
 
@@ -635,13 +607,7 @@ class EventHandleListener implements ListenerInterface
                     'error' => 'true',
                     'exception.class' => $exception::class,
                     'exception.code' => (string) $exception->getCode(),
-                ])
-                ->setData([
-                    'exception.message' => $exception->getMessage(),
                 ]);
-            if ($this->feature->isTracingExtraTagEnabled('exception.stack_trace')) {
-                $transaction->setData(['exception.stack_trace' => (string) $exception]);
-            }
         }
     }
 
@@ -707,13 +673,7 @@ class EventHandleListener implements ListenerInterface
                     'error' => 'true',
                     'exception.class' => $exception::class,
                     'exception.code' => (string) $exception->getCode(),
-                ])
-                ->setData([
-                    'exception.message' => $exception->getMessage(),
                 ]);
-            if ($this->feature->isTracingExtraTagEnabled('exception.stack_trace')) {
-                $transaction->setData(['exception.stack_trace' => (string) $exception]);
-            }
         }
     }
 
@@ -766,13 +726,7 @@ class EventHandleListener implements ListenerInterface
                     'error' => 'true',
                     'exception.class' => $exception::class,
                     'exception.code' => (string) $exception->getCode(),
-                ])
-                ->setData([
-                    'exception.message' => $exception->getMessage(),
                 ]);
-            if ($this->feature->isTracingExtraTagEnabled('exception.stack_trace')) {
-                $transaction->setData(['exception.stack_trace' => (string) $exception]);
-            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Remove exception.message and exception.stack_trace data from all tracing spans
- Remove exception.stack_trace extra tag from default configuration  
- Simplify exception handling in tracing aspects and listeners
- Remove Feature dependency from Tracer class as it's no longer needed

## Background

This change reduces the amount of potentially sensitive data captured in tracing spans while maintaining the essential exception metadata (class and code) as tags. The exception message and stack trace can contain sensitive information that shouldn't be included in tracing data.

## Changes Made

- **Configuration**: Removed `exception.stack_trace` from extra_tags in default config
- **CoroutineAspect**: Removed exception message and stack trace data setting
- **GuzzleHttpClientAspect**: Removed exception message and stack trace data setting  
- **EventHandleListener**: Removed exception message and stack trace data setting in all event handlers
- **Tracer**: Removed Feature dependency and exception data setting logic

## Test Plan

- [ ] Verify tracing still works correctly without exception data
- [ ] Confirm exception class and code are still captured as tags
- [ ] Test that no sensitive information leaks through tracing spans
- [ ] Validate that existing functionality remains intact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 重构
  - 追踪中不再记录异常消息与堆栈，仅保留异常类型与错误码，降低敏感信息曝光风险。
  - 移除与额外标签相关的开关与逻辑，简化配置与运行时开销。
  - 调整初始化方式，去除特性依赖；如有自定义集成，请检查兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->