### PR TITLE
fix(sentry): correct singleton key generation logic in SingletonAspect

### DIFF
--- a/src/sentry/src/Aspect/SingletonAspect.php
+++ b/src/sentry/src/Aspect/SingletonAspect.php
@@ -40,7 +40,7 @@ class SingletonAspect extends AbstractAspect
         $key = $className = $proceedingJoinPoint->className;
         $arguments = $proceedingJoinPoint->getArguments();
 
-        if (! array_key_exists(0, $arguments)) {
+        if (array_key_exists(0, $arguments)) {
             $key .= '#' . $arguments[0];
         }
 


### PR DESCRIPTION
## Summary
- Fix inverted condition for singleton key generation with arguments
- The `! array_key_exists(0, $arguments)` was incorrectly negating the check

## Test plan
- [x] Verified the condition logic now correctly appends `#{argument}` when getInstance is called with an argument
- [x] Code follows existing patterns in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 修正单例缓存键的构建逻辑，确保根据正确的条件判断缓存实例的检索和创建方式。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->