### PR TITLE
fix(sentry): correct origin semantic convention for Monolog handler

### DIFF
--- a/src/sentry/src/Monolog/LogsHandler.php
+++ b/src/sentry/src/Monolog/LogsHandler.php
@@ -60,7 +60,7 @@ class LogsHandler extends \Sentry\Monolog\LogsHandler
                 Arr::dot($record['extra'] ?? [], 'extra.'),
                 ['logger.channel' => $record['channel'] ?? ''],
                 ['logger.group' => $this->group],
-                ['sentry.origin' => 'auto.logger.monolog']
+                ['sentry.origin' => 'auto.log.monolog']
             )
         );
 


### PR DESCRIPTION
## Summary

This PR corrects the `sentry.origin` attribute value in the Monolog LogsHandler to comply with Sentry's semantic conventions.

## Changes

- Changed `sentry.origin` from `auto.logger.monolog` to `auto.log.monolog` in `src/sentry/src/Monolog/LogsHandler.php:63`

## Rationale

According to Sentry's semantic conventions, the origin value for log instrumentation should use `auto.log.*` instead of `auto.logger.*` to properly identify the instrumentation type. This ensures consistency with Sentry's telemetry standards and improves observability data quality.

## Test Plan

- [x] Verify that logs are still being sent to Sentry correctly
- [x] Confirm the `sentry.origin` attribute appears as `auto.log.monolog` in Sentry UI
- [x] Check that existing log handling functionality remains unchanged

fix:https://github.com/friendsofhyperf/components/pull/965

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了 Sentry Monolog 集成中日志元数据的标识方式，确保日志在聚合时的来源信息更加准确。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->