### PR TITLE
refactor(co-phpunit): improve ClassLoader detection using registered autoloaders

### DIFF
--- a/src/co-phpunit/phpunit-patch.php
+++ b/src/co-phpunit/phpunit-patch.php
@@ -11,20 +11,17 @@ declare(strict_types=1);
 (function () {
     /** @var null|\Composer\Autoload\ClassLoader $classLoader */
     $classLoader = null;
-    $autoloadFiles = [
-        __DIR__ . '/../../vendor/autoload.php',
-        __DIR__ . '/../../../vendor/autoload.php',
-        __DIR__ . '/../../../../vendor/autoload.php',
-    ];
-    foreach ($autoloadFiles as $autoloadFile) {
-        if (file_exists($autoloadFile)) {
-            $classLoader = require $autoloadFile;
-            break;
+
+    foreach (spl_autoload_functions() as $loader) {
+        if (is_array($loader) && $loader[0] instanceof Composer\Autoload\ClassLoader) {
+            $classLoader = $loader[0];
         }
     }
-    if (! $classLoader instanceof Composer\Autoload\ClassLoader) {
+
+    if (! $classLoader) {
         return;
     }
+
     if ($file = $classLoader->findFile(PHPUnit\Framework\TestCase::class)) {
         $content = file_get_contents($file);
         $replace = 'public function runBare';


### PR DESCRIPTION
## Summary
- Refactored ClassLoader detection in phpunit-patch.php to use registered autoload functions instead of hardcoded file paths
- Simplified code by removing the static array of potential vendor/autoload.php locations
- Improved robustness by leveraging PHP's `spl_autoload_functions()` to find the Composer ClassLoader

## Benefits
- **More reliable**: Works correctly regardless of vendor directory location
- **Cleaner code**: Eliminates hardcoded path array and unnecessary file existence checks  
- **Better practice**: Uses PHP's autoload registry instead of filesystem scanning

## Changes
- Replaced file path iteration with `spl_autoload_functions()` loop
- Directly check if loader is a Composer\Autoload\ClassLoader instance
- Simplified conditional logic

## Test Plan
- [ ] Verify co-phpunit tests run successfully with the refactored code
- [ ] Test in different vendor directory scenarios (project root, nested dependencies)
- [ ] Confirm ClassLoader is properly detected and PHPUnit patching works as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 改进了内部类加载器发现机制，现采用动态运行时检测替代静态文件依赖，增强系统可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->