### PR TITLE
feat(sentry): add producer identification to AMQP tracing

### DIFF
--- a/src/sentry/src/Tracing/Aspect/AmqpProducerAspect.php
+++ b/src/sentry/src/Tracing/Aspect/AmqpProducerAspect.php
@@ -25,6 +25,7 @@ use Sentry\Tracing\SpanContext;
 use Sentry\Util\SentryUid;
 
 use function FriendsOfHyperf\Sentry\trace;
+use function Hyperf\Config\config;
 
 /**
  * @property array{application_headers?:AMQPTable} $properties
@@ -86,6 +87,7 @@ class AmqpProducerAspect extends AbstractAspect
                         'message_id' => $messageId,
                         'destination_name' => $destinationName,
                         'body_size' => $bodySize,
+                        'producer' => config('app_name', 'unknown'),
                     ]);
                     (function () use ($carrier) {
                         $this->properties['application_headers'] ??= new AMQPTable();

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -586,6 +586,7 @@ class EventHandleListener implements ListenerInterface
                     'messaging.message.body.size' => $carrier?->get('body_size'),
                     'messaging.message.receive.latency' => $carrier?->has('publish_time') ? (microtime(true) - $carrier->get('publish_time')) : null,
                     'messaging.message.retry.count' => 0,
+                    'messaging.message.producer' => $carrier?->get('producer', 'unknown'),
                     'messaging.destination.name' => $carrier?->get('destination_name') ?: implode(', ', (array) $message->getRoutingKey()),
                     'messaging.amqp.message.type' => $message->getTypeString(),
                     'messaging.amqp.message.routing_key' => $message->getRoutingKey(),


### PR DESCRIPTION
## Summary
- Add producer application name to AMQP message tracing data for better observability
- Enable tracking of message flow across distributed services
- Capture producer information in both producer and consumer spans

## Changes
- **AmqpProducerAspect.php**: Add 'producer' attribute to span data using `app_name` config
- **EventHandleListener.php**: Capture and propagate producer information from message carrier

## Technical Details
The producer name is extracted from the `app_name` configuration and included in the AMQP tracing span data. On the consumer side, this information is retrieved from the message carrier and added to the consumer span, allowing for end-to-end visibility of which service produced each message.

Fallback to 'unknown' is used when producer information is unavailable.

## Test Plan
- [ ] Verify producer attribute is included in AMQP producer spans
- [ ] Verify producer information is captured in consumer spans
- [ ] Test with configured app_name
- [ ] Test fallback behavior when producer info is missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 增强了消息队列操作的追踪数据收集，现在包含生产者应用名称信息，提升可观测性和调试能力。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->