### PR TITLE
refactor(sentry): simplify tracing data collection and remove sensitive exception details

### DIFF
--- a/src/sentry/src/Tracing/Aspect/CoroutineAspect.php
+++ b/src/sentry/src/Tracing/Aspect/CoroutineAspect.php
@@ -112,12 +112,7 @@ class CoroutineAspect extends AbstractAspect
             try {
                 $callable();
             } catch (Throwable $exception) {
-                $coTransaction->setStatus(SpanStatus::internalError())
-                    ->setTags([
-                        'error' => 'true',
-                        'exception.class' => $exception::class,
-                        'exception.code' => (string) $exception->getCode(),
-                    ]);
+                $coTransaction->setStatus(SpanStatus::internalError());
 
                 throw $exception;
             }

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -351,23 +351,17 @@ class EventHandleListener implements ListenerInterface
         }
 
         $traceId = (string) $span->getTraceId();
+
         if ($event instanceof RpcEvent\RequestHandled && $this->container->has(RpcContext::class)) {
             $this->container->get(RpcContext::class)->set('sentry-trace-id', $traceId);
         } elseif ($event->response instanceof ResponsePlusInterface) {
             $event->response->setHeader('sentry-trace-id', $traceId);
         }
 
-        $span->setStatus(
-            SpanStatus::createFromHttpStatusCode($event->response->getStatusCode())
-        );
+        $span->setHttpStatus($event->response->getStatusCode());
 
-        if ($exception = $event->getThrowable()) {
-            $span->setStatus(SpanStatus::internalError())
-                ->setTags([
-                    'error' => 'true',
-                    'exception.class' => $exception::class,
-                    'exception.code' => (string) $exception->getCode(),
-                ]);
+        if ($event->getThrowable()) {
+            $span->setStatus(SpanStatus::internalError());
         }
     }
 
@@ -422,13 +416,8 @@ class EventHandleListener implements ListenerInterface
                 'command.exit_code' => (string) $exitCode,
             ]);
 
-            if (method_exists($event, 'getThrowable') && $exception = $event->getThrowable()) {
-                $transaction->setStatus(SpanStatus::internalError())
-                    ->setTags([
-                        'error' => 'true',
-                        'exception.class' => $exception::class,
-                        'exception.code' => (string) $exception->getCode(),
-                    ]);
+            if (method_exists($event, 'getThrowable') && $event->getThrowable()) {
+                $transaction->setStatus(SpanStatus::internalError());
             }
 
             $transaction->setStatus(
@@ -463,13 +452,8 @@ class EventHandleListener implements ListenerInterface
                     $span->setData(['db.redis.result' => $event->result]);
                 }
 
-                if ($exception = $event->throwable) {
-                    $span->setStatus(SpanStatus::internalError())
-                        ->setTags([
-                            'error' => 'true',
-                            'exception.class' => $exception::class,
-                            'exception.code' => (string) $exception->getCode(),
-                        ]);
+                if ($event->throwable) {
+                    $span->setStatus(SpanStatus::internalError());
                 }
             },
             SpanContext::make()
@@ -537,13 +521,8 @@ class EventHandleListener implements ListenerInterface
             return;
         }
 
-        if (method_exists($event, 'getThrowable') && $exception = $event->getThrowable()) {
-            $transaction->setStatus(SpanStatus::internalError())
-                ->setTags([
-                    'error' => 'true',
-                    'exception.class' => $exception::class,
-                    'exception.code' => (string) $exception->getCode(),
-                ]);
+        if (method_exists($event, 'getThrowable') && $event->getThrowable()) {
+            $transaction->setStatus(SpanStatus::internalError());
         }
     }
 
@@ -614,13 +593,8 @@ class EventHandleListener implements ListenerInterface
             'messaging.amqp.message.result' => $event instanceof AmqpEvent\AfterConsume ? $event->getResult()->value : 'fail',
         ]);
 
-        if (method_exists($event, 'getThrowable') && $exception = $event->getThrowable()) {
-            $transaction->setStatus(SpanStatus::internalError())
-                ->setTags([
-                    'error' => 'true',
-                    'exception.class' => $exception::class,
-                    'exception.code' => (string) $exception->getCode(),
-                ]);
+        if (method_exists($event, 'getThrowable') && $event->getThrowable()) {
+            $transaction->setStatus(SpanStatus::internalError());
         }
     }
 
@@ -683,13 +657,8 @@ class EventHandleListener implements ListenerInterface
             return;
         }
 
-        if (method_exists($event, 'getThrowable') && $exception = $event->getThrowable()) {
-            $transaction->setStatus(SpanStatus::internalError())
-                ->setTags([
-                    'error' => 'true',
-                    'exception.class' => $exception::class,
-                    'exception.code' => (string) $exception->getCode(),
-                ]);
+        if (method_exists($event, 'getThrowable') && $event->getThrowable()) {
+            $transaction->setStatus(SpanStatus::internalError());
         }
     }
 
@@ -739,13 +708,8 @@ class EventHandleListener implements ListenerInterface
             return;
         }
 
-        if (method_exists($event, 'getThrowable') && $exception = $event->getThrowable()) {
-            $transaction->setStatus(SpanStatus::internalError())
-                ->setTags([
-                    'error' => 'true',
-                    'exception.class' => $exception::class,
-                    'exception.code' => (string) $exception->getCode(),
-                ]);
+        if (method_exists($event, 'getThrowable') && $event->getThrowable()) {
+            $transaction->setStatus(SpanStatus::internalError());
         }
     }
 

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -360,7 +360,7 @@ class EventHandleListener implements ListenerInterface
 
         $span->setHttpStatus($event->response->getStatusCode());
 
