### PR TITLE
fix(confd): correct NacosClient instantiation parameter format

### DIFF
--- a/src/confd/src/Driver/Nacos.php
+++ b/src/confd/src/Driver/Nacos.php
@@ -54,7 +54,7 @@ class Nacos implements DriverInterface
         $this->isGrpcEnabled = (bool) ($config['grpc']['enable'] ?? false);
         $this->listenerConfig = (array) $this->config->get('confd.drivers.nacos.listener_config', []);
         $this->mapping = (array) $this->config->get('confd.drivers.nacos.mapping', []);
-        $this->client = make(NacosClient::class, ['config' => $this->buildNacosConfig($config)]);
+        $this->client = make(NacosClient::class, [$this->buildNacosConfig($config)]);
         $this->timer = new Timer($this->logger);
     }
 


### PR DESCRIPTION
## Summary
- Fixed NacosClient instantiation in the Nacos driver by correcting the parameter format passed to the `make()` function
- Changed from `['config' => $this->buildNacosConfig($config)]` to `[$this->buildNacosConfig($config)]`

## Motivation
The `make()` function expects positional parameters, not named parameters. The previous implementation used a named array format which was incorrect.

## Changes
- Updated `src/confd/src/Driver/Nacos.php:57` to use positional parameter format

## Test plan
- [ ] Verify NacosClient is instantiated correctly with the configuration
- [ ] Test confd driver with Nacos backend
- [ ] Ensure no regression in existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 重构
  * 调整内部 Nacos 配置驱动的实例化方式，规范参数传递与绑定，提升兼容性与稳定性。此次更新不引入用户可见变更，现有功能与行为保持不变，无需任何操作或配置调整。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->