### PR TITLE
feat(sentry): add coordinator tracing span configuration

### DIFF
--- a/src/sentry/publish/sentry.php
+++ b/src/sentry/publish/sentry.php
@@ -145,6 +145,7 @@ return [
     // Enable or disable specific tracing spans
     'tracing_spans' => [
         'cache' => env('SENTRY_TRACING_SPANS_CACHE', true),
+        'coordinator' => env('SENTRY_TRACING_SPANS_COORDINATOR', false),
         'coroutine' => env('SENTRY_TRACING_SPANS_COROUTINE', true),
         'db' => env('SENTRY_TRACING_SPANS_DB', true),
         'elasticsearch' => env('SENTRY_TRACING_SPANS_ELASTICSEARCH', true),


### PR DESCRIPTION
## Summary
- Add `coordinator` option to the `tracing_spans` config in `src/sentry/publish/sentry.php`

## Changes
- Added `SENTRY_TRACING_SPANS_COORDINATOR` env variable with default value `false`
- Placed alphabetically between `cache` and `coroutine` in the config

## Test Plan
- Verify the published config file contains the new `coordinator` key
- Confirm existing tracing spans are unaffected

## Risks
- Low risk: additive config change only, defaults to `false` (disabled)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **配置更新**
  * 新增追踪配置选项，支持通过环境变量自定义设置，默认值为禁用状态。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->