### PR TITLE
feat(sentry): improve coroutine backtrace filtering

### DIFF
--- a/src/sentry/src/Util/CoroutineBacktraceHelper.php
+++ b/src/sentry/src/Util/CoroutineBacktraceHelper.php
@@ -21,12 +21,14 @@ class CoroutineBacktraceHelper
         'Hyperf\Coroutine\Waiter->wait',
         'Hyperf\Coroutine\co', 'co',
         'Hyperf\Coroutine\go', 'go',
+        'Hyperf\Coroutine\wait', 'wait',
         'Hyperf\Coroutine\parallel', 'parallel',
     ];
 
     protected static array $breakFunctions = [
         'Multiplex\Socket\Client->loop', 'Multiplex\Socket\Client->heartbeat',
         'FriendsOfHyperf\Sentry\HttpClient\HttpClient->loop',
+        'FriendsOfHyperf\Sentry\Transport\CoHttpTransport->loop',
         'Hyperf\Kafka\Producer->loop',
         'Hyperf\Metric\Listener\OnMetricFactoryReady->process',
         'Hyperf\Metric\Listener\QueueWatcher->process',


### PR DESCRIPTION
## Summary
- Add `Hyperf\Coroutine\wait` and `wait` to skip functions list
- Add `FriendsOfHyperf\Sentry\Transport\CoHttpTransport->loop` to break functions list

## Details
This PR improves the accuracy of backtrace filtering for Sentry error reporting by including additional coroutine-related functions that should be handled during stack trace analysis:

1. **Skip Functions**: Added `Hyperf\Coroutine\wait` and `wait` to ensure these coroutine utility functions are properly skipped during backtrace processing
2. **Break Functions**: Added `FriendsOfHyperf\Sentry\Transport\CoHttpTransport->loop` to treat this transport loop as a break point in the stack trace

These changes ensure cleaner and more meaningful stack traces are reported to Sentry by filtering out internal coroutine management functions.

## Test plan
- [x] Verified the changes compile without errors
- [ ] Tested with Sentry error reporting to confirm improved backtrace filtering
- [ ] Verified that the new functions are correctly filtered in stack traces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了错误追踪的堆栈跟踪处理机制，增强了异步操作环境下错误信息的采集和分析能力。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->