### PR TITLE
refactor(sentry): remove friendsofhyperf/support dependency

### DIFF
--- a/src/sentry/composer.json
+++ b/src/sentry/composer.json
@@ -22,7 +22,6 @@
         "pull-request": "https://github.com/friendsofhyperf/components/pulls"
     },
     "require": {
-        "friendsofhyperf/support": "~3.2.0",
         "hyperf/command": "~3.2.0",
         "hyperf/context": "~3.2.0",
         "hyperf/coroutine": "~3.2.0",

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -18,7 +18,6 @@ use FriendsOfHyperf\Sentry\Integration;
 use FriendsOfHyperf\Sentry\Util\Carrier;
 use FriendsOfHyperf\Sentry\Util\CoContainer;
 use FriendsOfHyperf\Sentry\Util\SqlParser;
-use FriendsOfHyperf\Support\RedisCommand;
 use Hyperf\Amqp\Event as AmqpEvent;
 use Hyperf\Amqp\Message\ConsumerMessage;
 use Hyperf\AsyncQueue\Event as AsyncQueueEvent;
@@ -466,7 +465,7 @@ class EventHandleListener implements ListenerInterface
 
         $pool = $this->container->get(RedisPoolFactory::class)->getPool($event->connectionName);
         $config = $this->config->get('redis.' . $event->connectionName, []);
-        $redisStatement = (string) new RedisCommand($event->command, $event->parameters);
+        $redisStatement = $event->getFormatCommand();
 
         trace(
             function (Scope $scope) use ($event) {


### PR DESCRIPTION
## Summary
- Removed `friendsofhyperf/support` dependency from sentry package composer.json
- Replaced `RedisCommand` class usage with native `$event->getFormatCommand()` method in EventHandleListener

## Motivation
This change reduces package coupling and maintenance overhead by eliminating an unnecessary dependency. The `getFormatCommand()` method provides the same functionality natively, making the external dependency redundant.

## Changes
- **src/sentry/composer.json**: Removed `friendsofhyperf/support` from required dependencies
- **src/sentry/src/Tracing/Listener/EventHandleListener.php**: 
  - Removed `FriendsOfHyperf\Support\RedisCommand` import
  - Replaced `new RedisCommand($event->command, $event->parameters)` with `$event->getFormatCommand()`

## Test plan
- [ ] Verify Redis tracing still works correctly
- [ ] Check that `getFormatCommand()` produces the same output format as `RedisCommand`
- [ ] Run existing test suite to ensure no regressions
- [ ] Validate Redis span data in Sentry dashboard