### PR TITLE
feat(validated-dto): support Cast attribute for DTOCast type

### DIFF
--- a/src/validated-dto/src/SimpleDTO.php
+++ b/src/validated-dto/src/SimpleDTO.php
@@ -20,6 +20,7 @@ use FriendsOfHyperf\ValidatedDTO\Attributes\Map;
 use FriendsOfHyperf\ValidatedDTO\Attributes\Rules;
 use FriendsOfHyperf\ValidatedDTO\Casting\ArrayCast;
 use FriendsOfHyperf\ValidatedDTO\Casting\Castable;
+use FriendsOfHyperf\ValidatedDTO\Casting\DTOCast;
 use FriendsOfHyperf\ValidatedDTO\Casting\EnumCast;
 use FriendsOfHyperf\ValidatedDTO\Concerns\DataResolver;
 use FriendsOfHyperf\ValidatedDTO\Concerns\DataTransformer;
@@ -324,9 +325,10 @@ abstract class SimpleDTO implements BaseDTO, CastsAttributes, JsonSerializable
                 continue;
             }
 
-            $param = $cast->type === EnumCast::class
-                ? $cast->param
-                : new $cast->param();
+            $param = match (true) {
+                in_array($cast->type, [EnumCast::class, DTOCast::class]) => $cast->param,
+                default => new $cast->param(),
+            };
 
             $casts[$property] = new $cast->type($param);
         }

--- a/tests/ValidatedDTO/Datasets/CallableCastingDTOInstance.php
+++ b/tests/ValidatedDTO/Datasets/CallableCastingDTOInstance.php
@@ -11,12 +11,14 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Tests\ValidatedDTO\Datasets;
 
+use FriendsOfHyperf\ValidatedDTO\Attributes\Cast;
 use FriendsOfHyperf\ValidatedDTO\Casting\DTOCast;
 use FriendsOfHyperf\ValidatedDTO\Exception\CastException;
 use FriendsOfHyperf\ValidatedDTO\SimpleDTO;
 
 class CallableCastingDTOInstance extends SimpleDTO
 {
+    #[Cast(DTOCast::class, SimpleNameDTO::class)]
     public SimpleNameDTO $name;
 
     public ?int $age = null;
@@ -29,7 +31,6 @@ class CallableCastingDTOInstance extends SimpleDTO
     protected function casts(): array
     {
         return [
-            'name' => new DTOCast(SimpleNameDTO::class),
             'age' => function (string $property, mixed $value) {
                 if (! is_numeric($value)) {
                     throw new CastException($property);


### PR DESCRIPTION
## Summary
- Enhanced SimpleDTO to properly handle DTOCast with Cast attributes
- DTOCast now works similarly to EnumCast, passing class names directly as parameters
- Updated test to demonstrate using Cast attribute instead of manual casts() method

## Changes
- Modified `SimpleDTO.php:328-330` to use match expression that handles both DTOCast and EnumCast without instantiation
- Updated `CallableCastingDTOInstance.php` test to use `#[Cast(DTOCast::class, SimpleNameDTO::class)]` attribute
- Removed redundant cast definition from casts() method in test

## Benefits
- Improves consistency in cast type handling
- Enables declarative Cast attribute usage for DTOCast
- Simplifies code by reducing manual cast definitions

## Test plan
- [x] Verify existing ValidatedDTO tests pass
- [x] Confirm CallableCastingDTOInstance properly uses Cast attribute
- [x] Ensure DTOCast behaves identically to previous implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新功能
  * 支持在属性上使用注解进行 DTO 类型转换，简化配置；统一处理枚举与 DTO 转换参数，支持直接传递参数。
* 重构
  * 优化转换构建逻辑，改用更清晰的分支方式，提升可读性与可维护性。
* 测试
  * 更新用例以覆盖基于注解的 DTO 转换场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->