### PR TITLE
refactor(sentry): use Context API for transaction storage

### DIFF
--- a/src/sentry/src/Constants.php
+++ b/src/sentry/src/Constants.php
@@ -66,5 +66,8 @@ class Constants
 
     public const TRACEPARENT = 'traceparent';
 
+    /**
+     * @deprecated since v3.1, will be removed in v3.2.
+     */
     public static bool $runningInCommand = false;
 }

--- a/src/sentry/src/Metrics/Listener/OnBeforeHandle.php
+++ b/src/sentry/src/Metrics/Listener/OnBeforeHandle.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Sentry\Metrics\Listener;
 
-use FriendsOfHyperf\Sentry\Constants;
 use FriendsOfHyperf\Sentry\Feature;
 use FriendsOfHyperf\Sentry\Integration;
 use FriendsOfHyperf\Sentry\Metrics\Event\MetricFactoryReady;
@@ -59,7 +58,7 @@ class OnBeforeHandle implements ListenerInterface
             return;
         }
 
-        Constants::$runningInCommand = true;
+        SentryContext::setRunningInCommand();
 
         if ($this->feature->isCommandMetricsEnabled() && $this->container->has(EventDispatcherInterface::class)) {
             $this->container->get(EventDispatcherInterface::class)->dispatch(new MetricFactoryReady());

--- a/src/sentry/src/Metrics/Listener/OnMetricFactoryReady.php
+++ b/src/sentry/src/Metrics/Listener/OnMetricFactoryReady.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Sentry\Metrics\Listener;
 
-use FriendsOfHyperf\Sentry\Constants as SentryConstants;
 use FriendsOfHyperf\Sentry\Feature;
 use FriendsOfHyperf\Sentry\Integration;
 use FriendsOfHyperf\Sentry\Metrics\CoroutineServerStats;
 use FriendsOfHyperf\Sentry\Metrics\Event\MetricFactoryReady;
 use FriendsOfHyperf\Sentry\Metrics\Traits\MetricSetter;
+use FriendsOfHyperf\Sentry\SentryContext;
 use Hyperf\Coordinator\Timer;
 use Hyperf\Engine\Coroutine as Co;
 use Hyperf\Event\Contract\ListenerInterface;
@@ -84,7 +84,7 @@ class OnMetricFactoryReady implements ListenerInterface
 
         $serverStatsFactory = null;
 
-        if (! SentryConstants::$runningInCommand) {
+        if (! SentryContext::isRunningInCommand()) {
             if ($this->container->has(SwooleServer::class) && $server = $this->container->get(SwooleServer::class)) {
                 if ($server instanceof SwooleServer) {
                     $serverStatsFactory = fn (): array => $server->stats();

--- a/src/sentry/src/SentryContext.php
+++ b/src/sentry/src/SentryContext.php
@@ -39,6 +39,8 @@ class SentryContext
 
     public const CTX_RPC_SPAN_CONTEXT = 'sentry.ctx.rpc.span.context';
 
+    public const CTX_RUNNING_IN_COMMAND = 'sentry.ctx.running_in_command';
+
     public static function disableTracing(): void
     {
         Context::set(self::CTX_DISABLE_COROUTINE_TRACING, true);
@@ -157,5 +159,15 @@ class SentryContext
     public static function destroyRpcSpanContext(): void
     {
         Context::destroy(self::CTX_RPC_SPAN_CONTEXT);
+    }
+
+    public static function setRunningInCommand(): void
+    {
+        Context::set(self::CTX_RUNNING_IN_COMMAND, true);
+    }
+
+    public static function isRunningInCommand(): bool
+    {
+        return (bool) Context::get(self::CTX_RUNNING_IN_COMMAND);
     }
 }


### PR DESCRIPTION
## Summary

- Replace static property `$transaction` with Hyperf's `Context` API for storing transaction data
- Add constant `TRANSACTION` for context key
- Improve coroutine isolation in Swoole/Swow environments

## Details

This change enhances coroutine safety by using Hyperf's Context API instead of a static property. In a coroutine environment like Swoole/Swow, static properties are shared across all coroutines, which can lead to race conditions and incorrect transaction data being associated with the wrong request.

The Context API provides request-scoped storage that is properly isolated between coroutines.

## Changes

- `Integration.php`:
  - Replace `private static ?string $transaction` with `public const TRANSACTION = 'sentry.integration.transaction'`
  - Update `getTransaction()` to use `Context::get(self::TRANSACTION)`
  - Update `setTransaction()` to use `Context::set(self::TRANSACTION, $transaction)`
  - Add null safety check in event processing

## Test plan

- [ ] Run existing Sentry integration tests
- [ ] Verify transaction data is correctly isolated across concurrent requests
- [ ] Test with both Swoole and Swow runtime environments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **重构**
  * 将事务与运行模式状态从静态存储迁移到上下文管理，提升并发场景下的稳定性与一致性。

* **改进**
  * 在命令行/守护进程场景下的度量收集与分支判定改为基于上下文，改善指标采集可靠性。

* **弃用**
  * 标记旧的运行模式标识为即将废弃，建议迁移到新的上下文接口。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->