### PR TITLE
refactor: add constants for default hashids configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ docs/.vitepress/dist
 docs/.vitepress/cache
 **/node_modules
 src/**/node_modules
+todos/

--- a/src/model-hashids/src/Concerns/HasHashid.php
+++ b/src/model-hashids/src/Concerns/HasHashid.php
@@ -22,6 +22,12 @@ use function Hyperf\Config\config;
  */
 trait HasHashid
 {
+    public const DEFAULT_HASHIDS_CONNECTION = 'main';
+
+    public const DEFAULT_HASHIDS_ALPHABET = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
+
+    public const DEFAULT_HASHIDS_LENGTH = 0;
+
     public static function bootHasHashid()
     {
         static::addGlobalScope(new HashidScope());
@@ -63,8 +69,8 @@ trait HasHashid
 
         return new Hashids(
             $config['salt'] ?? '',
-            $config['length'] ?? 0,
-            $config['alphabet'] ?? 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'
+            $config['length'] ?? self::DEFAULT_HASHIDS_LENGTH,
+            $config['alphabet'] ?? self::DEFAULT_HASHIDS_ALPHABET
         );
     }
 
@@ -73,7 +79,7 @@ trait HasHashid
      */
     protected function getHashidsConnection()
     {
-        return config('hashids.default', 'main');
+        return config('hashids.default', self::DEFAULT_HASHIDS_CONNECTION);
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR refactors the `HasHashid` trait to improve code maintainability by extracting hardcoded default values into class constants.

- Added `DEFAULT_HASHIDS_CONNECTION` constant for the default connection name ('main')
- Added `DEFAULT_HASHIDS_ALPHABET` constant for the default alphabet string
- Added `DEFAULT_HASHIDS_LENGTH` constant for the default length (0)
- Updated `getHashidsDriver()` and `getHashidsConnection()` methods to use these constants
- Added `todos/` directory to `.gitignore`

## Benefits

- Improves code maintainability by centralizing default values
- Makes it easier to understand and modify default configuration
- Follows DRY principle by avoiding magic strings
- Provides clear documentation of default values

## Test plan

- [ ] Verify existing hashids functionality works as expected
- [ ] Confirm constants are properly used throughout the trait
- [ ] Check that no behavior changes have been introduced