### PR TITLE
fix: replace filter with contains method in ClassAliasAutoloader

### DIFF
--- a/src/tinker/src/ClassAliasAutoloader.php
+++ b/src/tinker/src/ClassAliasAutoloader.php
@@ -118,7 +118,7 @@ class ClassAliasAutoloader
             return false;
         }
 
-        if (! $this->includedAliases->filter(fn ($alias) => str_starts_with($class, $alias))->isEmpty()) {
+        if (! $this->includedAliases->contains(fn ($alias) => str_starts_with($class, $alias))) {
             return true;
         }
 
@@ -126,7 +126,7 @@ class ClassAliasAutoloader
             return false;
         }
 
-        if (! $this->excludedAliases->filter(fn ($alias) => str_starts_with($class, $alias))->isEmpty()) {
+        if (! $this->excludedAliases->contains(fn ($alias) => str_starts_with($class, $alias))) {
             return false;
         }
 


### PR DESCRIPTION
## Summary
- Replace `filter()->isEmpty()` with `contains()` method in ClassAliasAutoloader
- Improves performance and code clarity for alias checking logic
- Uses more appropriate collection method for existence checks

## Test plan
- [ ] Verify class alias autoloading still works correctly
- [ ] Test that included and excluded aliases are properly handled
- [ ] Run existing test suite to ensure no regressions
- [ ] Check performance improvement in alias resolution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 优化了内部类别检查逻辑，提升代码性能和可维护性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->