### PR TITLE
refactor(sentry): standardize message ID generation using SentryUid in tracing aspects

### DIFF
--- a/src/sentry/src/Tracing/Aspect/AmqpProducerAspect.php
+++ b/src/sentry/src/Tracing/Aspect/AmqpProducerAspect.php
@@ -22,6 +22,7 @@ use Hyperf\Di\Aop\ProceedingJoinPoint;
 use PhpAmqpLib\Wire\AMQPTable;
 use Sentry\State\Scope;
 use Sentry\Tracing\SpanContext;
+use Sentry\Util\SentryUid;
 
 use function FriendsOfHyperf\Sentry\trace;
 
@@ -73,7 +74,7 @@ class AmqpProducerAspect extends AbstractAspect
             }
         }
 
-        $messageId = uniqid('amqp_', true);
+        $messageId = SentryUid::generate();
         $destinationName = implode(', ', (array) $routingKey);
         $bodySize = strlen($producerMessage->payload());
 

--- a/src/sentry/src/Tracing/Aspect/AsyncQueueJobMessageAspect.php
+++ b/src/sentry/src/Tracing/Aspect/AsyncQueueJobMessageAspect.php
@@ -20,6 +20,7 @@ use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Sentry\State\Scope;
 use Sentry\Tracing\SpanContext;
+use Sentry\Util\SentryUid;
 
 use function FriendsOfHyperf\Sentry\trace;
 use function Hyperf\Support\with;
@@ -76,7 +77,7 @@ class AsyncQueueJobMessageAspect extends AbstractAspect
 
         /** @var \Hyperf\AsyncQueue\Driver\Driver $driver */
         $driver = $proceedingJoinPoint->getInstance();
-        $messageId = method_exists($job, 'getId') ? $job->getId() : uniqid('async_queue_', true);
+        $messageId = method_exists($job, 'getId') ? $job->getId() : SentryUid::generate();
         $destinationName = Context::get('sentry.messaging.destination.name', 'default');
         $bodySize = (fn ($job) => strlen($this->packer->pack($job)))->call($driver, $job);
         $data = [

--- a/src/sentry/src/Tracing/Aspect/KafkaProducerAspect.php
+++ b/src/sentry/src/Tracing/Aspect/KafkaProducerAspect.php
@@ -20,6 +20,7 @@ use longlang\phpkafka\Producer\ProduceMessage;
 use longlang\phpkafka\Protocol\RecordBatch\RecordHeader;
 use Sentry\State\Scope;
 use Sentry\Tracing\SpanContext;
+use Sentry\Util\SentryUid;
 
 use function FriendsOfHyperf\Sentry\trace;
 
@@ -54,7 +55,7 @@ class KafkaProducerAspect extends AbstractAspect
 
     protected function sendAsync(ProceedingJoinPoint $proceedingJoinPoint)
     {
-        $messageId = uniqid('kafka_', true);
+        $messageId = SentryUid::generate();
         $destinationName = $proceedingJoinPoint->arguments['keys']['topic'] ?? 'unknown';
         $bodySize = strlen($proceedingJoinPoint->arguments['keys']['value'] ?? '');
 
@@ -107,7 +108,7 @@ class KafkaProducerAspect extends AbstractAspect
                             $carrier = Carrier::fromSpan($span)
                                 ->with([
                                     'publish_time' => microtime(true),
-                                    'message_id' => uniqid('kafka_', true),
+                                    'message_id' => SentryUid::generate(),
                                     'destination_name' => $this->getTopic(),
                                     'body_size' => strlen((string) $this->getValue()),
                                 ]);


### PR DESCRIPTION
## Summary
- Replace `uniqid()` calls with `SentryUid::generate()` in AMQP, AsyncQueue, and Kafka producer aspects
- Ensures consistent message ID generation across all Sentry tracing components
- Improves integration with Sentry's internal ID generation patterns

## Changes Made
- **AmqpProducerAspect.php**: Updated message ID generation to use `SentryUid::generate()`
- **AsyncQueueJobMessageAspect.php**: Updated fallback message ID generation to use `SentryUid::generate()`
- **KafkaProducerAspect.php**: Updated message ID generation in both `sendAsync()` and batch methods to use `SentryUid::generate()`

## Test Plan
- [ ] Verify AMQP producer tracing generates proper message IDs
- [ ] Verify AsyncQueue job tracing generates proper message IDs
- [ ] Verify Kafka producer tracing generates proper message IDs
- [ ] Confirm message IDs follow Sentry's UID format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 统一 AMQP、Kafka 与异步队列的消息ID生成方式，采用更可靠的唯一ID以提升可追踪性与一致性，便于跨消息链路的追踪与关联。
  - 不影响现有功能与下游字段使用，行为保持一致，仅优化ID生成策略。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->