### PR TITLE
Fix access token persistence key in oauth2-server.php

### DIFF
--- a/src/oauth2-server/publish/oauth2-server.php
+++ b/src/oauth2-server/publish/oauth2-server.php
@@ -49,7 +49,7 @@ return [
         # Whether to require code challenge for public clients for the auth code grant
         'require_code_challenge_for_public_clients' => true,
         # Whether to enable access token saving to persistence layer (default to true)
-        'persist_access_tokens' => true,
+        'persist_access_token' => true,
     ],
     'resource_server' => [
         # Full path to the public key file


### PR DESCRIPTION
Related: https://github.com/friendsofhyperf/components/issues/1057

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * OAuth2 服务器配置中的一个授权参数名称已更新。使用该配置的用户需要相应地调整其配置文件以反映此更改。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->