### PR TITLE
[codex] update repository guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,50 +1,153 @@
-# Repository Guidelines
+# Repository Guidelines for AI Agents
 
-## Project Structure & Module Organization
+## Scope and Source of Truth
 
-- `src/`: Hyperf components, each in a kebab-case folder (e.g., `src/pretty-console/src/`) with PSR-4 namespaces `FriendsOfHyperf\*`.
-- `tests/`: Pest test suites mirroring `src/` namespaces; grouped execution configured in `tests/Pest.php`.
-- `docs/`, `README*.md`: User-facing docs; update snippets when component behavior changes.
-- `bin/`: Maintenance helpers (README regeneration, JSON fixer). Run from repo root.
-- `todos/`, `types/`: Task notes and PHP stubs. Avoid editing `vendor/` directly.
+- This repository is the source monorepo for 48 independently installable
+  `friendsofhyperf/*` Composer packages.
+- Treat component source, component `composer.json` files, and tests as authoritative.
+  Do not invent public APIs, configuration keys, defaults, or framework behavior from
+  documentation alone.
+- Read the target component's `composer.json`, public source, tests found with `rg`, README,
+  and published configuration before changing behavior or documentation.
+- Preserve user changes and unrelated diffs. Do not revert, reformat, or regenerate files
+  outside the requested scope.
+- Do not create commits, push branches, split repositories, or publish releases unless the
+  user explicitly requests it.
 
-## Build, Test, and Development Commands
+## Repository Model
 
-- Install PHP deps: `composer install` (PHP ≥ 8.2 with required extensions).
-- Lint (dry run): `composer test:lint` uses php-cs-fixer; auto-fix with
-  `composer cs-fix -- path/to/file`.
-- Static analysis: `composer analyse` (PHPStan); stricter run `composer analyse:types`.
-- Tests: `composer test` runs lint → unit → type coverage; `composer test:unit` or
-  `vendor/bin/pest` for unit-only; `composer test:types` to enforce type coverage.
-- Targeted groups: `vendor/bin/pest --group cache`, `--group telescope`, etc.
-- Docs translation helper: `npm install` (or `pnpm install`), then `npm run docs:translate`.
+- `src/<component>/`: independent kebab-case Composer packages with PSR-4 namespaces under
+  `FriendsOfHyperf\*`.
+- `tests/<Component>/`: shared Pest tests. Groups are registered in `tests/Pest.php`; not
+  every component has a group.
+- `docs/{en,zh-cn,zh-hk,zh-tw}/`: four synchronized VitePress locales. Simplified Chinese is
+  the translation source.
+- `types/`: PHP stubs checked independently at PHPStan max level.
+- `bin/`: maintenance, generation, repository split, and release scripts.
+- Root `composer.json`: generated aggregation of component dependencies, PSR-4 mappings,
+  autoload files, ConfigProviders, and `replace` entries.
 
-## Coding Style & Naming Conventions
+Most components expose a `src/ConfigProvider.php` that registers Hyperf dependencies,
+listeners, aspects, commands, or publishable resources. Some components are framework-
+independent libraries and intentionally have no ConfigProvider.
 
-- PHP: PSR-12 style, 4-space indentation, short array syntax; enforced by php-cs-fixer.
-- Namespaces align with directory structure; keep component folders kebab-case and class
-  names StudlyCase.
-- Markdown: ATX headings, fenced code blocks with language hints, wrap lines around
-  100 chars. JSON/TOML: 2-space indent; avoid comments in JSON.
+## Change Workflow
 
-## Testing Guidelines
+1. Inspect `git status --short` and identify the exact allowed write scope.
+2. Read the target component's `composer.json`, relevant source, tests, README, and docs.
+3. Search with `rg` for usages, contracts, configuration keys, and existing tests.
+4. Make the smallest change consistent with local patterns.
+5. Add or update focused tests for public behavior changes.
+6. Update affected README and documentation snippets without adding unverified claims.
+7. Run targeted verification first, then broader checks proportional to the change.
+8. Finish with `git diff --check`, `git status --short`, and a path-scoped diff review.
 
-- Framework: Pest with base case `FriendsOfHyperf\Tests\TestCase` (sets up Hyperf DI and
-  mixin listeners). Fixtures live near the specs they serve.
-- Keep tests deterministic (no external network); mock collaborators via helpers in
-  `tests/Concerns/InteractsWithContainer.php`.
-- Maintain type coverage; add/update tests when public APIs or DTO contracts change.
+## Build and Verification
 
-## Commit & Pull Request Guidelines
+Install PHP dependencies from the repository root:
 
-- Use Conventional Commits, scoped where possible (e.g., `feat(cache): add redis tagging`,
-  `fix(tinker): handle empty input`).
-- Before opening a PR, ensure `composer test` passes; include rationale, linked issues,
-  and before/after notes for behavioral or doc changes.
-- Document any config updates to `config.toml`/`config.json`; never commit secrets.
+```bash
+composer install
+```
 
-## Security & Configuration Tips
+Standard checks:
 
