### PR TITLE
feat(sentry): align GrpcAspect with OpenTelemetry semantic conventions

### DIFF
--- a/src/sentry/src/Tracing/Aspect/GrpcAspect.php
+++ b/src/sentry/src/Tracing/Aspect/GrpcAspect.php
@@ -41,8 +41,9 @@ class GrpcAspect extends AbstractAspect
         $method = $proceedingJoinPoint->arguments['keys']['method'];
         $options = $proceedingJoinPoint->arguments['keys']['options'];
         $data = [
-            'grpc.method' => $method,
-            'grpc.options' => $options,
+            'rpc.system' => 'grpc',
+            'rpc.method' => $method,
+            'rpc.options' => $options,
         ];
 
         $parent = SentrySdk::getCurrentHub()->getSpan();
@@ -64,9 +65,9 @@ class GrpcAspect extends AbstractAspect
         return trace(
             fn (Scope $scope) => $proceedingJoinPoint->process(),
             SpanContext::make()
-                ->setOp('grpc.client')
+                ->setOp('rpc.client')
                 ->setDescription($method)
-                ->setOrigin('auto.grpc')
+                ->setOrigin('auto.rpc')
                 ->setData($data)
         );
     }


### PR DESCRIPTION
## Summary

This PR updates the `GrpcAspect` to align with OpenTelemetry semantic conventions for RPC spans:

- **Operation name**: Changed from `grpc.client` to `rpc.client`
- **Origin**: Updated from `auto.grpc` to `auto.rpc`
- **Span attributes**: Renamed to follow OTel conventions:
  - `grpc.method` → `rpc.method`
  - `grpc.options` → `rpc.options`
  - Added `rpc.system` attribute set to `grpc`

These changes improve compatibility with OpenTelemetry standards and observability tools that expect standard RPC span naming conventions.

## Test plan

- [ ] Verify existing gRPC tracing functionality continues to work
- [ ] Confirm span attributes are correctly populated in Sentry dashboard
- [ ] Check that the `rpc.system` attribute is set to `grpc`
- [ ] Validate that operation name appears as `rpc.client` in traces
- [ ] Ensure no breaking changes to existing monitoring/alerting configurations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 重构
  * 统一 RPC 追踪命名：将 grpc.method/grpc.options 替换为 rpc.system=grpc、rpc.method、rpc.options。
  * 更新跨度标识：操作名由 grpc.client 改为 rpc.client，来源由 auto.grpc 改为 auto.rpc。
  * 保持原有流程与头部注入逻辑不变；监控面板中的字段命名与筛选可能随之变化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->