### PR TITLE
feat: add feature flag support for tracing aspects

### DIFF
--- a/src/sentry/src/Tracing/Aspect/ElasticsearchRequestAspect.php
+++ b/src/sentry/src/Tracing/Aspect/ElasticsearchRequestAspect.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace FriendsOfHyperf\Sentry\Tracing\Aspect;
 
 use FriendsOfHyperf\Sentry\Constants;
+use FriendsOfHyperf\Sentry\Feature;
 use Hyperf\Context\Context;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
@@ -26,8 +27,16 @@ class ElasticsearchRequestAspect extends AbstractAspect
         'Elastic\Elasticsearch\Client::sendRequest',
     ];
 
+    public function __construct(protected Feature $feature)
+    {
+    }
+
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
+        if (! $this->feature->isTracingSpanEnabled('elasticsearch')) {
+            return $proceedingJoinPoint->process();
+        }
+
         if ($proceedingJoinPoint->methodName === 'sendRequest') { // ES 8.x
             $request = $proceedingJoinPoint->arguments['keys']['request'] ?? null;
             if ($request instanceof RequestInterface) {


### PR DESCRIPTION
## Summary

This PR adds feature flag support to tracing aspects, enabling fine-grained control over which types of operations are traced. Each aspect now checks the corresponding feature flag before performing tracing operations.

## Changes

- **DbConnectionAspect**: Added `Feature` dependency injection and check for `db` tracing feature flag before caching server information
- **RedisConnectionAspect**: Added `Feature` dependency injection and check for `redis` tracing feature flag before caching slot/node information
- **ElasticsearchRequestAspect**: Added `Feature` dependency injection and check for `elasticsearch` tracing feature flag before processing requests
- **RpcEndpointAspect**: Added `Feature` dependency injection and check for `rpc` tracing feature flag before storing server address

## Benefits

- Users can now selectively enable/disable tracing for specific operation types (db, redis, elasticsearch, rpc)
- Reduces overhead when certain types of tracing are not needed
- Provides more flexible configuration options without code changes
- Consistent feature flag pattern across all tracing aspects

## Test Plan

- [ ] Verify db tracing can be disabled via feature flag
- [ ] Verify redis tracing can be disabled via feature flag  
- [ ] Verify elasticsearch tracing can be disabled via feature flag
- [ ] Verify rpc tracing can be disabled via feature flag
- [ ] Verify all aspects work normally when feature flags are enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 为数据库、Elasticsearch、Redis 和 RPC 等追踪功能添加了运行时功能门控机制。用户现可通过功能标志灵活控制各类追踪的启用和禁用状态，提供更细粒度的追踪管理能力。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->