-- Keep `auth.json`, tokens, `history.jsonl`, and `sessions/` artifacts local; add ignore
-  rules as needed.
-- Scrub logs or debug output before sharing to avoid leaking PII or credentials.
+```bash
+composer test          # lint, all Pest tests, then type coverage
+composer analyse       # PHPStan; not included in composer test
+composer analyse:types # PHPStan max-level analysis for types/
+```
+
+Focused checks:
+
+```bash
+vendor/bin/pest --group cache
+vendor/bin/pest tests/CoPhpunit
+vendor/bin/pest tests/Support/DispatchTest.php
+composer analyse src/cache
+composer cs-fix -- src/cache
+```
+
+- Prefer an existing Pest group from `tests/Pest.php`.
+- When no group exists, run the component test directory or specific test file.
+- Keep tests deterministic and offline. Use helpers in
+  `tests/Concerns/InteractsWithContainer.php` for container mocks, swaps, and spies.
+- `composer cs-fix` modifies files. Use it only on the intended paths and review its diff.
+- Report checks that could not run because of missing PHP extensions, services, or tools.
+
+## Component and Composer Rules
+
+- Component directory names remain kebab-case; PHP classes remain StudlyCase and namespaces
+  must match their PSR-4 mapping.
+- Component-local dependencies belong in `src/<component>/composer.json`.
+- Internal component dependencies should follow the repository's existing version
+  constraints and package naming.
+- Root aggregation metadata is maintained by `bin/composer-json-fixer`. If component package
+  metadata changes, verify whether the root `composer.json` must be regenerated.
+- `composer json-fix`, `composer repo:pending`, and `composer gen:readme` can modify many
+  files. Do not run them for a narrowly scoped task unless their output is required.
+- Never edit `vendor/` directly.
+
+## Documentation Rules
+
+- Component README files and `docs/<locale>/components/<component>.md` are separate sources;
+  inspect both when behavior or examples change.
+- Keep page sets and heading levels synchronized across `en`, `zh-cn`, `zh-hk`, and `zh-tw`.
+- Keep code blocks, installation commands, configuration keys, and API examples
+  semantically synchronized across all four locales.
+- Every component documentation page must include the correct
+  `composer require friendsofhyperf/<component>` command.
+- When adding, removing, or renaming pages, update the four locale sidebars under
+  `docs/.vitepress/src/<locale>/`.
+- `docs/index.md` is the source for the Simplified Chinese home page workflow; do not update
+  only `docs/zh-cn/index.md`.
+- Automated translation can overwrite manually polished text. Review translations, links,
+  Markdown structure, and terminology after generation.
+
+Documentation checks:
+
+```bash
+npm install
+npm run docs:check
+```
+
+`docs:check` validates locale page parity, heading structures, component installation
+commands, and local links. It does not prove that prose or code examples match behavior, so
+also verify claims against source and tests. `npm run docs:translate` modifies translated
+files and requires translation service configuration; run it only when the user explicitly
+requests translation regeneration.
+
+## Coding Style
+
+- PHP follows PSR-12, uses 4-space indentation and short array syntax, and is enforced by
+  php-cs-fixer.
+- Preserve strict types declarations and existing component conventions.
+- Markdown uses ATX headings and fenced code blocks with language hints. Keep prose concise
+  and wrap long lines near 100 characters where practical.
+- JSON uses 2-space indentation and no comments.
+- Add abstractions only when they reduce real duplication or match an established pattern.
+
+## Generated and High-Risk Operations
+
+The following scripts are maintainer operations with broad or remote side effects:
+
+- `bin/pending-repositories.sh`
+- `bin/split.sh`, `bin/split-linux.sh`, and `bin/split-docs.sh`
+- `bin/release.sh`
+
+Split scripts can force-push independent repositories. Release scripts tag the monorepo and
+component repositories. Never run these scripts unless the user explicitly requests the
+operation and the remote impact is understood.
+
+Do not expose or commit credentials such as `auth.json`, API keys, tokens, repository split
+keys, or local session/history files. Scrub logs before sharing them.
+
+## Commits and Pull Requests
+
+- Use Conventional Commits with a component scope when applicable, for example
+  `fix(cache): handle missing store`.
+- Keep commits focused and do not include unrelated formatting or generated churn.
+- Before a pull request, run the relevant focused tests, lint, PHPStan, and documentation
+  checks. For broad behavior changes, run the complete applicable suite.
+- Summaries should state the evidence inspected, behavior changed, checks run, checks not
+  run, and exact files modified.