-        if ($event->getThrowable()) {
+        if (method_exists($event, 'getThrowable') && $event->getThrowable()) {
             $span->setStatus(SpanStatus::internalError());
         }
     }

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -416,7 +416,7 @@ class EventHandleListener implements ListenerInterface
                 'command.exit_code' => (string) $exitCode,
             ]);
 
-            if (method_exists($event, 'getThrowable') && $event->getThrowable()) {
+            if ($event->getThrowable()) {
                 $transaction->setStatus(SpanStatus::internalError());
             }
 
@@ -521,7 +521,7 @@ class EventHandleListener implements ListenerInterface
             return;
         }
 
-        if (method_exists($event, 'getThrowable') && $event->getThrowable()) {
+        if ($event instanceof CrontabEvent\FailToExecute) {
             $transaction->setStatus(SpanStatus::internalError());
         }
     }
@@ -593,7 +593,7 @@ class EventHandleListener implements ListenerInterface
             'messaging.amqp.message.result' => $event instanceof AmqpEvent\AfterConsume ? $event->getResult()->value : 'fail',
         ]);
 
-        if (method_exists($event, 'getThrowable') && $event->getThrowable()) {
+        if ($event instanceof AmqpEvent\FailToConsume) {
             $transaction->setStatus(SpanStatus::internalError());
         }
     }
@@ -657,7 +657,7 @@ class EventHandleListener implements ListenerInterface
             return;
         }
 
-        if (method_exists($event, 'getThrowable') && $event->getThrowable()) {
+        if ($event instanceof AmqpEvent\FailToConsume) {
             $transaction->setStatus(SpanStatus::internalError());
         }
     }
@@ -708,7 +708,7 @@ class EventHandleListener implements ListenerInterface
             return;
         }
 
-        if (method_exists($event, 'getThrowable') && $event->getThrowable()) {
+        if ($event instanceof AmqpEvent\FailToConsume) {
             $transaction->setStatus(SpanStatus::internalError());
         }
     }

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -657,7 +657,7 @@ class EventHandleListener implements ListenerInterface
             return;
         }
 
-        if ($event instanceof AmqpEvent\FailToConsume) {
+        if ($event instanceof KafkaEvent\FailToConsume) {
             $transaction->setStatus(SpanStatus::internalError());
         }
     }
@@ -708,7 +708,7 @@ class EventHandleListener implements ListenerInterface
             return;
         }
 
-        if ($event instanceof AmqpEvent\FailToConsume) {
+        if ($event instanceof AsyncQueueEvent\FailToConsume) {
             $transaction->setStatus(SpanStatus::internalError());
         }
     }

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -708,7 +708,7 @@ class EventHandleListener implements ListenerInterface
             return;
         }
 
-        if ($event instanceof AsyncQueueEvent\FailToConsume) {
+        if ($event instanceof AsyncQueueEvent\FailedHandle) {
             $transaction->setStatus(SpanStatus::internalError());
         }
     }

--- a/src/sentry/src/Tracing/Tracer.php
+++ b/src/sentry/src/Tracing/Tracer.php
@@ -84,15 +84,7 @@ class Tracer
                 try {
                     return $trace($scope);
                 } catch (Throwable $exception) {
-                    $span = $scope->getSpan();
-                    if ($span !== null) {
-                        $span->setStatus(SpanStatus::internalError())
-                            ->setTags([
-                                'error' => 'true',
-                                'exception.class' => $exception::class,
-                                'exception.code' => (string) $exception->getCode(),
-                            ]);
-                    }
+                    $scope->getSpan()?->setStatus(SpanStatus::internalError());
                     throw $exception;
                 }
             },


### PR DESCRIPTION
## Summary

This PR refactors the Sentry tracing components to improve security and reduce data overhead by removing sensitive exception details from tracing spans while maintaining essential error tracking functionality.

### Key Changes

- **Security Enhancement**: Remove detailed exception information (class names, codes, messages) from tracing spans to prevent sensitive data exposure
- **API Simplification**: Replace manual HTTP status and tag setting with the cleaner `setHttpStatus()` method  
- **Data Reduction**: Remove coroutine ID tracking from HTTP client spans to reduce unnecessary data overhead
- **Code Cleanup**: Remove unused imports and standardize exception handling patterns across all tracing components

### Files Modified

- `src/sentry/src/Tracing/Aspect/CoroutineAspect.php`: Simplified exception handling
- `src/sentry/src/Tracing/Aspect/GuzzleHttpClientAspect.php`: Removed sensitive data collection and unused imports
- `src/sentry/src/Tracing/Listener/EventHandleListener.php`: Standardized error handling across all event listeners
- `src/sentry/src/Tracing/Tracer.php`: Simplified exception handling in trace method

### Benefits

- **Improved Security**: Prevents sensitive exception data from being transmitted to Sentry
- **Cleaner Code**: More consistent and maintainable error handling patterns
- **Reduced Overhead**: Less data collection reduces performance impact and storage requirements
- **Better Privacy**: Removes potentially sensitive class names and error details from external monitoring

### Test Plan

- [ ] Verify Sentry tracing still works correctly for successful requests
- [ ] Confirm error status is properly set when exceptions occur
- [ ] Check that HTTP status codes are correctly tracked
- [ ] Ensure no sensitive data appears in Sentry traces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 传播 traceId 至 RpcContext 或响应头。
  - 统一通过 setHttpStatus 设置 HTTP 状态。
  - 更合理记录 HTTP 响应体：可读文本保留，二进制以占位符呈现。
- 重构
  - 简化错误处理：统一仅标记 internalError，不再附加异常类名/代码等标签。
  - 精简 Guzzle on_stats 与各类监听器的状态更新逻辑，移除多余的 span 变更，保持追踪头注入与整体流程不变。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->