### PR TITLE
feat(sentry): add backwards compatibility for legacy configuration keys

### DIFF
--- a/src/sentry/src/Listener/SetupSentryListener.php
+++ b/src/sentry/src/Listener/SetupSentryListener.php
@@ -87,17 +87,16 @@ class SetupSentryListener implements ListenerInterface
 
     protected function compatibilityConfigurations(): void
     {
-        if ($this->config->has('sentry.tracing.spans') && ! $this->config->has('sentry.tracing_spans')) {
-            $this->config->set('sentry.tracing_spans', $this->config->get('sentry.tracing.spans'));
-        }
+        $mapping = [
+            'sentry.tracing.spans' => 'sentry.tracing_spans',
+            'sentry.tracing.extra_tags' => 'sentry.tracing_tags',
+            'sentry.tracing.enable' => 'sentry.tracing', // MUST be last
+        ];
 
-        if ($this->config->has('sentry.tracing.extra_tags') && ! $this->config->has('sentry.tracing_tags')) {
-            $this->config->set('sentry.tracing_tags', $this->config->get('sentry.tracing.extra_tags'));
-        }
-
-        if ($this->config->has('sentry.tracing.enable')) {
-            foreach ($this->config->get('sentry.tracing.enable') as $key => $enabled) {
-                $this->config->set("sentry.tracing.{$key}", $enabled);
+        foreach ($mapping as $oldKey => $newKey) {
+            if ($this->config->has($oldKey) && ! $this->config->has($newKey)) {
+                $this->config->set($newKey, $this->config->get($oldKey));
+                $this->config->set($oldKey, []);
             }
         }
     }


### PR DESCRIPTION
## Summary

This PR adds a backwards compatibility layer for legacy Sentry configuration keys to ensure a smooth migration path for users upgrading from previous versions.

## Changes

- Added `compatibilityConfigurations()` method to handle legacy config migration
- Maps `sentry.tracing.spans` → `sentry.tracing_spans`
- Maps `sentry.tracing.extra_tags` → `sentry.tracing_tags`
- Migrates `sentry.tracing.enable.*` to flat `sentry.tracing.*` structure

## Context

Recent refactoring simplified the Sentry configuration structure (#991, #990). This PR ensures that existing configurations using the old structure continue to work without requiring immediate migration.

## Test Plan

- [ ] Verify old configuration keys (`sentry.tracing.spans`, `sentry.tracing.extra_tags`, `sentry.tracing.enable`) are properly migrated
- [ ] Verify new configuration structure works as expected
- [ ] Verify no breaking changes for existing users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 改进了配置系统的向后兼容性处理，确保旧的配置键在升级时能够自动迁移至新格式，保持现有配置的正常运作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->