--- a/README.md
+++ b/README.md
@@ -4,245 +4,189 @@
 [![Latest Stable Version](https://poser.pugx.org/friendsofhyperf/components/v)](https://packagist.org/packages/friendsofhyperf/components)
 [![License](https://poser.pugx.org/friendsofhyperf/components/license)](https://packagist.org/packages/friendsofhyperf/components)
 [![PHP Version Require](https://poser.pugx.org/friendsofhyperf/components/require/php)](https://packagist.org/packages/friendsofhyperf/components)
-[![Hyperf Version Require](https://img.shields.io/badge/hyperf->=3.2.0-brightgreen.svg?style=flat-square)](https://packagist.org/packages/friendsofhyperf/components)
+[![Hyperf Version Require](https://img.shields.io/badge/hyperf-%3E%3D3.2.0-brightgreen.svg?style=flat-square)](https://packagist.org/packages/friendsofhyperf/components)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/friendsofhyperf/components)
 
 [中文说明](README_CN.md)
 
-🚀 The most popular and comprehensive collection of high-quality components for the [Hyperf](https://hyperf.io) framework, providing 50+ production-ready packages to accelerate your application development.
+A monorepo of 48 independently installable components for
+[Hyperf](https://hyperf.io) 3.2 and later.
 
-## 📖 About
+## Requirements
 
-This repository is a **monorepo** containing a collection of battle-tested, community-driven components that extend the Hyperf framework with additional features and integrations. Each component is independently usable and can be installed separately or as a complete suite.
+- PHP 8.2 or later
+- Hyperf 3.2 or later
+- Swoole or Swow, when required by the application or component
 
-## ✨ Features
+Each component declares its exact dependencies in `src/<component>/composer.json`.
 
-- 🎯 **50+ Components** - Comprehensive collection covering various development needs
-- 🔌 **Easy Integration** - Seamless integration with Hyperf 3.2+
-- 📦 **Modular Design** - Install only what you need
-- 🛡️ **Production Ready** - Battle-tested in production environments
-- 📚 **Well Documented** - Comprehensive documentation in multiple languages
-- 🧪 **Fully Tested** - High test coverage with PHPUnit and Pest
-- 🌍 **Multi-language** - Documentation available in Chinese (Simplified, Traditional, HK) and English
+## Installation
 
-## 📋 Requirements
-
-- PHP >= 8.2
-- Hyperf >= 3.2.0
-- Swoole or Swow extension
-
-## 💾 Installation
-
-### Install All Components
+Install the complete collection:
 
 ```bash
 composer require friendsofhyperf/components
 ```
 
-### Install Individual Components
-
-You can install specific components as needed:
+Or install only the components your application needs:
 
 ```bash
-# Example: Install Telescope (Debug Assistant)
 composer require friendsofhyperf/telescope
-
-# Example: Install HTTP Client
 composer require friendsofhyperf/http-client
-
-# Example: Install Model Factory
 composer require friendsofhyperf/model-factory --dev
 ```
 
-## 🎯 Quick Start
-
-After installing a component, most packages will automatically register with Hyperf through the `ConfigProvider`. Some components may require publishing configuration files:
+Most framework-integrated packages are discovered through their `ConfigProvider`. Some
+components also publish configuration or resources:
 
 ```bash
-php bin/hyperf.php vendor:publish friendsofhyperf/[component-name]
+php bin/hyperf.php vendor:publish friendsofhyperf/<component>
 ```
 
-## 📦 Available Components
+Consult the component README and documentation before publishing files; not every component
+provides publishable resources.
 
-### 🔧 Development & Debugging Tools
+## Components
 
-- **[telescope](src/telescope)** - Elegant debug assistant for Hyperf (requests, exceptions, SQL, Redis, etc.)
-- **[tinker](src/tinker)** - Powerful REPL for interactive debugging
-- **[web-tinker](src/web-tinker)** - Web-based Tinker interface
-- **[ide-helper](src/ide-helper)** - Enhanced IDE support and autocompletion
-- **[pretty-console](src/pretty-console)** - Beautiful console output formatting
+### Development and Debugging
 
-### 💾 Database & Models
+- [telescope](src/telescope) - request, exception, SQL, Redis, and runtime inspection
+- [tinker](src/tinker) - interactive REPL
+- [web-tinker](src/web-tinker) - browser-based Tinker interface
+- [ide-helper](src/ide-helper) - IDE metadata generation
+- [pretty-console](src/pretty-console) - improved console presentation
 
-- **[model-factory](src/model-factory)** - Database model factories for testing
-- **[model-observer](src/model-observer)** - Eloquent model observers
-- **[model-scope](src/model-scope)** - Global and local query scopes
-- **[model-hashids](src/model-hashids)** - Hashids integration for models
-- **[model-morph-addon](src/model-morph-addon)** - Polymorphic relationship enhancements
-- **[compoships](src/compoships)** - Multi-column relationships for Eloquent
-- **[fast-paginate](src/fast-paginate)** - High-performance pagination
-- **[mysql-grammar-addon](src/mysql-grammar-addon)** - MySQL grammar extensions
-- **[trigger](src/trigger)** - MySQL trigger support
+### Database and Models
 
-### 🗄️ Caching & Storage
+- [model-factory](src/model-factory), [model-observer](src/model-observer),
+  [model-scope](src/model-scope), [model-hashids](src/model-hashids), and
+  [model-morph-addon](src/model-morph-addon)
+- [compoships](src/compoships), [fast-paginate](src/fast-paginate),
+  [mysql-grammar-addon](src/mysql-grammar-addon), and [trigger](src/trigger)
 
-- **[cache](src/cache)** - Advanced caching with multiple drivers
-- **[lock](src/lock)** - Distributed locking mechanisms
-- **[redis-subscriber](src/redis-subscriber)** - Redis pub/sub subscriber
+### Infrastructure and Integrations
 
-### 🌐 HTTP & API
+- Cache and coordination: [cache](src/cache), [lock](src/lock), and
+  [redis-subscriber](src/redis-subscriber)
+- HTTP and APIs: [http-client](src/http-client) and [oauth2-server](src/oauth2-server)
+- Messaging: [notification](src/notification), [notification-mail](src/notification-mail),
+  [notification-easysms](src/notification-easysms), [mail](src/mail), and
+  [tcp-sender](src/tcp-sender)
+- External services: [elasticsearch](src/elasticsearch),
+  [telescope-elasticsearch](src/telescope-elasticsearch), [openai-client](src/openai-client),
+  [recaptcha](src/recaptcha), and [sentry](src/sentry)
+- Configuration: [confd](src/confd) and [config-consul](src/config-consul)
 
-- **[http-client](src/http-client)** - Elegant HTTP client (Laravel-style)
-- **[oauth2-server](src/oauth2-server)** - OAuth2 server implementation
+### Framework Extensions
 
-### 📨 Notifications & Communication
+- Commands: [command-benchmark](src/command-benchmark),
+  [command-signals](src/command-signals), [command-validation](src/command-validation), and
+  [console-spinner](src/console-spinner)
+- Architecture: [facade](src/facade), [ipc-broadcaster](src/ipc-broadcaster), and
+  [exception-event](src/exception-event)
+- Security and validation: [encryption](src/encryption), [purifier](src/purifier),
+  [rate-limit](src/rate-limit), [validated-dto](src/validated-dto), and
+  [grpc-validation](src/grpc-validation)
+- Shared utilities: [helpers](src/helpers), [support](src/support), and [macros](src/macros)
+- Queue and testing: [amqp-job](src/amqp-job) and [co-phpunit](src/co-phpunit)
 
-- **[notification](src/notification)** - Multi-channel notifications
-- **[notification-mail](src/notification-mail)** - Email notification channel
-- **[notification-easysms](src/notification-easysms)** - SMS notification via EasySMS
-- **[mail](src/mail)** - Email sending component
-- **[tcp-sender](src/tcp-sender)** - TCP message sender
+Every component directory contains its own package metadata and README. The complete list is
+available under [`src/`](src).
 
-### 🔍 Search & Data
+## Documentation
 
-- **[elasticsearch](src/elasticsearch)** - Elasticsearch client integration
-- **[telescope-elasticsearch](src/telescope-elasticsearch)** - Elasticsearch storage for Telescope
+The documentation site is available in four languages:
 
-### ⚙️ Configuration & Infrastructure
-
-- **[confd](src/confd)** - Configuration management with confd
-- **[config-consul](src/config-consul)** - Consul configuration center
-
-### 🛠️ Command & Console
-
-- **[command-signals](src/command-signals)** - Signal handling for commands
-- **[command-validation](src/command-validation)** - Command input validation
-- **[command-benchmark](src/command-benchmark)** - Command performance benchmarking
-- **[console-spinner](src/console-spinner)** - Console loading spinners
-
-### 🧩 Dependency Injection & Architecture
-
-- **[facade](src/facade)** - Laravel-style facades for Hyperf
-- **[ipc-broadcaster](src/ipc-broadcaster)** - Inter-process communication broadcaster
-
-### 🔐 Security & Validation
-
-- **[encryption](src/encryption)** - Data encryption and decryption
-- **[purifier](src/purifier)** - HTML purification (XSS protection)
-- **[recaptcha](src/recaptcha)** - Google reCAPTCHA integration
-- **[validated-dto](src/validated-dto)** - Data Transfer Objects with validation
-- **[grpc-validation](src/grpc-validation)** - gRPC request validation
-
-### 🎨 Utilities & Helpers
-
-- **[helpers](src/helpers)** - Useful helper functions
-- **[support](src/support)** - Support utilities and classes
-- **[macros](src/macros)** - Macro support for various classes
-
-### 📊 Monitoring & Logging
-
-- **[sentry](src/sentry)** - Sentry error tracking integration
-
-### 🚀 Queue & Jobs
-
-- **[amqp-job](src/amqp-job)** - AMQP-based job queue
-
-### 🧪 Testing
-
-- **[co-phpunit](src/co-phpunit)** - Coroutine-compatible PHPUnit
-
-### 🤖 AI & External Services
-
-- **[openai-client](src/openai-client)** - OpenAI API client
-
-### 📝 Others
-
-- **[exception-event](src/exception-event)** - Exception event handling
-
-## 📚 Documentation
-
-For detailed documentation, visit the [official documentation website](https://docs.hdj.me/).
-
-### Documentation by Language
-
-- [简体中文 (Simplified Chinese)](https://docs.hdj.me/zh-cn/)
-- [繁體中文 (Traditional Chinese)](https://docs.hdj.me/zh-tw/)
-- [香港繁體 (Hong Kong Traditional)](https://docs.hdj.me/zh-hk/)
+- [Simplified Chinese](https://docs.hdj.me/zh-cn/)
+- [Traditional Chinese](https://docs.hdj.me/zh-tw/)
+- [Hong Kong Traditional Chinese](https://docs.hdj.me/zh-hk/)
 - [English](https://docs.hdj.me/en/)
 
-## 🔨 Development
+Component documentation is maintained under `docs/<locale>/components/`. Component READMEs
+and documentation pages are separate sources, so behavior changes may require updates to
+both.
 
-### Clone the Repository
+## Repository Layout
 
-```bash
-git clone https://github.com/friendsofhyperf/components.git
-cd components
+```text
+src/<component>/        independently installable component packages
+tests/<Component>/      shared Pest test suite
+docs/<locale>/          VitePress documentation in four languages
+types/                  PHP stubs checked at PHPStan max level
+bin/                    repository maintenance, split, and release scripts
 ```
 
-### Install Dependencies
+The root package aggregates all components. Most components integrate with Hyperf through a
+`ConfigProvider`; a small number are framework-independent libraries.
+
+## Development
+
+Install dependencies from the repository root:
 
 ```bash
 composer install
 ```
 
-### Running Tests
+Run the standard local checks:
 
 ```bash
-# Run all tests
-composer test
-
-# Run specific test suites
-composer test:unit      # Unit tests
-composer test:lint      # Code style checks
-composer test:types     # Type coverage analysis
+composer test          # code style, Pest tests, and type coverage
+composer analyse       # PHPStan analysis
+composer analyse:types # PHPStan max-level analysis for types/
 ```
 
-### Code Quality
+Run focused checks while developing a component:
 
 ```bash
-# Fix code style
-composer cs-fix
-
-# Run static analysis
-composer analyse
+vendor/bin/pest --group cache
+vendor/bin/pest tests/CoPhpunit
+composer analyse src/cache
+composer cs-fix -- src/cache
 ```
 
-## 🤝 Contributing
+Pest groups are defined in [`tests/Pest.php`](tests/Pest.php). Not every component has a
+group, so use a test directory or file when necessary. `composer test` does not run PHPStan;
+run `composer analyse` separately before submitting code changes.
 
-We welcome contributions from the community! Please read our [Contributing Guidelines](CONTRIBUTE.md) before submitting pull requests.
+For documentation changes:
 
-### Development Workflow
+```bash
+npm install
+npm run docs:check
+```
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Make your changes
-4. Run tests and code quality checks
-5. Commit your changes (`git commit -m 'Add amazing feature'`)
-6. Push to the branch (`git push origin feature/amazing-feature`)
-7. Open a Pull Request
+Simplified Chinese is the translation source. Keep the page set and heading structure
+synchronized across `en`, `zh-cn`, `zh-hk`, and `zh-tw`, then review generated translations
+before submission. `npm run docs:translate` modifies translated files and requires translation
+service configuration; run it only when intentionally regenerating translations.
 
-## 🌟 Support & Community
+## Contributing
 
-- 📖 **Documentation**: [docs.hdj.me](https://docs.hdj.me/)
-- 💬 **Issues**: [GitHub Issues](https://github.com/friendsofhyperf/components/issues)
-- 🐦 **Twitter**: [@huangdijia](https://twitter.com/huangdijia)
-- 📧 **Email**: [huangdijia@gmail.com](mailto:huangdijia@gmail.com)
+Read [CONTRIBUTE.md](CONTRIBUTE.md) and [AGENTS.md](AGENTS.md) before making changes.
 
-## 🔗 Mirrors
+- Treat component source and tests as the authority for documented behavior.
+- Update tests when public behavior changes.
+- Update the component README and documentation snippets when they are affected.
+- Keep changes scoped; do not edit generated or unrelated files without a reason.
+- Run targeted checks first, followed by the relevant repository-level checks.
+- Use Conventional Commits, scoped to a component when possible.
 
-- [GitHub](https://github.com/friendsofhyperf/components)
-- [CNB](https://cnb.cool/friendsofhyperf/components)
+## Release Model
 
-## 👥 Contributors
+This monorepo is the source of truth. Maintenance workflows split `src/<component>` into
+individual `friendsofhyperf/<component>` repositories, and releases apply a shared version
+tag across the monorepo and component repositories.
 
-We are grateful to all the contributors who have helped make this project better!
+The split and release scripts force-push or tag remote repositories. They are maintainer-only
+operations and should not be run during normal development.
 
-[![Contributors](https://contrib.rocks/image?repo=friendsofhyperf/components)](https://github.com/friendsofhyperf/components/graphs/contributors)
+## Community
 
-## 📄 License
+- [Documentation](https://docs.hdj.me/)
+- [GitHub Issues](https://github.com/friendsofhyperf/components/issues)
+- [CNB Mirror](https://cnb.cool/friendsofhyperf/components)
+- [Contributors](https://github.com/friendsofhyperf/components/graphs/contributors)
 
-This project is open-sourced software licensed under the [MIT License](LICENSE).
+## License
 
----
-
-<p align="center">Made with ❤️ by <a href="https://github.com/huangdijia">Deeka Wong</a> and <a href="https://github.com/friendsofhyperf/components/graphs/contributors">contributors</a></p>
+FriendsOfHyperf Components is open-sourced software licensed under the [MIT License](LICENSE).

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,248 +1,183 @@
-# FriendsOfHyperf 组件库
+# FriendsOfHyperf Components
 
 [![Latest Test](https://github.com/friendsofhyperf/components/workflows/tests/badge.svg)](https://github.com/friendsofhyperf/components/actions)
 [![Latest Stable Version](https://poser.pugx.org/friendsofhyperf/components/v)](https://packagist.org/packages/friendsofhyperf/components)
 [![License](https://poser.pugx.org/friendsofhyperf/components/license)](https://packagist.org/packages/friendsofhyperf/components)
 [![PHP Version Require](https://poser.pugx.org/friendsofhyperf/components/require/php)](https://packagist.org/packages/friendsofhyperf/components)
-[![Hyperf Version Require](https://img.shields.io/badge/hyperf->=3.2.0-brightgreen.svg?style=flat-square)](https://packagist.org/packages/friendsofhyperf/components)
+[![Hyperf Version Require](https://img.shields.io/badge/hyperf-%3E%3D3.2.0-brightgreen.svg?style=flat-square)](https://packagist.org/packages/friendsofhyperf/components)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/friendsofhyperf/components)
 
 [English](README.md)
 
-🚀 最受欢迎且全面的 [Hyperf](https://hyperf.io) 框架高质量组件集合，提供 50+ 个生产就绪的包，加速您的应用程序开发。
+面向 [Hyperf](https://hyperf.io) 3.2 及以上版本的组件 monorepo，包含 48 个可独立安装的组件。
 
-## 📖 关于
+## 环境要求
 
-本仓库是一个 **单体仓库（monorepo）**，包含了一系列久经考验、社区驱动的组件，这些组件扩展了 Hyperf 框架的功能和集成。每个组件都可以独立使用，可以单独安装或作为完整套件安装。
+- PHP 8.2 或以上版本
+- Hyperf 3.2 或以上版本
+- 应用或组件需要时，安装 Swoole 或 Swow
 
-## ✨ 特性
+每个组件的准确依赖声明位于 `src/<component>/composer.json`。
 
-- 🎯 **50+ 组件** - 涵盖各种开发需求的全面集合
-- 🔌 **易于集成** - 与 Hyperf 3.2+ 无缝集成
-- 📦 **模块化设计** - 只安装您需要的组件
-- 🛡️ **生产就绪** - 在生产环境中久经考验
-- 📚 **文档完善** - 提供多语言的全面文档
-- 🧪 **充分测试** - 使用 PHPUnit 和 Pest 进行高测试覆盖
-- 🌍 **多语言支持** - 文档提供简体中文、繁体中文、香港繁体和英文版本
+## 安装
 
-## 📋 环境要求
-
-- PHP >= 8.2
-- Hyperf >= 3.2.0
-- Swoole 或 Swow 扩展
-
-## 💾 安装
-
-### 安装所有组件
+安装完整组件集合：
 
 ```bash
 composer require friendsofhyperf/components
 ```
 
-### 安装单个组件
-
-您可以根据需要安装特定组件：
+也可以只安装应用需要的组件：
 
 ```bash
-# 示例：安装 Telescope（调试助手）
 composer require friendsofhyperf/telescope
-
-# 示例：安装 HTTP 客户端
 composer require friendsofhyperf/http-client
-
-# 示例：安装模型工厂
 composer require friendsofhyperf/model-factory --dev
 ```
 
-## 🎯 快速开始
-
-安装组件后，大多数包会通过 `ConfigProvider` 自动注册到 Hyperf。部分组件可能需要发布配置文件：
+大部分与框架集成的组件会通过 `ConfigProvider` 自动发现。部分组件还提供配置或资源发布：
 
 ```bash
-php bin/hyperf.php vendor:publish friendsofhyperf/[组件名称]
+php bin/hyperf.php vendor:publish friendsofhyperf/<component>
 ```
 
-## 📦 可用组件
+并非所有组件都提供可发布资源，执行前请先查看组件 README 和文档。
 
-### 🔧 开发与调试工具
+## 组件
 
-- **[telescope](src/telescope)** - 优雅的 Hyperf 调试助手（请求、异常、SQL、Redis 等）
-- **[tinker](src/tinker)** - 强大的交互式调试 REPL
-- **[web-tinker](src/web-tinker)** - 基于 Web 的 Tinker 界面
-- **[ide-helper](src/ide-helper)** - 增强的 IDE 支持和自动补全
-- **[pretty-console](src/pretty-console)** - 美化的控制台输出格式
+### 开发与调试
 
-### 💾 数据库与模型
+- [telescope](src/telescope) - 查看请求、异常、SQL、Redis 和运行时信息
+- [tinker](src/tinker) - 交互式 REPL
+- [web-tinker](src/web-tinker) - 基于浏览器的 Tinker 界面
+- [ide-helper](src/ide-helper) - 生成 IDE 元数据
+- [pretty-console](src/pretty-console) - 改进控制台输出
 
-- **[model-factory](src/model-factory)** - 用于测试的数据库模型工厂
-- **[model-observer](src/model-observer)** - Eloquent 模型观察者
-- **[model-scope](src/model-scope)** - 全局和局部查询作用域
-- **[model-hashids](src/model-hashids)** - 模型的 Hashids 集成
-- **[model-morph-addon](src/model-morph-addon)** - 多态关联增强
-- **[compoships](src/compoships)** - Eloquent 的多列关联
-- **[fast-paginate](src/fast-paginate)** - 高性能分页
-- **[mysql-grammar-addon](src/mysql-grammar-addon)** - MySQL 语法扩展
-- **[trigger](src/trigger)** - MySQL 触发器支持
+### 数据库与模型
 
-### 🗄️ 缓存与存储
+- [model-factory](src/model-factory)、[model-observer](src/model-observer)、
+  [model-scope](src/model-scope)、[model-hashids](src/model-hashids) 和
+  [model-morph-addon](src/model-morph-addon)
+- [compoships](src/compoships)、[fast-paginate](src/fast-paginate)、
+  [mysql-grammar-addon](src/mysql-grammar-addon) 和 [trigger](src/trigger)
 
-- **[cache](src/cache)** - 支持多驱动的高级缓存
-- **[lock](src/lock)** - 分布式锁机制
-- **[redis-subscriber](src/redis-subscriber)** - Redis 发布/订阅订阅者
+### 基础设施与集成
 
-### 🌐 HTTP 与 API
+- 缓存与协调：[cache](src/cache)、[lock](src/lock) 和
+  [redis-subscriber](src/redis-subscriber)
+- HTTP 与 API：[http-client](src/http-client) 和 [oauth2-server](src/oauth2-server)
+- 消息与通知：[notification](src/notification)、[notification-mail](src/notification-mail)、
+  [notification-easysms](src/notification-easysms)、[mail](src/mail) 和
+  [tcp-sender](src/tcp-sender)
+- 外部服务：[elasticsearch](src/elasticsearch)、
+  [telescope-elasticsearch](src/telescope-elasticsearch)、[openai-client](src/openai-client)、
+  [recaptcha](src/recaptcha) 和 [sentry](src/sentry)
+- 配置管理：[confd](src/confd) 和 [config-consul](src/config-consul)
 
-- **[http-client](src/http-client)** - 优雅的 HTTP 客户端（Laravel 风格）
-- **[oauth2-server](src/oauth2-server)** - OAuth2 服务器实现
+### 框架扩展
 
-### 📨 通知与通信
+- 命令行：[command-benchmark](src/command-benchmark)、
+  [command-signals](src/command-signals)、[command-validation](src/command-validation) 和
+  [console-spinner](src/console-spinner)
+- 架构能力：[facade](src/facade)、[ipc-broadcaster](src/ipc-broadcaster) 和
+  [exception-event](src/exception-event)
+- 安全与验证：[encryption](src/encryption)、[purifier](src/purifier)、
+  [rate-limit](src/rate-limit)、[validated-dto](src/validated-dto) 和
+  [grpc-validation](src/grpc-validation)
+- 通用工具：[helpers](src/helpers)、[support](src/support) 和 [macros](src/macros)
+- 队列与测试：[amqp-job](src/amqp-job) 和 [co-phpunit](src/co-phpunit)
 
-- **[notification](src/notification)** - 多渠道通知
-- **[notification-mail](src/notification-mail)** - 邮件通知渠道
-- **[notification-easysms](src/notification-easysms)** - 通过 EasySMS 发送短信通知
-- **[mail](src/mail)** - 邮件发送组件
-- **[tcp-sender](src/tcp-sender)** - TCP 消息发送器
+每个组件目录均包含独立的包元数据和 README。完整列表可在 [`src/`](src) 中查看。
 
-### 🔍 搜索与数据
+## 文档
 
-- **[elasticsearch](src/elasticsearch)** - Elasticsearch 客户端集成
-- **[telescope-elasticsearch](src/telescope-elasticsearch)** - Telescope 的 Elasticsearch 存储
-
-### ⚙️ 配置与基础设施
-
-- **[confd](src/confd)** - 使用 confd 进行配置管理
-- **[config-consul](src/config-consul)** - Consul 配置中心
-
-### 🛠️ 命令与控制台
-
-- **[command-signals](src/command-signals)** - 命令的信号处理
-- **[command-validation](src/command-validation)** - 命令输入验证
-- **[command-benchmark](src/command-benchmark)** - 命令性能基准测试
-- **[console-spinner](src/console-spinner)** - 控制台加载动画
-
-### 🧩 依赖注入与架构
-
-- **[facade](src/facade)** - Hyperf 的 Laravel 风格门面
-- **[ipc-broadcaster](src/ipc-broadcaster)** - 进程间通信广播器
-
-### 🔐 安全与验证
-
-- **[encryption](src/encryption)** - 数据加密和解密
-- **[purifier](src/purifier)** - HTML 净化（XSS 防护）
-- **[recaptcha](src/recaptcha)** - Google reCAPTCHA 集成
-- **[validated-dto](src/validated-dto)** - 带验证的数据传输对象
-- **[grpc-validation](src/grpc-validation)** - gRPC 请求验证
-
-### 🎨 实用工具与助手
-
-- **[helpers](src/helpers)** - 实用的辅助函数
-- **[support](src/support)** - 支持工具和类
-- **[macros](src/macros)** - 各种类的宏支持
-
-### 📊 监控与日志
-
-- **[sentry](src/sentry)** - Sentry 错误追踪集成
-
-### 🚀 队列与任务
-
-- **[amqp-job](src/amqp-job)** - 基于 AMQP 的任务队列
-
-### 🧪 测试
-
-- **[co-phpunit](src/co-phpunit)** - 协程兼容的 PHPUnit
-
-### 🤖 AI 与外部服务
-
-- **[openai-client](src/openai-client)** - OpenAI API 客户端
-
-### 📝 其他
-
-- **[exception-event](src/exception-event)** - 异常事件处理
-
-## 📚 文档
-
-详细文档请访问 [官方文档网站](https://docs.hdj.me/)。
-
-### 多语言文档
+文档站提供四种语言：
 
 - [简体中文](https://docs.hdj.me/zh-cn/)
 - [繁體中文](https://docs.hdj.me/zh-tw/)
 - [香港繁體](https://docs.hdj.me/zh-hk/)
 - [English](https://docs.hdj.me/en/)
 
-## 🔨 开发
+组件文档位于 `docs/<locale>/components/`。组件 README 与文档页面是两套独立内容，行为变更
+可能需要同时更新两处。
 
-### 克隆仓库
+## 仓库结构
 
-```bash
-git clone https://github.com/friendsofhyperf/components.git
-cd components
+```text
+src/<component>/        可独立安装的组件包
+tests/<Component>/      共用 Pest 测试套件
+docs/<locale>/          四语言 VitePress 文档
+types/                  使用 PHPStan 最高级别检查的 PHP 存根
+bin/                    仓库维护、拆分和发布脚本
 ```
 
-### 安装依赖
+根包聚合所有组件。大部分组件通过 `ConfigProvider` 与 Hyperf 集成，少数组件是独立于框架的
+库。
+
+## 开发
+
+在仓库根目录安装依赖：
 
 ```bash
 composer install
 ```
 
-### 运行测试
+运行标准本地检查：
 
 ```bash
-# 运行所有测试
-composer test
-
-# 运行特定测试套件
-composer test:unit      # 单元测试
-composer test:lint      # 代码风格检查
-composer test:types     # 类型覆盖率分析
+composer test          # 代码风格、Pest 测试和类型覆盖率
+composer analyse       # PHPStan 静态分析
+composer analyse:types # 对 types/ 运行 PHPStan 最高级别分析
 ```
 
-### 代码质量
+开发单个组件时，优先运行目标检查：
 
 ```bash
-# 修复代码风格
-composer cs-fix
-
-# 运行静态分析
-composer analyse
+vendor/bin/pest --group cache
+vendor/bin/pest tests/CoPhpunit
+composer analyse src/cache
+composer cs-fix -- src/cache
 ```
 
-## 🤝 贡献
+Pest 分组定义在 [`tests/Pest.php`](tests/Pest.php)。并非每个组件都有分组，必要时应按测试目录
+或文件运行。`composer test` 不包含 PHPStan，提交代码变更前需要单独运行 `composer analyse`。
 
-我们欢迎社区的贡献！在提交 Pull Request 之前，请阅读我们的[贡献指南](CONTRIBUTE.md)。
+文档变更使用：
 
-### 开发流程
+```bash
+npm install
+npm run docs:check
+```
 
-1. Fork 本仓库
-2. 创建特性分支（`git checkout -b feature/amazing-feature`）
-3. 进行修改
-4. 运行测试和代码质量检查
-5. 提交更改（`git commit -m 'Add amazing feature'`）
-6. 推送到分支（`git push origin feature/amazing-feature`）
-7. 开启 Pull Request
+简体中文是翻译源。保持 `en`、`zh-cn`、`zh-hk` 和 `zh-tw` 的页面集合与标题结构同步，并在
+提交前人工检查生成的翻译。`npm run docs:translate` 会修改翻译文件并依赖翻译服务配置。
+仅在明确需要重新生成翻译时执行。
 
-## 🌟 支持与社区
+## 贡献
 
-- 📖 **文档**：[docs.hdj.me](https://docs.hdj.me/)
-- 💬 **问题反馈**：[GitHub Issues](https://github.com/friendsofhyperf/components/issues)
-- 🐦 **Twitter**：[@huangdijia](https://twitter.com/huangdijia)
-- 📧 **邮箱**：[huangdijia@gmail.com](mailto:huangdijia@gmail.com)
+修改前请阅读 [CONTRIBUTE.md](CONTRIBUTE.md) 和 [AGENTS.md](AGENTS.md)。
 
-## 🔗 镜像
+- 以组件源码和测试为文档行为的权威依据。
+- 公共行为变更时更新测试。
+- 组件 README 或文档代码片段受影响时同步更新。
+- 严格控制修改范围，不无故编辑生成文件或无关文件。
+- 优先运行目标检查，再运行相关的仓库级检查。
+- 使用 Conventional Commits，适用时添加组件 scope。
 
-- [GitHub](https://github.com/friendsofhyperf/components)
-- [CNB](https://cnb.cool/friendsofhyperf/components)
+## 发布模型
 
-## 👥 贡献者
+本 monorepo 是源码权威。维护流程会把 `src/<component>` 拆分到独立的
+`friendsofhyperf/<component>` 仓库，并为 monorepo 与组件仓库统一发布版本标签。
 
-感谢所有为本项目做出贡献的人！
+拆分和发布脚本会强制推送或为远端仓库打标签，仅供维护者使用，日常开发中不应执行。
 
-[![Contributors](https://contrib.rocks/image?repo=friendsofhyperf/components)](https://github.com/friendsofhyperf/components/graphs/contributors)
+## 社区
 
-## 📄 许可证
+- [文档](https://docs.hdj.me/)
+- [GitHub Issues](https://github.com/friendsofhyperf/components/issues)
+- [CNB 镜像](https://cnb.cool/friendsofhyperf/components)
+- [贡献者](https://github.com/friendsofhyperf/components/graphs/contributors)
 
-本项目采用 [MIT 许可证](LICENSE)开源。
+## 许可证
 
----
-
-<p align="center">由 <a href="https://github.com/huangdijia">Deeka Wong</a> 和<a href="https://github.com/friendsofhyperf/components/graphs/contributors">贡献者们</a>用 ❤️ 制作</p>
+FriendsOfHyperf Components 使用 [MIT License](LICENSE) 开源。


### PR DESCRIPTION
## Summary

- rewrite the English and Chinese repository READMEs around the verified 48-component monorepo structure
- document focused development, testing, PHPStan, documentation, and release workflows
- expand AGENTS.md with source-first verification, strict scope control, multilingual documentation rules, and high-risk operation safeguards

## Why

The existing guides contained stale component counts and did not clearly distinguish standard checks, generated metadata, documentation synchronization, or maintainer-only split and release operations.

## Validation

- `git diff --check`
- `node docs/bin/check-docs.js`
- verified both READMEs link all 48 components
- verified English and Chinese README heading structures match
- verified changed files are limited to `README.md`, `README_CN.md`, and `AGENTS.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Documentation**
  * 更新了仓库AI代理指南，扩展了工作流、编码风格等内容
  * 重写了项目README文档，优化了组件列表分类和安装说明结构
  * 增强了中文文档说明，包含仓库结构、开发流程和贡献指引
  * 改进了多语言文档的组织与清晰度
<!-- end of auto-generated comment: release notes by coderabbit.ai -->