### PR TITLE
docs(readme): add Chinese component readmes

### DIFF
--- a/src/amqp-job/README.md
+++ b/src/amqp-job/README.md
@@ -1,5 +1,7 @@
 # Amqp Job
 
+[中文说明](README_CN.md)
+
 ## Introduction
 
 `friendsofhyperf/amqp-job` dispatches PHP job objects through `hyperf/amqp`. A job

--- a/src/amqp-job/README_CN.md
+++ b/src/amqp-job/README_CN.md
@@ -1,0 +1,138 @@
+# Amqp Job
+
+[English](README.md)
+
+## 简介
+
+`friendsofhyperf/amqp-job` 通过 `hyperf/amqp` 分发 PHP 任务对象。任务使用 `AmqpJob`
+注解声明 AMQP 绑定，服务启动时，组件会为每个已启用且带有该注解的任务自动注册消费者。
+
+组件默认使用 PHP 序列化，因此只应分发可信的任务对象，并确保消费者可以加载对应的类。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/amqp-job
+```
+
+Hyperf 会自动发现包中的 `ConfigProvider`。它会注册消费者监听器，并将重试次数存储绑定到
+Redis，将消息打包器绑定到 `PhpSerializerPacker`。分发任务前，请先配置 `hyperf/amqp`
+及所选的 AMQP 连接池。将 `amqp.enable` 设置为 `false` 会跳过所有任务消费者的自动注册。
+
+## 定义并分发任务
+
+```php
+use FriendsOfHyperf\AmqpJob\Annotation\AmqpJob;
+use FriendsOfHyperf\AmqpJob\Job;
+use FriendsOfHyperf\AmqpJob\JobMessage;
+use Hyperf\Amqp\Result;
+use Hyperf\Amqp\Producer;
+
+#[AmqpJob(
+    exchange: 'hyperf.exchange',
+    routingKey: 'hyperf.routing.key',
+    pool: 'default',
+    queue: 'hyperf.queue',
+    maxAttempts: 3,
+    confirm: true,
+    nums: 2,
+)]
+class FooJob extends Job
+{
+    public function __construct(private readonly int $id)
+    {
+    }
+
+    public function handle(): Result
+    {
+        // Process $this->id.
+        return Result::ACK;
+    }
+}
+
+function dispatchFoo(Producer $producer, int $id): bool
+{
+    $message = (new JobMessage(new FooJob($id)))
+        ->setExchange('hyperf.exchange')
+        ->setRoutingKey('hyperf.routing.key')
+        ->setPoolName('default');
+
+    return $producer->produce($message, confirm: true, timeout: 5);
+}
+```
+
+`dispatch(JobInterface $payload, ?bool $confirm = null, ?int $timeout = null): bool`
+是创建并发布 `JobMessage` 的便捷函数。如果任务尚无任务 ID，它会为其分配唯一 ID。可选的
+`confirm` 和 `timeout` 参数会覆盖本次分发使用的任务值。
+
+当前 `dispatch()` 不会将任务的交换机、路由键或连接池复制到 `JobMessage`。因此生成的生产者
+消息会使用空交换机、空路由键和 Hyperf 的 `default` AMQP 连接池。若要发布到 `AmqpJob`
+声明的绑定，请像上例一样创建 `JobMessage`、设置目的地，再交给 `Hyperf\Amqp\Producer`。
+
+## 注解选项
+
+| 选项 | 类型 | 默认值 | 行为 |
+| --- | --- | --- | --- |
+| `exchange` | `string` | 必填 | 自动消费者使用的交换机，也是 `Job::getExchange()` 的返回值。 |
+| `routingKey` | `string` | 必填 | 自动消费者使用的路由键，也是 `Job::getRoutingKey()` 的返回值。 |
+| `pool` | `?string` | `null` | 自动消费者连接池，也是 `Job::getPoolName()` 的返回值。 |
+| `queue` | `?string` | `null` | 消费者队列；省略时保持未设置。 |
+| `maxAttempts` | `int` | `0` | 处理失败的最大尝试次数；`0` 表示不重试。 |
+| `maxConsumption` | `int` | `0` | 消费者退出前最多消费的消息数。 |
+| `confirm` | `bool` | `false` | `Job::getConfirm()` 的返回值，由 `dispatch()` 使用。 |
+| `enable` | `bool` | `true` | 控制是否自动注册消费者。 |
+| `nums` | `int` | `1` | 消费者进程数。 |
+| `name` | `?string` | `null` | 消费者进程名称。 |
+
+如果任务未使用该注解，其 getter 默认返回交换机 `hyperf`、路由键 `hyperf.job`、无指定
+连接池、关闭发布确认、5 秒发布超时和不重试。子类可以提供 `$exchange`、`$routingKey`、
+`$poolName`、`$confirm`、`$timeout` 或 `$maxAttempts` 等受保护属性来覆盖这些 getter 值。
+如上所述，`dispatch()` 只使用确认和超时 getter。
+
+## 消费与重试
+
+当 `handle()` 没有返回值或返回无法识别的字符串时，`JobConsumer` 会确认任务。返回
+`Hyperf\Amqp\Result` 或其字符串值可以直接控制消费结果。
+
+当 `handle()` 抛出异常时，如果存在兼容的日志记录器，消费者会记录异常。设置
+`maxAttempts > 0` 后，基于 Redis 的次数计数器会重新入队任务，直到达到配置的总尝试次数。
+随后消费者会调用 `fail(Throwable $e)` 并丢弃消息。默认 `fail()` 方法不执行任何操作，
+可以覆盖它：
+
+```php
+use Throwable;
+
+public function fail(Throwable $e): void
+{
+    // Report or persist the terminal failure.
+}
+```
+
+默认 Redis 次数键使用 `hyperf:amqp-job:attempts:` 前缀，并在 86,400 秒后过期，因此启用
+重试时必须可用 Redis。绑定 `FriendsOfHyperf\AmqpJob\Contract\Attempt` 或
+`FriendsOfHyperf\AmqpJob\Contract\Packer` 可以替换默认实现。记录异常时，消费者会依次
+解析 `FriendsOfHyperf\AmqpJob\Contract\LoggerInterface` 和
+`Hyperf\Contract\StdoutLoggerInterface`；两者都不可用时会跳过日志记录。
+
+## 注册自定义消费者
+
+通常使用自动注册的消费者即可。若要通过手动声明的消费者消费兼容的序列化任务，请继承
+`JobConsumer` 并使用 Hyperf 的 `Consumer` 注解：
+
+```php
+namespace App\Amqp\Consumer;
+
+use FriendsOfHyperf\AmqpJob\JobConsumer;
+use Hyperf\Amqp\Annotation\Consumer;
+
+#[Consumer(
+    exchange: 'hyperf.exchange',
+    routingKey: 'hyperf.routing.key',
+    queue: 'hyperf.queue',
+    name: 'MyConsumer',
+    nums: 4,
+)]
+class MyConsumer extends JobConsumer
+{
+}
+```

--- a/src/cache/README.md
+++ b/src/cache/README.md
@@ -1,5 +1,7 @@
 # Cache
 
+[中文说明](README_CN.md)
+
 ## Introduction
 
 `friendsofhyperf/cache` wraps the drivers provided by `hyperf/cache` with a

--- a/src/cache/README_CN.md
+++ b/src/cache/README_CN.md
@@ -1,0 +1,149 @@
+# Cache
+
+[English](README.md)
+
+## 简介
+
+`friendsofhyperf/cache` 使用 Laravel 风格的仓库 API 封装 `hyperf/cache`
+提供的驱动。它支持 PSR-16 操作、命名存储、门面访问、缓存事件、宏以及
+stale-while-revalidate 缓存。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/cache
+```
+
+该组件要求 Hyperf 3.2。其 `ConfigProvider` 会在容器中注册
+`FriendsOfHyperf\Cache\Contract\Factory` 和
+`FriendsOfHyperf\Cache\Contract\Repository`。
+
+## 配置
+
+该组件不会发布独立的配置文件。请通过 `hyperf/cache` 配置驱动和命名存储；
+`CacheManager::store($name)` 会将名称传给 Hyperf 的缓存管理器。默认仓库解析
+`default` 存储。
+
+## 获取仓库
+
+### 依赖注入
+
+注入 `Contract\Repository` 以使用默认存储：
+
+```php
+namespace App\Controller;
+
+use FriendsOfHyperf\Cache\Contract\Repository;
+
+class IndexController
+{
+    public function __construct(private Repository $cache)
+    {
+    }
+
+    public function index(): mixed
+    {
+        return $this->cache->remember('users', 60, function () {
+            return [];
+        });
+    }
+}
+```
+
+需要命名存储时注入 `Contract\Factory`：
+
+```php
+use FriendsOfHyperf\Cache\Contract\Factory;
+
+$cache = $factory->store('redis');
+```
+
+### 门面
+
+```php
+use FriendsOfHyperf\Cache\Facade\Cache;
+
+$users = Cache::remember('users', 60, function () {
+    return [];
+});
+
+$users = Cache::store('redis')->get('users');
+```
+
+`Cache::driver($name)` 是 `Cache::store($name)` 的别名。
+`Cache::resolve($name)` 会创建新仓库，而不是返回管理器中缓存的仓库实例。
+
+## 核心操作
+
+仓库实现了 `Psr\SimpleCache\CacheInterface`，因此可使用 `get()`、`set()`、
+`delete()`、`clear()`、`getMultiple()`、`setMultiple()`、`deleteMultiple()` 和
+`has()`。此外还提供以下扩展：
+
+| 方法 | 行为 |
+| --- | --- |
+| `get($key, $default = null)` | 获取单个项目；未命中时会执行可调用的默认值。传入数组会转交给 `many()`。 |
+| `put($key, $value, $ttl = null)` | 存储单个项目；`null` 表示永久存储，非正数 TTL 会删除该键。传入关联数组会转交给 `putMany()`，并将第二个参数用作其 TTL。 |
+| `putMany($values, $ttl = null)` | 存储多个项目；非正数 TTL 会删除对应键。 |
+| `forever($key, $value)` | 不设置 TTL 地存储单个项目。 |
+| `add($key, $value, $ttl = null)` | 仅当 `get($key)` 返回 `null` 时存储项目。 |
+| `many($keys)` | 获取多个键；关联数组输入可为每个键提供默认值。 |
+| `pull($key, $default = null)` | 获取项目后将其删除。 |
+| `remember($key, $ttl, Closure $callback)` | 返回缓存值，或按 TTL 存储回调结果。 |
+| `rememberForever($key, Closure $callback)` / `sear(...)` | 返回缓存值，或永久存储回调结果。 |
+| `increment($key, $value = 1)` / `decrement(...)` | 读取、调整并以无 TTL 方式存储整数值。 |
+| `flush()` | `clear()` 的别名。 |
+| `missing($key)` | `has($key)` 的反向判断。 |
+| `getDriver()` / `getStore()` | 返回底层 Hyperf `DriverInterface`。 |
+
+扩展仓库方法接受的 TTL 可以是秒数、`DateInterval` 或 `DateTimeInterface`。
+
+::: warning 行为边界
+仓库会将已缓存的 `null` 视为未命中。`add()`、`pull()` 和递增/递减方法由分离的
+操作实现，因此不是原子操作。虽然 `pull()` 接受 `$default` 参数，但当前实现不会
+将它传给 `get()`，键不存在时返回 `null`。
+:::
+
+## Stale-While-Revalidate
+
+`flexible()` 接受包含两个 TTL 的数组：第一个值是新鲜期，第二个值是缓存值及其
+内部创建时间戳使用的存储 TTL。
+
+```php
+use FriendsOfHyperf\Cache\Facade\Cache;
+
+$users = Cache::flexible('users', [30, 300], function () {
+    return [];
+}, [
+    'seconds' => 10,
+    'owner' => 'users-refresh',
+]);
+```
+
+缓存未命中时，回调立即执行。在新鲜期内直接返回缓存值；新鲜期结束后返回旧值，
+并通过延迟回调尝试在锁内刷新缓存。如果其他进程已更新创建时间戳，则跳过刷新。
+
+使用 `flexible()` 前需要安装两个可选依赖：
+
+```shell
+composer require friendsofhyperf/lock hyperf/coroutine
+```
+
+可选的锁数组接受 `seconds` 和 `owner`，默认值分别为 `0` 和 `null`。
+
+## 事件
+
+当容器提供 `Psr\EventDispatcher\EventDispatcherInterface` 时，仓库会为读取、
+写入、删除和清空操作分发事件：
+
+- `CacheHit`、`CacheMissed`、`RetrievingKey`、`RetrievingManyKeys`
+- `WritingKey`、`WritingManyKeys`、`KeyWritten`、`KeyWriteFailed`
+- `ForgettingKey`、`KeyForgotten`、`KeyForgetFailed`
+- `CacheFlushing`、`CacheFlushed`
+
+每个事件都包含存储名称。单键事件还包含键；适用时，写入事件会公开值和 TTL，
+批量事件会公开键，`WritingManyKeys` 还会公开值。批量读取还会为每个返回的键分发
+`CacheHit` 或 `CacheMissed`。
+
+## 参考
+
+该 API 的设计受 Laravel Cache 启发，但具体行为应以本组件的契约和实现为准。

--- a/src/co-phpunit/README.md
+++ b/src/co-phpunit/README.md
@@ -1,5 +1,7 @@
 # Co-PHPUnit
 
+[中文说明](README_CN.md)
+
 Co-PHPUnit runs PHPUnit tests inside a Swoole coroutine. It is useful for tests that exercise
 coroutine-aware Hyperf components.
 

--- a/src/co-phpunit/README_CN.md
+++ b/src/co-phpunit/README_CN.md
@@ -1,0 +1,107 @@
+# Co-PHPUnit
+
+[English](README.md)
+
+Co-PHPUnit 让 PHPUnit 测试在 Swoole 协程中运行，适用于测试依赖协程上下文的 Hyperf
+组件。
+
+## 安装
+
+将组件安装为开发依赖：
+
+```bash
+composer require friendsofhyperf/co-phpunit --dev
+```
+
+组件依赖 `hyperf/coordinator` `~3.2.0`，并支持 PHPUnit 10、11 和 12。它没有将 Swoole
+扩展声明为 Composer 依赖；未加载该扩展时，测试会回退到 PHPUnit 的普通执行方式。
+
+## 使用
+
+### 在协程中运行测试
+
+在测试类或共享的测试基类中使用 `RunTestsInCoroutine`：
+
+```php
+<?php
+
+namespace App\Tests;
+
+use FriendsOfHyperf\CoPHPUnit\Concerns\RunTestsInCoroutine;
+use PHPUnit\Framework\TestCase;
+use Swoole\Coroutine;
+
+class ServiceTest extends TestCase
+{
+    use RunTestsInCoroutine;
+
+    public function testRunsInCoroutine(): void
+    {
+        self::assertNotSame(-1, Coroutine::getCid());
+    }
+}
+```
+
+安装组件后，不需要额外配置 PHPUnit 或 Composer 自动加载。
+
+### 退出协程执行
+
+将 `NonCoroutine` 应用于单个测试方法，可以让该方法在不创建协程的情况下运行：
+
+```php
+<?php
+
+namespace App\Tests;
+
+use FriendsOfHyperf\CoPHPUnit\Attributes\NonCoroutine;
+use FriendsOfHyperf\CoPHPUnit\Concerns\RunTestsInCoroutine;
+use PHPUnit\Framework\TestCase;
+use Swoole\Coroutine;
+
+class ServiceTest extends TestCase
+{
+    use RunTestsInCoroutine;
+
+    #[NonCoroutine]
+    public function testRunsWithoutCoroutine(): void
+    {
+        self::assertSame(-1, Coroutine::getCid());
+    }
+}
+```
+
+也可以将 `#[NonCoroutine]` 应用于测试类，让该类中的所有测试方法退出协程执行。该属性可用于
+类和方法，且没有构造参数。
+
+组件的公开 API 包括：
+
+- `FriendsOfHyperf\CoPHPUnit\Concerns\RunTestsInCoroutine`；
+- `FriendsOfHyperf\CoPHPUnit\Attributes\NonCoroutine`。
+
+## 执行行为
+
+`RunTestsInCoroutine` 会重写 PHPUnit 的 `runBare()` 方法。
+
+每个测试开始前，遇到以下任一情况时，它不会创建协程，而是以普通方式运行测试：
+
+- 未加载 Swoole 扩展；
+- 当前已经位于 Swoole 协程中；
+- 测试类带有 `#[NonCoroutine]`；或
+- 当前测试方法带有 `#[NonCoroutine]`。
+
+否则，它会调用 `Swoole\Coroutine\run()`，并在协程内执行 PHPUnit 父类的 `runBare()`。
+异常会先被捕获，并在协程退出后重新抛出。在 `finally` 块中，该 trait 会清除所有 Swoole
+定时器，并恢复 Hyperf 的 `WORKER_EXIT` 协调器。仅当该 trait 创建协程时，才会执行这些
+清理操作。
+
+`#[NonCoroutine]` 只会阻止该 trait 创建协程。如果测试已经在协程内运行，该属性不会让测试
+退出现有协程。
+
+## PHPUnit 补丁
+
+组件通过 Composer 的 `autoload.files` 注册 `phpunit-patch.php`。加载 Composer 自动加载
+文件时，该补丁会找到 PHPUnit 的 `TestCase` 源文件；如果 `TestCase::runBare()` 带有
+`final` 关键字，则将其移除，以便 trait 重写该方法。
+
+该补丁会直接写入已安装的 PHPUnit 源文件。需要应用补丁时，请确保 Composer 的 vendor
+目录可写。

--- a/src/command-benchmark/README.md
+++ b/src/command-benchmark/README.md
@@ -1,5 +1,7 @@
 # Command benchmark
 
+[中文说明](README_CN.md)
+
 [![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/command-benchmark)](https://packagist.org/packages/friendsofhyperf/command-benchmark)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/command-benchmark)](https://packagist.org/packages/friendsofhyperf/command-benchmark)
 [![License](https://img.shields.io/packagist/l/friendsofhyperf/command-benchmark)](https://github.com/friendsofhyperf/command-benchmark)

--- a/src/command-benchmark/README_CN.md
+++ b/src/command-benchmark/README_CN.md
@@ -1,0 +1,70 @@
+# Command Benchmark
+
+[English](README.md)
+
+Hyperf 命令的基准测试组件，Fork 自
+[christophrumpel/artisan-benchmark](https://github.com/christophrumpel/artisan-benchmark)。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/command-benchmark
+```
+
+该包声明依赖 Hyperf Collection、Command 和 Event `~3.2.0`。Hyperf 包发现机制会加载其
+`ConfigProvider`，并注册组件的 AOP 切面。
+
+## 使用
+
+该切面会为继承 `Hyperf\Command\Command` 的命令添加无需值的
+`--enable-benchmark` 选项。调用命令时添加该选项即可：
+
+```shell
+php bin/hyperf.php your:command --enable-benchmark
+```
+
+命令的 `execute()` 方法正常返回后，组件会输出前后带空行的彩色摘要：
+
+```text
+⚡ TIME: 2.5s  MEM: 15.23MB  SQL: 42
+```
+
+未传入 `--enable-benchmark` 时不会输出摘要。
+
+## 指标
+
+- **TIME**：从命令构造函数返回后到其 `execute()` 方法返回的耗时。小于一秒时显示为毫秒，
+  小于 60 秒时显示为秒，更长时间显示为分钟和秒。
+- **MEM**：进程内存差值的报告值，以 MB 为单位并保留两位小数。实现会用最终的
+  `memory_get_usage()` 值减去通过 `memory_get_usage(true)` 记录的起始值；该值不是峰值内存，
+  也可能为负数。
+- **SQL**：从命令构造函数返回后到输出摘要前观察到的
+  `Hyperf\Database\Events\QueryExecuted` 事件数量。监听器会观察进程内派发的所有此类事件，
+  不仅限于可归因于当前命令的查询；未派发此类事件时为 `0`。
+
+每个命令在构造时都会开始收集指标，即使之后调用命令时没有传入
+`--enable-benchmark`。因此，报告的区间可能包含命令构造完成至执行之间的工作，并不仅限于
+`execute()` 方法体。
+
+## 配置
+
+组件不会发布配置文件。`FriendsOfHyperf\CommandBenchmark\ConfigProvider` 会自动注册
+`FriendsOfHyperf\CommandBenchmark\Aspect\CommandAspect`。如果禁用了 Hyperf 包发现机制，
+请确保加载该配置提供器。
+
+组件没有配置项或注解；其操作入口是 `--enable-benchmark` 命令选项。
+
+## 注意事项
+
+- 仓库目前没有该组件的专用测试。
+- 指标收集和 SQL 事件监听器会产生开销，建议主要用于开发和诊断。无论之后是否使用该选项，
+  每个命令构造时都会收集指标并注册监听器。
+- 应将 `--enable-benchmark` 视为保留选项名；命令自行定义同名但不兼容的选项会导致选项注册失败。
+- `hyperf/database` 不是该包声明的依赖；仅当应用派发其 `QueryExecuted` 事件时，SQL 指标
+  才有意义。
+- SQL 指标统计已派发的 `QueryExecuted` 事件，不会直接检查数据库连接。
+
+## 联系方式
+
+- [Twitter](https://twitter.com/huangdijia)
+- [Gmail](mailto:huangdijia@gmail.com)

--- a/src/command-signals/README.md
+++ b/src/command-signals/README.md
@@ -1,5 +1,7 @@
 # Command Signals
 
+[中文说明](README_CN.md)
+
 [![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/command-signals)](https://packagist.org/packages/friendsofhyperf/command-signals)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/command-signals)](https://packagist.org/packages/friendsofhyperf/command-signals)
 [![License](https://img.shields.io/packagist/l/friendsofhyperf/command-signals)](https://github.com/friendsofhyperf/command-signals)

--- a/src/command-signals/README_CN.md
+++ b/src/command-signals/README_CN.md
@@ -1,0 +1,110 @@
+# Command Signals
+
+[English](README.md)
+
+`friendsofhyperf/command-signals` 为 Hyperf 命令提供基于协程的 POSIX 信号处理能力。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/command-signals
+```
+
+该组件支持 Hyperf 3.2，并会被自动发现。它的 `ConfigProvider` 不会发布任何配置。下方
+命令示例假设应用已经安装 `hyperf/command`；该组件没有将其声明为依赖。
+
+实现通过 Hyperf Engine 处理信号，并调用 `posix_getpid()` 和 `posix_kill()`。请在支持
+POSIX 信号且可运行协程的 Swoole 或 Swow 环境中使用。PHP POSIX 扩展必须提供上述两个
+函数。Composer 建议安装 `ext-swoole >= 4.6.0` 或 `ext-swow >= 0.1.0`，但没有将
+POSIX 扩展声明为依赖。
+
+## 使用
+
+在命令中引入 `InteractsWithSignals`，然后调用 `trap()` 并传入一个信号编号或信号编号数组。
+回调会接收到信号编号。
+
+```php
+namespace App\Command;
+
+use FriendsOfHyperf\CommandSignals\Traits\InteractsWithSignals;
+use Hyperf\Command\Annotation\Command;
+use Hyperf\Command\Command as HyperfCommand;
+use Psr\Container\ContainerInterface;
+
+#[Command]
+class FooCommand extends HyperfCommand
+{
+    use InteractsWithSignals;
+
+    public function __construct(protected ContainerInterface $container)
+    {
+        parent::__construct('foo');
+    }
+
+    public function configure()
+    {
+        parent::configure();
+        $this->setDescription('Hyperf Demo Command');
+    }
+
+    public function handle()
+    {
+        $this->trap([SIGINT, SIGTERM], function (int $signo): void {
+            $this->warn(sprintf('Received signal %d, exiting...', $signo));
+        });
+
+        sleep(10);
+
+        $this->info('Bye!');
+    }
+}
+```
+
+首次调用 `trap()` 时，它会通过容器创建 `SignalRegistry`，并在当前协程结束时自动清空回调。
+同一个信号可以注册多个回调；收到该信号时，这些回调会并发执行。
+
+每个已注册信号只会被处理一次。回调执行完成后，注册器会停止等待，并再次向当前进程发送同一
+信号，因此操作系统通常会执行该信号的默认动作。
+
+使用 `untrap()` 清空一个信号、多个信号或全部信号的回调。它不会取消已经启动的等待协程；
+如果之后收到该信号，注册器仍会在不执行回调后再次向进程发送该信号。
+
+```php
+$this->untrap(SIGINT);
+$this->untrap([SIGINT, SIGTERM]);
+$this->untrap();
+```
+
+## API
+
+Trait 向命令提供以下受保护方法：
+
+- `trap(array|int $signo, callable $callback): void`
+- `untrap(null|array|int $signo = null): void`
+
+`SignalRegistry` 也是公开类。其构造函数为
+`__construct(int $timeout = 1, int $concurrentLimit = 0)`；`timeout` 是每次等待尝试的
+超时秒数，`concurrentLimit` 用于限制并发执行的回调数量，值为 `0` 表示不限制并发数。它
+提供以下方法：
+
+- `register(int|array $signo, callable $signalHandler): void`
+- `unregister(null|int|array $signo = null): void`
+
+`unregister()` 会清空所选信号的回调；传入 `null` 会清空全部回调。
+
+## 运行
+
+- 按下 `Ctrl + C` 发送 `SIGINT`。
+
+```shell
+$ hyperf foo
+^CReceived signal 2, exiting...
+```
+
+- 发送 `SIGTERM`，例如使用 `killall php`。
+
+```shell
+$ hyperf foo
+Received signal 15, exiting...
+[1]    51936 terminated  php bin/hyperf.php foo
+```

--- a/src/command-validation/README.md
+++ b/src/command-validation/README.md
@@ -1,5 +1,7 @@
 # Command Validation
 
+[中文说明](README_CN.md)
+
 Validate a Hyperf command's arguments and options before the command runs.
 
 ## Installation

--- a/src/command-validation/README_CN.md
+++ b/src/command-validation/README_CN.md
@@ -1,0 +1,91 @@
+# Command Validation
+
+[English](README.md)
+
+在 Hyperf 命令运行前验证其参数和选项。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/command-validation
+```
+
+该组件要求 Hyperf `~3.2.0`（包括 `hyperf/validation`），且未声明可选依赖。
+Hyperf 会自动发现该组件的空 `ConfigProvider`，因此该组件没有需要发布的配置。
+
+## 使用
+
+在命令中引入 `ValidatesInput` trait 并重写 `rules()`。也可以重写
+`messages()` 和 `attributes()` 来自定义验证错误。
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use FriendsOfHyperf\CommandValidation\Traits\ValidatesInput;
+use Hyperf\Command\Command as HyperfCommand;
+use Hyperf\Command\Annotation\Command;
+
+#[Command]
+class FooCommand extends HyperfCommand
+{
+    use ValidatesInput;
+
+    protected ?string $signature = 'foo:hello {?name : The name of the person to greet.}';
+
+    public function handle(): void
+    {
+        $this->info(sprintf('Hello %s.', $this->input->getArgument('name')));
+    }
+
+    protected function rules(): array
+    {
+        return [
+            'name' => 'required',
+        ];
+    }
+
+    protected function messages(): array
+    {
+        return [
+            'name.required' => 'The :attribute field is required.',
+        ];
+    }
+
+    protected function attributes(): array
+    {
+        return [
+            'name' => 'recipient name',
+        ];
+    }
+}
+```
+
+## 验证行为
+
+Hyperf 会发现 trait 的 `setUpValidatesInput()` 钩子，并在命令执行前调用。
+该组件会：
+
+1. 在 `rules()` 为空时立即返回。
+2. 将命令的全部参数和选项合并为待验证数据。如果参数与选项使用相同键名，
+   选项值优先。
+3. 使用命令提供的规则、消息和属性名称创建验证器。
+4. 调用 `validate()`。验证失败会抛出
+   `Hyperf\Validation\ValidationException`，因此命令处理方法不会运行。
+
+该组件会忽略 `validate()` 返回的已验证数据，也不会修改命令输入；处理方法读取的
+仍是原始参数和选项值。如果容器未提供 `ValidatorFactoryInterface`，验证会抛出
+`RuntimeException`，提示安装 `hyperf/validation`。
+
+请勿直接调用 `setUpValidatesInput()`。
+
+## 自定义方法
+
+| 方法 | 用途 | 默认值 |
+| --- | --- | --- |
+| `rules(): array` | 命令参数和选项的验证规则。 | `[]` |
+| `messages(): array` | 自定义验证消息。 | `[]` |
+| `attributes(): array` | 待验证字段的自定义显示名称。 | `[]` |

--- a/src/compoships/README.md
+++ b/src/compoships/README.md
@@ -1,5 +1,7 @@
 # Compoships
 
+[中文说明](README_CN.md)
+
 [![Latest Stable Version](https://poser.pugx.org/friendsofhyperf/compoships/v/stable.svg)](https://packagist.org/packages/friendsofhyperf/compoships)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/compoships)](https://packagist.org/packages/friendsofhyperf/compoships)
 [![License](https://img.shields.io/packagist/l/friendsofhyperf/compoships)](https://github.com/friendsofhyperf/compoships)

--- a/src/compoships/README_CN.md
+++ b/src/compoships/README_CN.md
@@ -1,0 +1,200 @@
+# Compoships
+
+[English](README.md)
+
+**Compoships** 允许 Hyperf 的 Model ORM 定义基于两个或更多列匹配的模型关系。
+它适用于第三方或遗留数据库结构中单个外键列不足以定位关联记录的场景。
+
+Compoships 只扩展关系处理能力；它不会让 Hyperf 模型自身的主键变成复合主键。
+
+## 问题
+
+Eloquent 风格的关系通常只会把一个外键列匹配到一个本地键或拥有者键列。在关系中
+额外添加 `where` 子句并不能替代复合键关系，因为预加载会在单个模型实例可用之前
+构造关系查询。下面的示例中，准备预加载约束时 `$this->team_id` 是 `null`。
+
+```php
+namespace App;
+
+use Hyperf\Database\Model\Model;
+
+class User extends Model
+{
+    public function tasks()
+    {
+        return $this->hasMany(Task::class)->where('team_id', $this->team_id);
+    }
+}
+```
+
+## 安装
+
+通过 Composer 安装组件：
+
+```shell
+composer require friendsofhyperf/compoships
+```
+
+该组件面向 Hyperf 3.2，并依赖组件声明的 `hyperf/database` 及相关 Hyperf 支撑包。
+`composer.json` 中的建议包是可选第三方包，并不是 Compoships 关系所必需的依赖。
+
+## 配置
+
+无需发布配置文件。组件提供了 Hyperf `ConfigProvider`，但当前返回的是空配置数组。
+
+## 使用
+
+### 使用 `FriendsOfHyperf\Compoships\Database\Eloquent\Model` 类
+
+让模型继承 `FriendsOfHyperf\Compoships\Database\Eloquent\Model`，而不是直接继承
+`Hyperf\Database\Model\Model`。这个基础模型使用了 Compoships trait，同时保留正常
+的 Hyperf 模型行为。
+
+```php
+namespace App;
+
+use FriendsOfHyperf\Compoships\Database\Eloquent\Model;
+
+class User extends Model
+{
+}
+```
+
+### 使用 `FriendsOfHyperf\Compoships\Compoships` Trait
+
+如果模型必须继承其他基础类，可以在模型中使用
+`FriendsOfHyperf\Compoships\Compoships` trait。
+
+```php
+namespace App;
+
+use FriendsOfHyperf\Compoships\Compoships;
+use Hyperf\Database\Model\Model;
+
+class User extends Model
+{
+    use Compoships;
+}
+```
+
+当关系使用键名数组时，被关联模型也必须接入 Compoships：要么继承
+`FriendsOfHyperf\Compoships\Database\Eloquent\Model`，要么使用
+`FriendsOfHyperf\Compoships\Compoships` trait。否则定义关系时会抛出
+`FriendsOfHyperf\Compoships\Exceptions\InvalidUsageException`。
+
+## 关系语法
+
+Compoships 支持在以下关系方法中使用复合键：
+
+- `hasOne($related, $foreignKey = null, $localKey = null)`
+- `hasMany($related, $foreignKey = null, $localKey = null)`
+- `belongsTo($related, $foreignKey = null, $ownerKey = null, $relation = null)`
+
+将键参数从字符串改为数组即可。数组顺序和元素数量应保持一致，因为值会按数组下标
+逐项匹配。
+
+对 `hasOne` 和 `hasMany` 来说，外键数组表示被关联模型上的列，本地键数组表示当前
+模型上的列：
+
+```php
+namespace App;
+
+use FriendsOfHyperf\Compoships\Compoships;
+use Hyperf\Database\Model\Model;
+
+class Team extends Model
+{
+    use Compoships;
+
+    public function latestTask()
+    {
+        return $this->hasOne(Task::class, ['team_id', 'category_id'], ['id', 'category_id']);
+    }
+
+    public function tasks()
+    {
+        return $this->hasMany(Task::class, ['team_id', 'category_id'], ['id', 'category_id']);
+    }
+}
+```
+
+对 `belongsTo` 来说，外键数组表示当前模型上的列，拥有者键数组表示被关联模型上的
+列：
+
+```php
+namespace App;
+
+use FriendsOfHyperf\Compoships\Compoships;
+use Hyperf\Database\Model\Model;
+
+class Task extends Model
+{
+    use Compoships;
+
+    public function team()
+    {
+        return $this->belongsTo(Team::class, ['team_id', 'category_id'], ['id', 'category_id']);
+    }
+}
+```
+
+## 示例
+
+假设一个任务列表由多个团队管理，并且每个团队中每个任务分类都有一名负责用户：
+
+- 一个任务属于一个分类。
+- 一个任务被分配给一个团队。
+- 一个团队有多个用户。
+- 一个用户属于一个团队。
+- 一个用户负责一个分类下的任务。
+
+某个任务的负责用户，就是该任务所属团队中负责该任务分类的用户。
+
+```php
+namespace App;
+
+use FriendsOfHyperf\Compoships\Compoships;
+use Hyperf\Database\Model\Model;
+
+class User extends Model
+{
+    use Compoships;
+
+    public function tasks()
+    {
+        return $this->hasMany(Task::class, ['team_id', 'category_id'], ['team_id', 'category_id']);
+    }
+}
+```
+
+反向关系使用同一组列：
+
+```php
+namespace App;
+
+use FriendsOfHyperf\Compoships\Compoships;
+use Hyperf\Database\Model\Model;
+
+class Task extends Model
+{
+    use Compoships;
+
+    public function user()
+    {
+        return $this->belongsTo(
+            User::class,
+            ['team_id', 'category_id'],
+            ['team_id', 'category_id']
+        );
+    }
+}
+```
+
+## 行为说明
+
+Compoships 使用自定义查询构造器，因此预加载可以应用多列 `whereIn` 约束，关系存在性
+查询也可以通过 `whereColumn` 比较多列。
+
+对 `hasOne` 和 `hasMany` 来说，`save()` 和 `create()` 会把父模型本地键的值按顺序
+写入被关联模型的各个外键列。对 `belongsTo` 来说，`associate()` 会把拥有者键的值
+按顺序写入当前模型的各个外键列。

--- a/src/confd/README.md
+++ b/src/confd/README.md
@@ -1,5 +1,7 @@
 # Confd
 
+[中文说明](README_CN.md)
+
 The Confd component fetches configuration from Etcd or Nacos, maps remote values to environment
 variable names, and can write them to an existing `.env` file or watch for changes.
 

--- a/src/confd/README_CN.md
+++ b/src/confd/README_CN.md
@@ -1,0 +1,171 @@
+# Confd
+
+[English](README.md)
+
+Confd 组件从 Etcd 或 Nacos 获取配置，将远程值映射为环境变量名，并可将其写入
+已有的 `.env` 文件或监听变更。
+
+## 安装
+
+安装组件以及所用驱动需要的包：
+
+```shell
+composer require friendsofhyperf/confd
+composer require hyperf/etcd
+# or
+composer require hyperf/nacos
+```
+
+Etcd 和 Nacos 是可选驱动依赖。Nacos v2 gRPC API 还需要 `google/protobuf`、`hyperf/grpc`
+和 `hyperf/http2-client`。解码 YAML 值需要 PHP YAML 扩展。
+
+发布配置文件：
+
+```shell
+php bin/hyperf.php vendor:publish friendsofhyperf/confd
+```
+
+## 配置
+
+发布的文件为 `config/autoload/confd.php`，主要选项如下：
+
+| 选项 | 说明 |
+| --- | --- |
+| `default` | 驱动名称。默认为 `etcd`，可通过 `CONFD_DRIVER` 设置。 |
+| `drivers.<name>.driver` | 实现 `DriverInterface` 的驱动类。 |
+| `drivers.<name>.mapping` | 将远程配置路径映射到环境变量名。 |
+| `env_path` | `confd:env` 更新的已有 `.env` 文件。 |
+| `watch` | 在服务器启动时开始监听。默认为 `true`，可通过 `CONFD_WATCH` 设置。 |
+| `watches` | 会触发 `WatchDispatched` 的环境变量名。 |
+| `interval` | 轮询间隔秒数。默认为 `1`，可通过 `CONFD_INTERVAL` 设置。 |
+
+### Etcd
+
+Etcd 驱动获取 `namespace` 下的键，并只返回 `mapping` 中列出的键。每个映射键是 Etcd
+键，每个映射值是 `fetch()` 返回的环境变量名。
+
+```php
+'etcd' => [
+    'driver' => FriendsOfHyperf\Confd\Driver\Etcd::class,
+    'client' => [
+        'uri' => env('ETCD_URI', ''),
+        'version' => 'v3beta',
+        'timeout' => 10,
+    ],
+    'namespace' => '/test',
+    'mapping' => [
+        '/mysql/host' => 'DB_HOST',
+        '/mysql/port' => 'DB_PORT',
+    ],
+],
+```
+
+### Nacos
+
+Nacos 驱动读取 `listener_config` 中的每个条目，根据 `type` 解码，再从 `mapping`
+解析点号路径。支持的类型为 `json`、`yml`/`yaml` 和 `xml`；其他类型或未指定类型时
+保留为字符串。
+
+```php
+'nacos' => [
+    'driver' => FriendsOfHyperf\Confd\Driver\Nacos::class,
+    'client' => [
+        'host' => '127.0.0.1',
+        'port' => 8848,
+        'username' => 'nacos',
+        'password' => 'nacos',
+        'guzzle' => [
+            'config' => ['timeout' => 3, 'connect_timeout' => 1],
+        ],
+        'grpc' => [
+            'enable' => false,
+            'heartbeat' => 10,
+        ],
+    ],
+    'listener_config' => [
+        'mysql' => [
+            'tenant' => 'framework',
+            'data_id' => 'mysql',
+            'group' => 'DEFAULT_GROUP',
+            'type' => 'json',
+        ],
+    ],
+    'mapping' => [
+        'mysql.host' => 'DB_HOST',
+        'mysql.charset' => 'DB_CHARSET',
+    ],
+],
+```
+
+当 `client.grpc.enable` 为 `false` 时，Nacos 按 `interval` 轮询；为 `true` 时，驱动为
+`listener_config` 中的条目注册 gRPC 监听。
+
+## 更新环境文件
+
+从选定驱动获取映射值，并更新配置的已有 `.env` 文件：
+
+```shell
+php bin/hyperf.php confd:env
+```
+
+使用 `--env-path`（或 `-E`）覆盖 `confd.env_path`：
+
+```shell
+php bin/hyperf.php confd:env --env-path=/path/to/.env
+```
+
+文件不存在或获取/写入失败时，命令返回退出码 `1`。
+
+## 公开 API
+
+`FriendsOfHyperf\Confd\Confd` 提供：
+
+- `fetch(): array`：从选定驱动获取映射后的环境变量值。
+- `watch(): void`：执行首次获取并启动选定驱动的监听循环。
+
+自定义驱动必须实现 `FriendsOfHyperf\Confd\Driver\DriverInterface`，其中声明了
+`fetch(): array` 和 `loop(callable $callback): void`。内置 `Noop` 驱动不返回值，
+也不启动循环。
+
+## 监听与事件
+
+启用 `confd.watch` 时，`WatchOnBootListener` 会在 `MainWorkerStart` 或
+`MainCoroutineServerStart` 时调用 `Confd::watch()`。
+
+监听循环中，已有值发生变更时会派发 `ConfigChanged`。如果变更的环境变量名也列在
+`confd.watches` 中，还会派发 `WatchDispatched`。两个事件都提供公开数组属性：
+
+- `ConfigChanged`：`$current`、`$previous` 和 `$changes`。
+- `WatchDispatched`：`$changes`。
+
+```php
+<?php
+
+namespace App\Listener;
+
+use FriendsOfHyperf\Confd\Event\ConfigChanged;
+use Hyperf\Event\Annotation\Listener;
+use Hyperf\Event\Contract\ListenerInterface;
+
+#[Listener]
+class ConfigChangedListener implements ListenerInterface
+{
+    public function listen(): array
+    {
+        return [ConfigChanged::class];
+    }
+
+    public function process(object $event): void
+    {
+        foreach ($event->changes as $key => $value) {
+            // React to the changed mapped environment value.
+        }
+    }
+}
+```
+
+## 支持的驱动
+
+- Etcd
+- Nacos
+- Noop

--- a/src/config-consul/README.md
+++ b/src/config-consul/README.md
@@ -1,5 +1,7 @@
 # Config Consul
 
+[中文说明](README_CN.md)
+
 A Consul configuration center driver for Hyperf.
 
 ## Installation

--- a/src/config-consul/README_CN.md
+++ b/src/config-consul/README_CN.md
@@ -1,0 +1,66 @@
+# Config Consul
+
+[English](README.md)
+
+适用于 Hyperf 的 Consul 配置中心引擎。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/config-consul
+```
+
+该包会自动安装所需的 Hyperf 配置中心、Consul、编解码和字符串处理依赖。
+
+## 配置
+
+```php
+// config/autoload/config_center.php
+
+return [
+    'enable' => true,
+    'driver' => 'consul',
+    'drivers' => [
+        'consul' => [
+            'driver' => FriendsOfHyperf\ConfigConsul\ConsulDriver::class,
+            'packer' => Hyperf\Codec\Packer\JsonPacker::class,
+            'client' => [
+                'uri' => env('CONSUL_URI'),
+                'token' => env('CONSUL_TOKEN'),
+            ],
+            'namespaces' => [
+                '/application',
+            ],
+            'mapping' => [
+                // consul key => config key
+                '/application/test' => 'test',
+            ],
+            'interval' => 5,
+        ],
+    ],
+];
+```
+
+| 配置项 | 说明 |
+| --- | --- |
+| `enable` | 启用 Hyperf 配置中心。 |
+| `driver` | 选择 `consul` 驱动配置。 |
+| `drivers.consul.driver` | 驱动类，应使用 `ConsulDriver::class`。 |
+| `drivers.consul.packer` | 解包每个映射值，默认为 `JsonPacker::class`。 |
+| `drivers.consul.client` | 可选的 Consul 客户端配置，支持 `uri` 和 `token`。 |
+| `drivers.consul.namespaces` | 要递归拉取的 Consul KV 前缀数组。 |
+| `drivers.consul.mapping` | 将规范化后的 Consul 键映射到 Hyperf 配置键；只有已映射的键会被应用。 |
+| `drivers.consul.interval` | 拉取间隔，单位为秒，默认为 `5`。 |
+
+省略 `client` 或将其设为空时，组件会复用 Hyperf 容器中绑定的
+`Hyperf\Consul\KVInterface` 客户端。配置 `client` 时，`uri` 默认为
+`http://127.0.0.1:8500`；非空 `token` 会通过 `X-Consul-Token` 请求头发送；HTTP 超时时间为
+2 秒。
+
+## 行为
+
+- 每个命名空间都会使用 Consul 的递归选项请求。如果多个命名空间返回相同的键，映射前以后一个命名空间的值为准。
+- Consul KV 值会先进行 Base64 解码，再交给配置的 packer。使用 `JsonPacker` 时，Base64 解码后的存储值必须是有效 JSON。
+- Consul 键在 `mapping` 查找前会被规范化为以 `/` 开头。
+- 该包会在容器中注册 `FriendsOfHyperf\ConfigConsul\ClientInterface` 和
+  `FriendsOfHyperf\ConfigConsul\Consul\KVInterface`；`ConsulDriver` 是配置中心驱动入口。

--- a/src/console-spinner/README.md
+++ b/src/console-spinner/README.md
@@ -1,5 +1,7 @@
 # console-spinner
 
+[中文说明](README_CN.md)
+
 [![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/console-spinner)](https://packagist.org/packages/friendsofhyperf/console-spinner)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/console-spinner)](https://packagist.org/packages/friendsofhyperf/console-spinner)
 [![License](https://img.shields.io/packagist/l/friendsofhyperf/console-spinner)](https://github.com/friendsofhyperf/console-spinner)

--- a/src/console-spinner/README_CN.md
+++ b/src/console-spinner/README_CN.md
@@ -1,0 +1,88 @@
+# Console Spinner
+
+[English](README.md)
+
+用于 Hyperf 命令的控制台 Spinner 组件。它封装了 Symfony `ProgressBar`，并在每次推进时切换
+进度字符。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/console-spinner
+```
+
+## 可选配置
+
+仅在需要自定义 Spinner 字符时发布配置文件：
+
+```shell
+php bin/hyperf.php vendor:publish friendsofhyperf/console-spinner
+```
+
+发布后的 `config/autoload/console_spinner.php` 文件包含：
+
+```php
+return [
+    'chars' => ['⠏', '⠛', '⠹', '⢸', '⣰', '⣤', '⣆', '⡇'],
+];
+```
+
+请确保 `chars` 是非空数组，因为 Spinner 每次推进时都会从中选择一个字符。
+
+## 使用
+
+在 Hyperf 命令中使用 `Spinnerable` Trait。它的受保护辅助方法 `spinner(int $max = 0)` 会创建
+一个具有指定最大步数的 Spinner：
+
+```php
+use FriendsOfHyperf\ConsoleSpinner\Traits\Spinnerable;
+use Hyperf\Command\Command;
+
+class FooCommand extends Command
+{
+    use Spinnerable;
+
+    public function handle(): void
+    {
+        $users = User::all();
+        $spinner = $this->spinner($users->count());
+        $spinner->setMessage('Loading...');
+        $spinner->start();
+
+        foreach ($users as $user) {
+            // Do your stuff...
+            $spinner->advance();
+        }
+
+        $spinner->finish();
+    }
+}
+```
+
+`Spinner::advance(int $step = 1)` 会切换 Spinner 字符并推进封装的进度条。调用其他方法时，会将
+调用转发给 Symfony `ProgressBar`；需要直接访问底层实例时，可使用 `getOriginalProgressBar()`。
+
+## 使用 `withSpinner` 处理步骤
+
+受保护辅助方法 `withSpinner($totalSteps, Closure $callback, string $message = '')` 会自动启动
+和结束 Spinner。
+
+当 `$totalSteps` 是数组等可计数的可迭代对象时，回调会接收当前元素和 Spinner，并在处理每个
+元素后自动推进 Spinner：
+
+```php
+$this->withSpinner(User::all(), function ($user, $spinner): void {
+    // Do your stuff with $user...
+}, 'Loading...');
+```
+
+当 `$totalSteps` 是整数时，回调只接收 Spinner，并负责推进它：
+
+```php
+$this->withSpinner(10, function ($spinner): void {
+    for ($i = 0; $i < 10; ++$i) {
+        // Do your stuff...
+        $spinner->advance();
+    }
+}, 'Loading...');
+```

--- a/src/elasticsearch/README.md
+++ b/src/elasticsearch/README.md
@@ -1,5 +1,7 @@
 # Elasticsearch
 
+[中文说明](README_CN.md)
+
 This component integrates the official Elasticsearch PHP client with Hyperf's Guzzle client and
 provides a static facade for configured connections.
 

--- a/src/elasticsearch/README_CN.md
+++ b/src/elasticsearch/README_CN.md
@@ -1,0 +1,95 @@
+# Elasticsearch
+
+[English](README.md)
+
+此组件将 Elasticsearch 官方 PHP 客户端与 Hyperf 的 Guzzle 客户端集成，并为已配置的连接提供静态
+Facade。
+
+## 要求
+
+此包适用于 Hyperf 3.2，并依赖 8 或 9 版本的 `elasticsearch/elasticsearch`、`hyperf/config`、
+`hyperf/context` 和 `hyperf/guzzle`。它没有声明可选依赖。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/elasticsearch
+php bin/hyperf.php vendor:publish friendsofhyperf/elasticsearch
+```
+
+发布命令会创建 `config/autoload/elasticsearch.php`。
+
+## 配置
+
+发布的配置定义了 `default` 连接。`ELASTICSEARCH_HOST` 会按逗号拆分，因此可以包含多个主机。可以在
+`elasticsearch` 下添加其他命名连接：
+
+```php
+return [
+    'default' => [
+        'hosts' => explode(',', env('ELASTICSEARCH_HOST', '')),
+    ],
+    'analytics' => [
+        'hosts' => ['http://127.0.0.1:9200'],
+    ],
+];
+```
+
+对于 Facade 连接，`hosts` 可以是数组或逗号分隔的字符串。Facade 只读取 `hosts` 键；其他客户端行为
+需要通过 `ClientBuilderFactory` 和上游 Builder 配置。
+
+## 使用
+
+### 客户端 Builder 工厂
+
+`ClientBuilderFactory::create(array $options = [])` 会将 `$options` 传给 Hyperf 的
+`GuzzleClientFactory`，并返回尚未构建的上游 `ClientBuilder`。请先配置 Builder，再调用 `build()`：
+
+```php
+use FriendsOfHyperf\Elasticsearch\ClientBuilderFactory;
+
+class Foo
+{
+    public function __construct(protected ClientBuilderFactory $clientBuilderFactory)
+    {
+    }
+
+    public function handle()
+    {
+        $client = $this->clientBuilderFactory
+            ->create(['timeout' => 5])
+            ->setHosts(['http://127.0.0.1:9200'])
+            ->build();
+
+        return $client->info();
+    }
+}
+```
+
+此工厂不会读取 `config/autoload/elasticsearch.php`；必须显式设置主机和其他 Builder 选项。
+
+### Facade
+
+Facade 静态调用使用 `default` 连接。使用 `connection()` 选择命名连接：
+
+```php
+use FriendsOfHyperf\Elasticsearch\Facade\Elasticsearch;
+
+$info = Elasticsearch::info();
+$results = Elasticsearch::connection('analytics')->search([
+    'index' => 'articles',
+    'body' => [
+        'query' => [
+            'match_all' => (object) [],
+        ],
+    ],
+]);
+```
+
+每次 Facade 调用都会构建一个新客户端。如果所选连接缺失或为 `null`，组件会抛出包含连接名称的
+`InvalidArgumentException`。
+
+## 上游 API
+
+客户端方法、请求参数、响应对象、身份验证和其他 Builder 选项由已安装的
+`elasticsearch/elasticsearch` 版本提供。使用这些功能时，请查阅对应版本的上游客户端文档。

--- a/src/encryption/README.md
+++ b/src/encryption/README.md
@@ -1,5 +1,7 @@
 # Encryption
 
+[中文说明](README_CN.md)
+
 The encryption component provides authenticated encryption for values and strings in Hyperf.
 
 ## Installation

--- a/src/encryption/README_CN.md
+++ b/src/encryption/README_CN.md
@@ -1,0 +1,116 @@
+# Encryption
+
+[English](README.md)
+
+加密组件为 Hyperf 中的值和字符串提供带认证的加密。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/encryption
+```
+
+此包面向 Hyperf 3.2。仅在需要为加密闭包签名时安装可选的 `opis/closure` 包：
+
+```shell
+composer require opis/closure
+```
+
+## 配置
+
+发布配置文件：
+
+```shell
+php bin/hyperf.php vendor:publish friendsofhyperf/encryption
+```
+
+此命令会创建 `config/autoload/encryption.php`，其中包含以下设置：
+
+| 配置键 | 环境变量 | 默认值 |
+| --- | --- | --- |
+| `encryption.key` | `APP_KEY` | 内置的示例 `base64:` 密钥 |
+| `encryption.cipher` | `APP_CIPHER` | `AES-256-CBC` |
+
+使用组件前请替换内置示例密钥。`base64:` 前缀表示组件会先对其后的内容进行 Base64 解码，
+再校验密钥长度。可使用以下命令为默认 cipher 生成新密钥：
+
+```shell
+php -r "echo 'base64:'.base64_encode(random_bytes(32)).PHP_EOL;"
+```
+
+支持的 cipher 及原始密钥长度如下：
+
+| Cipher | 密钥长度 |
+| --- | --- |
+| `AES-128-CBC` | 16 字节 |
+| `AES-256-CBC` | 32 字节 |
+| `AES-128-GCM` | 16 字节 |
+| `AES-256-GCM` | 32 字节 |
+
+Cipher 名称不区分大小写。缺少密钥时会抛出
+`FriendsOfHyperf\Encryption\Exception\MissingKeyException`；不支持的 cipher 或错误的密钥长度会抛出
+`RuntimeException`。
+
+## 助手函数
+
+此包会自动加载带命名空间的 `encrypt()` 和 `decrypt()` 函数。使用前请先导入：
+
+```php
+use function FriendsOfHyperf\Encryption\decrypt;
+use function FriendsOfHyperf\Encryption\encrypt;
+
+$payload = encrypt(['id' => 1]);
+$value = decrypt($payload);
+```
+
+`encrypt(mixed $value, bool $serialize = true)` 默认会序列化值，
+`decrypt(string $payload, bool $unserialize = true)` 会执行对应的反向操作。处理不需要序列化的原始字符串时，
+请将两个函数的第二个参数都设为 `false`。
+
+## Encrypter API
+
+容器会将 `FriendsOfHyperf\Encryption\Encrypter`、
+`FriendsOfHyperf\Encryption\Contract\Encrypter` 和
+`FriendsOfHyperf\Encryption\Contract\StringEncrypter` 绑定到已配置的加密器。
+
+```php
+use FriendsOfHyperf\Encryption\Contract\StringEncrypter;
+
+class TokenService
+{
+    public function __construct(private StringEncrypter $encrypter)
+    {
+    }
+
+    public function encrypt(string $token): string
+    {
+        return $this->encrypter->encryptString($token);
+    }
+}
+```
+
+具体类 `Encrypter` 还公开 `encrypt()`、`decrypt()`、`getKey()`、`getAllKeys()`、
+`getPreviousKeys()`、`previousKeys()`，以及静态方法 `supported()` 和 `generateKey()`。
+
+## 密钥轮换
+
+轮换当前密钥后，可在具体加密器上配置旧的原始密钥，以解密已有 payload。新 payload 始终使用当前密钥。
+
+```php
+use FriendsOfHyperf\Encryption\Encrypter;
+
+$encrypter->previousKeys([
+    base64_decode('PREVIOUS_BASE64_KEY'),
+]);
+```
+
+每个旧密钥的长度都必须符合当前 cipher 的要求。
+
+## 失败与可选闭包签名
+
+加密失败会抛出 `FriendsOfHyperf\Encryption\Contract\EncryptException`。无效、被篡改或无法解密的
+payload 会抛出 `FriendsOfHyperf\Encryption\Contract\DecryptException`。
+
+安装 `opis/closure` 且已配置 `encryption.key` 时，启动监听器会向
+`Opis\Closure\SerializableClosure` 注册同一个解析后的密钥，用于闭包签名。正常的值或字符串加密不依赖
+`opis/closure`。

--- a/src/exception-event/README.md
+++ b/src/exception-event/README.md
@@ -1,5 +1,7 @@
 # friendsofhyperf/exception-event
 
+[中文说明](README_CN.md)
+
 [![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/exception-event)](https://packagist.org/packages/friendsofhyperf/exception-event)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/exception-event)](https://packagist.org/packages/friendsofhyperf/exception-event)
 [![License](https://img.shields.io/packagist/l/friendsofhyperf/exception-event)](https://github.com/friendsofhyperf/exception-event)

--- a/src/exception-event/README_CN.md
+++ b/src/exception-event/README_CN.md
@@ -1,0 +1,104 @@
+# Exception Event
+
+[English](README.md)
+
+此组件会在 Hyperf 的异常处理器调度器处理异常后派发 `ExceptionDispatched` 事件，并提供辅助函数，
+用于在不抛出异常的情况下手动报告异常。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/exception-event
+```
+
+组件的 `ConfigProvider` 会通过 Composer 包发现机制自动注册切面。切面和监听器依赖 Hyperf 的 AOP
+及事件调度器支持，标准 Hyperf 应用已提供这些支持；在最小化安装中，请确保
+`hyperf/di` 和 `hyperf/event` 可用。
+
+## 自动派发
+
+注册的切面会拦截 `Hyperf\ExceptionHandler\ExceptionHandlerDispatcher::dispatch()`。调度器正常返回后，
+组件会派发 `ExceptionDispatched` 事件，其中包含已处理的异常，以及上下文中的当前请求和响应。
+
+## 定义监听器
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listener;
+
+use FriendsOfHyperf\ExceptionEvent\Event\ExceptionDispatched;
+use Hyperf\Contract\StdoutLoggerInterface;
+use Hyperf\Event\Annotation\Listener;
+use Hyperf\Event\Contract\ListenerInterface;
+
+#[Listener]
+class ExceptionEventListener implements ListenerInterface
+{
+    public function __construct(private StdoutLoggerInterface $logger)
+    {
+    }
+
+    public function listen(): array
+    {
+        return [
+            ExceptionDispatched::class,
+        ];
+    }
+
+    /**
+     * @param ExceptionDispatched $event
+     */
+    public function process(object $event): void
+    {
+        $exception = $event->throwable;
+
+        $this->logger->error(sprintf(
+            'Exception: %s in %s:%d',
+            $exception->getMessage(),
+            $exception->getFile(),
+            $exception->getLine()
+        ));
+    }
+}
+```
+
+## 事件属性
+
+`FriendsOfHyperf\ExceptionEvent\Event\ExceptionDispatched` 公开以下属性：
+
+- `Throwable $throwable`：已处理或手动报告的异常。
+- `?ServerRequestInterface $request`：当前请求；不在请求上下文中时为 `null`。
+- `?ResponseInterface $response`：当前响应；不在响应上下文中时为 `null`。
+
+## 手动报告
+
+组件会自动加载三个命名空间辅助函数：
+
+- `report(string|Throwable $exception = 'RuntimeException', ...$parameters)`：报告异常。
+- `report_if($condition, string|Throwable $exception = 'RuntimeException', ...$parameters)`：
+  条件为真值时报告。
+- `report_unless($condition, string|Throwable $exception = 'RuntimeException', ...$parameters)`：
+  条件为假值时报告。
+
+```php
+use DomainException;
+
+use function FriendsOfHyperf\ExceptionEvent\report;
+use function FriendsOfHyperf\ExceptionEvent\report_if;
+use function FriendsOfHyperf\ExceptionEvent\report_unless;
+
+report(new DomainException('The operation failed.'));
+report('The operation failed.'); // 使用此消息报告 RuntimeException。
+report(DomainException::class, 'The operation failed.');
+
+report_if($shouldReport, 'The operation failed.');
+report_unless($operationSucceeded, 'The operation failed.');
+```
+
+`report()` 会直接派发 `ExceptionDispatched`，不会抛出异常。当第一个参数是已存在的异常类名时，
+其余参数会传给该异常的构造函数；其他字符串会成为 `RuntimeException` 的消息。
+
+`report_if()` 在条件为真值时报告，`report_unless()` 在条件为假值时报告。两个函数都会返回原始条件。

--- a/src/facade/README.md
+++ b/src/facade/README.md
@@ -1,5 +1,7 @@
 # Hyperf Facades
 
+[中文说明](README_CN.md)
+
 [![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/facade)](https://packagist.org/packages/friendsofhyperf/facade)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/facade)](https://packagist.org/packages/friendsofhyperf/facade)
 [![License](https://img.shields.io/packagist/l/friendsofhyperf/facade)](https://github.com/friendsofhyperf/facade)

--- a/src/facade/README_CN.md
+++ b/src/facade/README_CN.md
@@ -1,0 +1,102 @@
+# Facades
+
+[English](README.md)
+
+Facade 组件为常用的 Hyperf 服务提供静态代理。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/facade
+```
+
+基础包依赖 `friendsofhyperf/support`、`hyperf/context` 和 `hyperf/di`。大多数
+Facade 还需要可选依赖，请仅安装应用实际使用的 Facade 所需的包，例如：
+
+```shell
+composer require hyperf/config hyperf/logger
+```
+
+## 支持的 Facade
+
+| Facade | 容器访问器 | 额外依赖 |
+| --- | --- | --- |
+| `AMQP` | `Hyperf\Amqp\Producer` | `hyperf/amqp` |
+| `App`, `DI` | `Psr\Container\ContainerInterface` | 已包含（`hyperf/di`） |
+| `AsyncQueue` | `Hyperf\AsyncQueue\Driver\DriverFactory` | `hyperf/async-queue` |
+| `Cache` | `Psr\SimpleCache\CacheInterface` | `hyperf/cache` |
+| `Config` | `Hyperf\Contract\ConfigInterface` | `hyperf/config` |
+| `Cookie` | `Hyperf\HttpMessage\Cookie\CookieJarInterface` | `hyperf/framework` |
+| `Crypt` | `FriendsOfHyperf\Encryption\Encrypter` | `friendsofhyperf/encryption` |
+| `Event` | `Psr\EventDispatcher\EventDispatcherInterface` | `hyperf/framework` |
+| `File`, `Filesystem` | `League\Flysystem\Filesystem` | `hyperf/filesystem` |
+| `Kafka` | `Hyperf\Kafka\ProducerManager` | `hyperf/kafka` |
+| `Log` | `Hyperf\Logger\LoggerFactory` | `hyperf/logger` |
+| `Pipeline` | `FriendsOfHyperf\Support\Pipeline\Hub` | 已包含（`friendsofhyperf/support`） |
+| `Redis` | `Hyperf\Redis\Redis` | `hyperf/redis` |
+| `Request` | `Hyperf\HttpServer\Contract\RequestInterface` | `hyperf/framework` |
+| `Response` | `Hyperf\HttpServer\Contract\ResponseInterface` | `hyperf/framework` |
+| `Session` | `Hyperf\Contract\SessionInterface` | `hyperf/session` |
+| `Translator` | `Hyperf\Contract\TranslatorInterface` | `hyperf/translation` |
+| `Validator` | `Hyperf\Validation\Contract\ValidatorFactoryInterface` | `hyperf/validation` |
+| `View` | `Hyperf\View\RenderInterface` | `hyperf/view` |
+
+`App` 是 `DI` 的别名，`File` 是 `Filesystem` 的别名。
+
+## 配置与解析
+
+Hyperf 会自动发现此组件，但它的 `ConfigProvider` 不发布或合并任何配置。请按各
+Hyperf 组件的正常方式配置底层服务。
+
+除下方列出的组件特有方法外，对 Facade 的静态调用会转发给
+`ApplicationContext` 根据上表访问器解析出的对象。Facade 基类会缓存首次解析的
+对象。如果容器中不存在对应访问器，将抛出
+`Hyperf\Di\Exception\NotFoundException`。
+
+需要底层对象本身时，可以调用 `getFacadeRoot()`：
+
+```php
+use FriendsOfHyperf\Facade\Config;
+
+$config = Config::getFacadeRoot();
+$name = Config::get('app_name', 'hyperf');
+```
+
+每个代理可接受的方法是其底层访问器的公开方法。具体签名请参考相应组件文档。
+
+## 组件特有方法
+
+以下公开方法由 Facade 类自身实现：
+
+| Facade | 方法 | 行为 |
+| --- | --- | --- |
+| `AMQP` | `dispatch(ProducerMessageInterface $producerMessage): PendingAmqpProducerMessageDispatch` | 创建 AMQP 待调度对象的实例方法。 |
+| `AsyncQueue` | `dispatch(Closure\|JobInterface $job): PendingAsyncQueueDispatch` | 创建异步队列待调度对象的实例方法。 |
+| `AsyncQueue` | `push(JobInterface $job, int $delay = 0, ?string $pool = null)` | 使用指定队列池推送；当 `$pool` 为 `null` 时使用 `$job->getPoolName()`；文档返回类型为 `bool`。 |
+| `Cookie` | `has($key)` | 检查当前请求中的 Cookie，而不是 CookieJar；文档参数类型为 `string`，返回类型为 `bool`。 |
+| `Cookie` | `get($key, $default = null)` | 读取当前请求中的 Cookie；文档键类型为 `string`，返回类型为 `mixed`。 |
+| `Kafka` | `dispatch(ProduceMessage $produceMessage): PendingKafkaProducerMessageDispatch` | 创建 Kafka 待调度对象的实例方法。 |
+| `Kafka` | `send(ProduceMessage $produceMessage, ?string $pool = null): void` | 以单元素批次发送消息；未指定队列池时使用 `default`。 |
+| `Kafka` | `sendBatch($produceMessages, ?string $pool = null): void` | 发送文档类型为 `ProduceMessage[]` 的消息批次；未指定队列池时使用 `default`。 |
+| `Log` | `channel(string $name = 'hyperf', string $channel = 'default')` | 从 `LoggerFactory` 获取 `LoggerInterface`；其他 `Log` 静态调用使用这两个默认值。 |
+
+`AMQP::dispatch`、`AsyncQueue::dispatch` 和 `Kafka::dispatch` 被声明为实例方法。
+它们不是静态 Facade 代理方法。
+
+```php
+use FriendsOfHyperf\Facade\AsyncQueue;
+use FriendsOfHyperf\Facade\Cookie;
+use FriendsOfHyperf\Facade\Kafka;
+use FriendsOfHyperf\Facade\Log;
+
+AsyncQueue::push($job, delay: 5, pool: 'default');
+
+Kafka::send($message);
+Kafka::sendBatch([$firstMessage, $secondMessage], 'default');
+
+$token = Cookie::get('token');
+$hasToken = Cookie::has('token');
+
+Log::channel('hyperf', 'default')->info('Using an explicit logger channel');
+Log::info('Uses the hyperf/default logger');
+```

--- a/src/fast-paginate/README.md
+++ b/src/fast-paginate/README.md
@@ -1,5 +1,7 @@
 # Fast Paginate
 
+[中文说明](README_CN.md)
+
 > Forked from [hammerstonedev/fast-paginate](https://github.com/hammerstonedev/fast-paginate)
 
 ## About

--- a/src/fast-paginate/README_CN.md
+++ b/src/fast-paginate/README_CN.md
@@ -1,0 +1,81 @@
+# Fast Paginate
+
+[English](README.md)
+
+> Forked from [hammerstonedev/fast-paginate](https://github.com/hammerstonedev/fast-paginate)
+
+## 关于
+
+Fast Paginate 为 Hyperf 模型查询构造器和关系提供更快的 `limit`/`offset` 分页宏。它最适合偏移量较大的
+查询，但实际性能取决于数据和索引，请在应用中与标准分页器进行基准测试。
+
+该组件使用类似延迟连接的方式。它首先对仅选择模型主键以及排序所需选中别名的查询进行分页，然后通过第二次
+查询获取当前页主键对应的完整数据。两次数据查询的概念形式如下：
+
+```sql
+select contacts.id from contacts limit 15 offset 150000;
+select * from contacts where contacts.id in (...);
+```
+
+组件会执行独立查询，而不是把带限制的查询放入 `where in` 子查询中。`fastPaginate()` 还会执行长度感知
+分页器所需的标准计数查询；`simpleFastPaginate()` 不会执行该计数查询。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/fast-paginate
+```
+
+该组件依赖 Hyperf 3.2 系列软件包。无需配置：Hyperf 会发现组件的 `ConfigProvider`，并在应用启动时注册
+分页宏。
+
+## 使用
+
+### 模型查询构造器和关系
+
+模型查询构造器和关系均提供以下两个宏：
+
+```php
+User::query()->fastPaginate();
+User::query()->simpleFastPaginate();
+
+User::first()->posts()->fastPaginate();
+User::first()->posts()->simpleFastPaginate();
+```
+
+它们的签名与对应的 Hyperf 模型查询构造器分页方法一致：
+
+```php
+fastPaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null);
+simpleFastPaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null);
+```
+
+- `$perPage`：每页条目数；`null` 使用模型配置的每页条目数。
+- `$columns`：获取完整数据时查询的列。
+- `$pageName`：用于解析当前页的查询字符串参数名。
+- `$page`：明确指定的页码；`null` 时从当前请求解析。
+
+`fastPaginate()` 返回包含总数的长度感知分页器。`simpleFastPaginate()` 返回仅判断是否还有下一页的简单
+分页器。`BelongsToMany` 关系会保留已填充的中间表数据，同时也支持 `HasManyThrough` 关系。
+
+### Scout 查询构造器
+
+安装 `hyperf/scout` 后，组件还会在 `Hyperf\Scout\Builder` 上注册 `fastPaginate()`：
+
+```php
+User::search('Hyperf')->fastPaginate();
+```
+
+其签名为 `fastPaginate($perPage = null, $pageName = 'page', $page = null)`。该 Scout 宏会直接调用
+Scout 的标准 `paginate()` 方法，不使用数据库两次查询优化。本组件不强制依赖 `hyperf/scout`。
+
+## 自动回退
+
+当查询结构与优化方式不兼容时，组件会自动调用对应的标准 `paginate()` 或 `simplePaginate()` 方法。
+以下情况会触发回退：
+
+- 查询包含 `having`、`group by` 或 `union` 子句；
+- `$perPage` 为 `-1`；
+- 排序所需的选中表达式包含 `?` 绑定占位符。
+
+这些回退会保留分页行为，但不会获得快速分页优化。

--- a/src/grpc-validation/README.md
+++ b/src/grpc-validation/README.md
@@ -1,5 +1,7 @@
 # gRPC Validation
 
+[中文说明](README_CN.md)
+
 Validate a protobuf request before a Hyperf gRPC service method runs.
 
 ## Installation

--- a/src/grpc-validation/README_CN.md
+++ b/src/grpc-validation/README_CN.md
@@ -1,0 +1,99 @@
+# gRPC Validation
+
+[English](README.md)
+
+在 Hyperf gRPC 服务方法执行前验证 protobuf 请求。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/grpc-validation
+```
+
+该组件面向 Hyperf 3.2，并依赖 `hyperf/context`、`hyperf/di`、`hyperf/grpc-server`
+和 `hyperf/validation`。Composer 会安装这些依赖，包内的 `ConfigProvider` 会自动注册验证切面，
+无需发布组件配置文件。
+
+## 基本用法
+
+在 gRPC 服务方法上添加 `Validation`，并为 protobuf 消息字段定义 Hyperf 验证规则：
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use FriendsOfHyperf\GrpcValidation\Annotation\Validation;
+
+final class GreeterService
+{
+    #[Validation(
+        rules: [
+            'name' => 'required|string|max:10',
+            'message' => 'required|string|max:500',
+        ],
+        messages: [
+            'name.required' => 'The name field is required.',
+        ],
+    )]
+    public function sayHello(HiUser $user): HiReply
+    {
+        $reply = new HiReply();
+        $reply->setMessage('Hello World');
+        $reply->setUser($user);
+
+        return $reply;
+    }
+}
+```
+
+示例中的 `HiUser` 和 `HiReply` 是项目根据 `.proto` 定义生成的类。组件会验证传给被注解方法的
+第一个 `Google\Protobuf\Internal\Message` 参数。
+
+## 注解选项
+
+| 选项 | 类型 | 默认值 | 行为 |
+| --- | --- | --- | --- |
+| `rules` | `array` | `[]` | 未提供可解析的 `formRequest` 时使用的 Hyperf 验证规则。 |
+| `messages` | `array` | `[]` | 与 `rules` 一起使用的自定义验证消息。 |
+| `formRequest` | `string` | `''` | 可从容器解析的 `Hyperf\Validation\Request\FormRequest` 类，其 `rules()` 和 `messages()` 会替代注解内的值。 |
+| `scene` | `string` | `''` | 传给 `FormRequest::scene()`；为空时使用被注解的方法名。 |
+| `resolve` | `bool` | `true` | 为 `true` 时，验证失败会立即抛出 gRPC 验证异常。 |
+
+## 使用 Form Request
+
+需要复用规则时可传入 Form Request 类。该类必须能从容器解析：
+
+```php
+use App\Request\SayHelloRequest;
+use FriendsOfHyperf\GrpcValidation\Annotation\Validation;
+
+final class GreeterService
+{
+    #[Validation(formRequest: SayHelloRequest::class, scene: 'create')]
+    public function sayHello(HiUser $user): HiReply
+    {
+        // ...
+    }
+}
+```
+
+组件会先调用 `scene()`，再读取 `rules()` 和 `messages()`。它不会执行完整的 Form Request
+验证生命周期，因此不会使用 `authorize()`、`attributes()` 和 `withValidator()` 等方法，也不会调用
+Form Request 受保护的场景规则筛选方法。若要让 `scene` 影响所选规则，请在 `rules()` 中自行选择，
+例如读取 `getScene()`。
+
+如果未设置 `formRequest`，或无法从容器解析它，组件会回退到注解内的 `rules` 和 `messages`。
+
+## 验证行为
+
+- protobuf 消息会先通过 `serializeToJsonString()` 转换并解码为数组，再进行验证。
+- 只有规则、protobuf 消息参数和非空解码数据同时存在时才会验证。特别是，完全为空的 protobuf
+  消息会序列化为 `{}`、解码为空数组，从而跳过验证。
+- 执行验证时，解码数据会以 protobuf 消息类名为键存入 Hyperf 上下文，验证器会以
+  `Hyperf\Contract\ValidatorInterface` 为键存入上下文。
+- 使用默认的 `resolve: true` 时，验证失败会抛出
+  `FriendsOfHyperf\GrpcValidation\Exception\ValidationException`。该异常继承
+  `Hyperf\GrpcServer\Exception\GrpcException`，使用第一条验证错误作为消息，代码为 `422`，
+  并将 Hyperf 验证异常保留为前一个异常。
+- 使用 `resolve: false` 时，组件会创建并存储验证器，但不会自动检查它或在失败时抛出异常。

--- a/src/helpers/README.md
+++ b/src/helpers/README.md
@@ -1,5 +1,7 @@
 # Helpers
 
+[中文说明](README_CN.md)
+
 [![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/helpers)](https://packagist.org/packages/friendsofhyperf/helpers)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/helpers)](https://packagist.org/packages/friendsofhyperf/helpers)
 [![License](https://img.shields.io/packagist/l/friendsofhyperf/helpers)](https://github.com/friendsofhyperf/helpers)

--- a/src/helpers/README_CN.md
+++ b/src/helpers/README_CN.md
@@ -1,0 +1,101 @@
+# Helpers
+
+[English](README.md)
+
+此组件为 Hyperf 提供常用辅助函数。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/helpers
+```
+
+## 配置与自动加载
+
+此包通过 Composer 自动加载函数文件。其配置提供器不会注册或发布任何配置，因此无需额外设置。
+
+除 `call` 定义在 `FriendsOfHyperf\Helpers\Command` 命名空间外，其他函数均定义在
+`FriendsOfHyperf\Helpers` 命名空间。
+
+## 函数参考
+
+| 函数 | 签名与行为 |
+| --- | --- |
+| `app` | `app(null\|string\|callable $abstract = null, array $parameters = [])`：从容器解析服务；将可调用值转换为 `Closure`。 |
+| `base_path` | `base_path(string $path = ''): string`：返回 `BASE_PATH`，可追加路径。 |
+| `blank` / `filled` | 判断值是否为空或非空。模型、数字和布尔值不视为空。 |
+| `cache` | `cache(...$arguments)`：无参数时返回缓存服务；字符串参数用于读取；数组参数用于设置其中第一组键值。 |
+| `cookie` | 创建 `Cookie`；未传名称时返回 `CookieJarInterface` 服务。非零有效期以分钟为单位。 |
+| `class_namespace` | `class_namespace(object\|string $class): string`：返回类的命名空间。 |
+| `di` | `di(?string $abstract = null, array $parameters = [])`：解析或创建服务。无容器时直接实例化类；此时不传抽象名称会抛出异常。 |
+| `enum_value` | 返回有值枚举的值、纯枚举的名称或原值。空的非字符串值使用可选默认值。 |
+| `event` | `event(object $event)`：分发事件并返回分发器的结果。 |
+| `fluent` | `fluent(object\|array $value): Fluent`：创建 `Fluent` 对象。 |
+| `get_client_ip` | 返回 `x-real-ip` 请求头；不存在时返回请求的 `remote_addr`。 |
+| `info` | `info(string\|Stringable $message, array $context = [], bool $backtrace = false)`：写入 info 日志；可附加 `backtrace` 上下文值。 |
+| `literal` | 仅有一个位置参数时原样返回；使用命名参数时创建对象。 |
+| `logger` | 未传消息时返回默认日志记录器；否则写入 debug 日志，并可附加调用栈。 |
+| `logs` | `logs(string $name = 'hyperf', ?string $channel = null): LoggerInterface`：从 `LoggerFactory` 获取日志记录器。 |
+| `microseconds` / `milliseconds` / `months` / `weeks` | 创建指定单位的 `CarbonInterval`。 |
+| `object_get` | 使用点号读取嵌套对象属性；键为空时返回对象，属性不存在时求值并返回默认值。 |
+| `preg_replace_array` | 使用替换数组中的值依次替换每个正则匹配项。 |
+| `request` | 未传键时返回请求；支持字符串键、键数组和可选默认值。 |
+| `resolve` | `resolve(string\|callable $abstract, array $parameters = [])`：通过 `di` 解析服务，或将可调用值转换为 `Closure`。 |
+| `response` | 无参数时返回响应服务；否则使用字符串或 JSON 数组内容和状态码创建响应，并接受响应头数组。 |
+| `rescue` | 执行回调；捕获任意 `Throwable` 后返回备用值，可选异常处理器会接收该异常。 |
+| `session` | 未传键时返回会话；数组用于存储值，字符串键用于读取值。 |
+| `throw_if` / `throw_unless` | 根据条件抛出异常实例、异常类或以消息创建的 `RuntimeException`；不抛出时返回条件值。 |
+| `transform` | 仅在值非空时执行回调；否则返回或求值默认值。 |
+| `validator` | 无参数时返回验证器工厂；否则使用数据、规则、消息和自定义属性创建验证器。 |
+| `when` | 根据求值后的表达式返回选中的值或默认值；选中值为 `Closure` 时执行它。 |
+| `Command\call` | `call(string $command, array $arguments = []): int`：使用 `NullOutput` 运行控制台命令并返回退出码。 |
+
+## 可选依赖
+
+仅为应用实际使用的辅助函数或集成安装可选 Hyperf 包。此包建议使用以下兼容的 `~3.2.0`
+版本：
+
+| 包 | 相关用途 |
+| --- | --- |
+| `hyperf/cache` | `cache` |
+| `hyperf/di` | 基于容器的服务解析 |
+| `hyperf/framework` | 运行时服务绑定和 `Command\call` |
+| `hyperf/logger` | `info`、`logger` 和 `logs` |
+| `hyperf/session` | `session` |
+| `hyperf/validation` | `validator` |
+| `hyperf/amqp`、`hyperf/async-queue`、`hyperf/kafka` | 包元数据为相应集成建议的依赖；此组件中的函数未直接引用它们。 |
+
+## 示例
+
+使用命名空间函数前先导入：
+
+```php
+use function FriendsOfHyperf\Helpers\blank;
+use function FriendsOfHyperf\Helpers\literal;
+use function FriendsOfHyperf\Helpers\object_get;
+use function FriendsOfHyperf\Helpers\transform;
+
+$profile = literal(name: 'Taylor', contact: (object) ['email' => 'taylor@example.com']);
+
+object_get($profile, 'contact.email'); // taylor@example.com
+blank('  '); // true
+transform(5, fn (int $value) => $value * 2); // 10
+```
+
+`cache` 会根据参数选择行为：
+
+```php
+use function FriendsOfHyperf\Helpers\cache;
+
+$cache = cache();
+$value = cache('key', 'default');
+cache(['key' => 'value'], 60);
+```
+
+控制台命令使用单独的命名空间：
+
+```php
+use function FriendsOfHyperf\Helpers\Command\call;
+
+$exitCode = call('foo:bar', ['argument' => 'value']);
+```

--- a/src/http-client/README.md
+++ b/src/http-client/README.md
@@ -1,5 +1,7 @@
 # HTTP Client
 
+[中文说明](README_CN.md)
+
 An HTTP client component for Hyperf, ported from Laravel and backed by Guzzle.
 
 ## Installation

--- a/src/http-client/README_CN.md
+++ b/src/http-client/README_CN.md
@@ -1,0 +1,180 @@
+# HTTP Client
+
+[English](README.md)
+
+适用于 Hyperf 的 HTTP 客户端组件，移植自 Laravel，并由 Guzzle 提供底层支持。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/http-client guzzlehttp/guzzle:^7.6
+```
+
+`guzzlehttp/guzzle` 是本包建议安装的依赖，发送请求时必须可用。无需发布配置文件。
+
+## 发送请求
+
+使用 `Http` 门面发送 `GET`、`HEAD`、`POST`、`PUT`、`PATCH` 和 `DELETE`
+请求。请求体默认以 JSON 格式发送。
+
+```php
+use FriendsOfHyperf\Http\Client\Http;
+
+$response = Http::get('https://example.com/users', [
+    'page' => 1,
+]);
+
+$response = Http::post('https://example.com/users', [
+    'name' => 'Taylor',
+]);
+```
+
+在 HTTP 方法前链式调用方法以配置待发送请求：
+
+```php
+$response = Http::baseUrl('https://example.com')
+    ->withToken('token')
+    ->acceptJson()
+    ->timeout(10)
+    ->connectTimeout(3)
+    ->withHeaders(['X-Trace-Id' => 'trace-id'])
+    ->withUrlParameters(['user' => 1])
+    ->get('/users/{user}', ['active' => true]);
+```
+
+使用 `withUrlParameters()` 展开 URI 模板占位符。使用 `asForm()`、`attach()`
+或 `withBody()` 分别发送表单、多部分或原始请求体：
+
+```php
+$response = Http::withUrlParameters(['user' => 1])
+    ->get('https://example.com/users/{user}');
+
+$response = Http::asForm()->post('https://example.com/login', [
+    'email' => 'taylor@example.com',
+]);
+
+$response = Http::attach('avatar', fopen('/path/to/avatar.jpg', 'r'), 'avatar.jpg')
+    ->post('https://example.com/users/1/avatar');
+```
+
+默认连接超时为 10 秒，请求总超时为 30 秒。可使用 `withOptions()` 传入其他
+Guzzle 请求选项。仅在确实需要禁用 TLS 证书验证时使用 `withoutVerifying()`。
+
+## 重试
+
+`retry()` 的第一个参数可以是总尝试次数，也可以是以毫秒为单位的退避延迟数组。
+第二个参数可以是固定延迟或闭包。可选的第三个参数决定是否重试失败响应或连接异常。
+
+```php
+use FriendsOfHyperf\Http\Client\PendingRequest;
+use Throwable;
+
+$response = Http::retry(
+    [100, 200],
+    0,
+    fn (Throwable $exception, PendingRequest $request) => true,
+)->get('https://example.com');
+```
+
+默认情况下，重试耗尽后会抛出异常。将第四个参数设为 `false` 可返回最终失败响应。
+
+## 响应与异常
+
+请求返回 `FriendsOfHyperf\Http\Client\Response`。常用响应方法包括：
+
+```php
+$response->body();
+$response->json();
+$response->json('user.name');
+$response->object();
+$response->collect();
+$response->fluent();
+$response->header('Content-Type');
+$response->headers();
+$response->status();
+$response->effectiveUri();
+
+$response->successful();
+$response->redirect();
+$response->failed();
+$response->clientError();
+$response->serverError();
+```
+
+HTTP 4xx 和 5xx 响应默认不会抛出异常。在待发送请求或响应上调用 `throw()` 可抛出
+`RequestException`。连接失败会抛出 `ConnectionException`。
+
+```php
+use FriendsOfHyperf\Http\Client\RequestException;
+
+try {
+    $response = Http::get('https://example.com/users/1')->throw();
+} catch (RequestException $exception) {
+    $response = $exception->response;
+}
+```
+
+## 并发请求
+
+使用 `pool()` 并发发送请求。使用 `as()` 为响应指定键名。
+
+```php
+use FriendsOfHyperf\Http\Client\Http;
+use FriendsOfHyperf\Http\Client\Pool;
+
+$responses = Http::pool(function (Pool $pool) {
+    return [
+        $pool->as('user')->get('https://example.com/users/1'),
+        $pool->as('posts')->get('https://example.com/posts'),
+    ];
+});
+
+$responses['user']->status();
+```
+
+## 测试
+
+`fake()` 会拦截匹配的请求，并记录请求以供断言。调用 `preventStrayRequests()`
+可拒绝没有匹配假响应的请求。
+
+```php
+use FriendsOfHyperf\Http\Client\Http;
+use FriendsOfHyperf\Http\Client\Request;
+
+Http::preventStrayRequests();
+Http::fake([
+    'example.com/users/*' => Http::response(['name' => 'Taylor'], 200),
+]);
+
+$response = Http::get('https://example.com/users/1');
+
+Http::assertSent(fn (Request $request) => $request->url() === 'https://example.com/users/1');
+Http::assertSentCount(1);
+```
+
+重复请求需要返回不同响应时，可使用响应序列。序列耗尽后默认抛出
+`OutOfBoundsException`，除非配置了 `whenEmpty()` 或 `dontFailWhenEmpty()`。
+
+```php
+Http::fakeSequence('example.com/*')
+    ->push(['result' => 'first'])
+    ->pushStatus(404);
+```
+
+其他可用断言包括 `assertNotSent()`、`assertNothingSent()`、`assertSentInOrder()`
+和 `assertSequencesAreEmpty()`。
+
+## 中间件与事件
+
+使用 `withMiddleware()`、`withRequestMiddleware()` 或 `withResponseMiddleware()`
+添加单次请求中间件。`Factory` 还提供 `globalMiddleware()`、
+`globalRequestMiddleware()` 和 `globalResponseMiddleware()`。
+
+使用 PSR 事件分发器创建 `Factory` 时，组件会分发 `RequestSending`、
+`ResponseReceived` 和 `ConnectionFailed` 事件。
+
+## Laravel 兼容性
+
+本组件 API 基于 Laravel HTTP 客户端，但实际可用 API 和行为以本组件源码为准。
+可参阅 [Laravel HTTP Client 文档](https://laravel.com/docs/9.x/http-client)
+了解更多背景，并在使用前对照本组件确认 API。

--- a/src/ide-helper/README.md
+++ b/src/ide-helper/README.md
@@ -1,5 +1,7 @@
 # ide-helper
 
+[中文说明](README_CN.md)
+
 [![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/ide-helper)](https://packagist.org/packages/friendsofhyperf/ide-helper)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/ide-helper)](https://packagist.org/packages/friendsofhyperf/ide-helper)
 [![License](https://img.shields.io/packagist/l/friendsofhyperf/ide-helper)](https://github.com/friendsofhyperf/ide-helper)

--- a/src/ide-helper/README_CN.md
+++ b/src/ide-helper/README_CN.md
@@ -1,0 +1,95 @@
+# IDE Helper
+
+[English](README.md)
+
+IDE Helper 组件为 Hyperf 模型及使用 `Hyperf\Macroable\Macroable` 的类生成 PHP 助手文件。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/ide-helper
+```
+
+Hyperf 会发现组件的 `ConfigProvider`，并自动注册 `ide-helper:model` 和
+`ide-helper:macro` 命令。组件不会发布配置文件。
+
+## 模型助手
+
+为应用 `app` 目录下找到的具体模型类生成助手：
+
+```shell
+php ./bin/hyperf.php ide-helper:model
+```
+
+命令会在当前目录写入 `_ide_helper_models.php`。它会生成 `Eloquent` 助手，并根据类型转换、
+访问器、关联关系和软删除推断模型属性及方法。
+
+使用 `--name`（`-N`）修改输出文件；使用 `--ignore`（`-I`）排除以逗号分隔的完整模型类名：
+
+```shell
+php ./bin/hyperf.php ide-helper:model --name=storage/ide-models.php \
+  --ignore='App\Model\InternalModel,App\Model\LegacyModel'
+```
+
+安装建议依赖 `doctrine/dbal` 后，还可从数据库表字段推断属性：
+
+```shell
+composer require --dev doctrine/dbal
+```
+
+## 宏助手
+
+为已加载的宏生成助手：
+
+```shell
+php ./bin/hyperf.php ide-helper:macro
+```
+
+扫描 Composer 优化类映射前，命令会运行 `composer dump-autoload -o --no-scripts`。默认会在
+当前目录写入 `_ide_helper_macros.php`。
+
+使用 `--name`（`-N`）修改输出文件：
+
+```shell
+php ./bin/hyperf.php ide-helper:macro --name=storage/ide-macros.php
+```
+
+## 配置
+
+需要自定义生成行为时，请创建 `config/autoload/ide-helper.php`：
+
+```php
+<?php
+
+return [
+    'model' => [
+        'ignores' => [
+            App\Model\InternalModel::class,
+        ],
+        'camel_case_properties' => false,
+        'type_overrides' => [
+            'integer' => 'int',
+        ],
+        'custom_db_types' => [
+            'mysql' => [
+                'tinyint' => 'integer',
+            ],
+        ],
+    ],
+    'macro' => [
+        'namespaces' => [
+            'App\\',
+        ],
+        'rejects' => [
+            App\Example\RejectedMacroable::class,
+        ],
+    ],
+];
+```
+
+- `model.ignores`：模型生成时排除的完整模型类名。
+- `model.camel_case_properties`：将生成的属性名转换为驼峰格式，默认为 `false`。
+- `model.type_overrides`：将推断出的模型属性类型映射为替代类型。
+- `model.custom_db_types.<platform>`：将自定义数据库类型映射为 Doctrine 类型。
+- `macro.namespaces`：只扫描类名以其中任一前缀开头的类映射条目；空数组会扫描全部条目。
+- `macro.rejects`：宏生成时排除的完整类名。

--- a/src/ipc-broadcaster/README.md
+++ b/src/ipc-broadcaster/README.md
@@ -1,5 +1,7 @@
 # Ipc Broadcaster
 
+[中文说明](README_CN.md)
+
 Broadcast serializable messages between Hyperf server workers and user processes.
 
 ## Installation

--- a/src/ipc-broadcaster/README_CN.md
+++ b/src/ipc-broadcaster/README_CN.md
@@ -1,0 +1,138 @@
+# Ipc Broadcaster
+
+[English](README.md)
+
+在 Hyperf Server Worker 和用户进程之间广播可序列化消息。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/ipc-broadcaster
+```
+
+该包会自动注册 `ConfigProvider`，将 `BroadcasterInterface` 绑定到
+`AllProcessesBroadcaster`，并注册 Server Worker 接收消息所需的监听器。该组件没有需要发布的配置文件。
+
+该包的 `composer.json` 仅声明了 `hyperf/event ~3.2.0`，且没有声明可选依赖。请在提供广播器所需
+Server、Process、容器和 DI 运行时类的 Hyperf Server 应用中使用。
+
+## 广播消息
+
+`broadcast()` 函数接受 `IpcMessageInterface` 实例或闭包。默认通过
+`AllProcessesBroadcaster` 将消息发送到其他所有 Server Worker 和所有已注册的协程用户进程。
+
+### 类消息
+
+继承 `IpcMessage` 并实现 `handle()`。`IpcMessage` 还通过
+`InteractsWithFromWorkerId` 提供 `getFromWorkerId()` 和 `setFromWorkerId()`。Server Worker
+收到消息时，`getFromWorkerId()` 包含发送方的 Worker ID。
+
+```php
+<?php
+
+namespace App\Broadcasting;
+
+use FriendsOfHyperf\IpcBroadcaster\IpcMessage;
+
+use function FriendsOfHyperf\IpcBroadcaster\broadcast;
+
+class FooMessage extends IpcMessage
+{
+    public function __construct(private string $foo)
+    {
+    }
+
+    public function handle(): void
+    {
+        echo $this->foo;
+    }
+}
+
+broadcast(new FooMessage('bar'));
+```
+
+消息对象及其属性必须可序列化，才能跨进程传输。
+
+### 闭包消息
+
+闭包在广播前会包装为 `ClosureIpcMessage` 并进行序列化，因此闭包捕获的值也必须可序列化。在常规
+Hyperf DI 环境中，有类型声明的闭包参数可从容器解析。
+
+```php
+use function FriendsOfHyperf\IpcBroadcaster\broadcast;
+
+broadcast(function () {
+    echo 'Hello world';
+});
+```
+
+## 选择目标
+
+注入 `BroadcasterInterface` 可使用默认的全进程广播行为，也可以构造特定广播器来选择目标：
+
+```php
+use FriendsOfHyperf\IpcBroadcaster\ServerBroadcaster;
+use FriendsOfHyperf\IpcBroadcaster\UserProcessesBroadcaster;
+
+$serverBroadcaster = new ServerBroadcaster($container, id: 1);
+$serverBroadcaster->broadcast($message);
+
+$userProcessBroadcaster = new UserProcessesBroadcaster(name: 'reporting', id: 0);
+$userProcessBroadcaster->broadcast($message);
+```
+
+`ServerBroadcaster` 接受容器和可选的 Worker ID；未传 ID 时，会发送到当前 Worker 之外的所有
+Server Worker。`UserProcessesBroadcaster` 接受可选的进程名称和进程 ID；两者均未传时，会发送到
+Hyperf `ProcessCollector` 收集的所有已注册进程。
+
+## 在用户进程中处理消息
+
+组件会为 Server Worker 收到的消息自动调用 `handle()`。在用户进程中，Hyperf 会派发
+`Hyperf\Process\Event\PipeMessage`，组件不会自动调用其中消息的 `handle()` 方法。需要让用户进程
+执行消息时，请注册监听器：
+
+```php
+use FriendsOfHyperf\IpcBroadcaster\Contract\IpcMessageInterface;
+use Hyperf\Event\Contract\ListenerInterface;
+use Hyperf\Process\Event\PipeMessage;
+
+class UserProcessPipeMessageListener implements ListenerInterface
+{
+    public function listen(): array
+    {
+        return [PipeMessage::class];
+    }
+
+    public function process(object $event): void
+    {
+        if ($event instanceof PipeMessage && $event->data instanceof IpcMessageInterface) {
+            $event->data->handle();
+        }
+    }
+}
+```
+
+## 在当前 Worker 中运行
+
+广播默认不会在当前 Server Worker 中执行。给消息添加 `RunsInCurrentWorker` 后，会先在当前 Worker
+中调用一次 `handle()`，再发送到所选目标：
+
+```php
+use FriendsOfHyperf\IpcBroadcaster\IpcMessage;
+use FriendsOfHyperf\IpcBroadcaster\Traits\RunsInCurrentWorker;
+
+class RefreshMessage extends IpcMessage
+{
+    use RunsInCurrentWorker;
+
+    public function handle(): void
+    {
+        // Refresh local state.
+    }
+}
+```
+
+## 协程服务器限制
+
+触发 `MainCoroutineServerStart` 后，跨进程广播会被禁用，广播器调用不会发送消息便直接返回。使用
+`RunsInCurrentWorker` 的消息仍会在广播器返回前在本地执行一次。

--- a/src/lock/README_CN.md
+++ b/src/lock/README_CN.md
@@ -1,66 +1,117 @@
-# 原子锁
+# Lock
 
-Hyperf 原子锁组件。[English Document](README.md)
+[English](README.md)
+
+Hyperf 原子锁组件。
 
 ## 安装
-
-- 安装依赖
 
 ```shell
 composer require friendsofhyperf/lock
 ```
 
-- 发布配置
+默认驱动使用 Redis。请根据使用的驱动安装对应的可选依赖：
+
+| 驱动 | 配置名称 | 可选依赖 |
+| --- | --- | --- |
+| `RedisLock` | `default` | `hyperf/redis` |
+| `FileSystemLock` | `file` | `hyperf/cache` |
+| `DatabaseLock` | `database` | `hyperf/db-connection` |
+| `CoroutineLock` | `co` | 无 |
+| `CacheLock` | 未发布 | `hyperf/cache` |
+
+发布配置文件：
 
 ```shell
 php bin/hyperf.php vendor:publish friendsofhyperf/lock -i config
 ```
 
-## 使用
+使用数据库驱动时，还需要发布并执行锁迁移：
 
-你可以使用 `lock()` 方法来创建和管理锁：
+```shell
+php bin/hyperf.php vendor:publish friendsofhyperf/lock -i migrations
+php bin/hyperf.php migrate
+```
+
+运行发布的迁移前，请将其中的 `value` 列改为 `owner`。当前 `DatabaseLock` 实现读写的是
+`owner` 列。
+
+## 配置
+
+发布的 `config/autoload/lock.php` 包含 `default`、`file`、`database` 和 `co` 配置。每项配置
+用于选择驱动类，并将其中的 `constructor` 选项传给驱动。`lock()` 和
+`LockFactory::make()` 的第四个参数是配置名称，而不是驱动类名。
+
+所选的 `lock.<driver>` 配置不存在时，工厂会抛出 `InvalidArgumentException`。你也可以新增
+自定义配置，其驱动须实现 `FriendsOfHyperf\Lock\Driver\LockInterface`。
+
+## 创建锁
+
+导入并调用带命名空间的辅助函数：
 
 ```php
-$lock = lock($name = 'foo', $seconds = 10, $owner = null);
+use function FriendsOfHyperf\Lock\lock;
+
+$lock = lock(name: 'foo', seconds: 10, owner: null, driver: 'default');
 
 if ($lock->get()) {
-    // 获取锁定10秒...
-
-    $lock->release();
+    try {
+        // The lock was acquired.
+    } finally {
+        $lock->release();
+    }
 }
 ```
 
-`get` 方法也可以接收一个闭包。在闭包执行之后，将会自动释放锁：
+不传名称调用 `lock()` 时返回 `LockFactory`，否则返回 `LockInterface` 实例。参数如下：
+
+- `name`：锁名称。
+- `seconds`：请求的锁有效期秒数，默认为 `0`。
+- `owner`：可选的所有者标识；省略时会随机生成。
+- `driver`：`lock` 下的配置名称，默认为 `default`。
+
+TTL 行为取决于驱动。特别是当 `seconds` 为 `0` 或负数时，`DatabaseLock` 会存储一天的
+过期时间。
+
+## 锁操作
+
+`LockInterface` 公开 `get()`、`block()`、`release()`、`owner()`、`forceRelease()`、
+`refresh()`、`isExpired()` 和 `getRemainingLifetime()`。
+
+`get()` 只尝试获取一次；未传回调时返回布尔值。传入回调时，它会返回回调结果，并在
+`finally` 块中释放锁：
 
 ```php
-lock('foo')->get(function () {
-    // 获取无限期锁并自动释放...
+$result = lock('foo', 10)->get(function () {
+    return 'completed';
 });
 ```
 
-如果你在请求时锁无法使用，你可以控制等待指定的秒数。如果在指定的时间限制内无法获取锁，则会抛出 `FriendsOfHyperf\Lock\Exception\LockTimeoutException`
+`block()` 会重试，直到获取锁或达到等待时限；超时时抛出 `LockTimeoutException`。传入回调
+时也会自动释放锁：
 
 ```php
 use FriendsOfHyperf\Lock\Exception\LockTimeoutException;
 
-$lock = lock('foo', 10);
-
 try {
-    $lock->block(5);
-
-    // 等待最多5秒后获取的锁...
-} catch (LockTimeoutException $e) {
-    // 无法获取锁...
-} finally {
-    $lock->release();
+    $result = lock('foo', 10)->block(5, function () {
+        return 'completed';
+    });
+} catch (LockTimeoutException $exception) {
+    // The lock was not acquired within five seconds.
 }
-
-lock('foo', 10)->block(5, function () {
-    // 等待最多5秒后获取的锁...
-});
 ```
 
-注解方式
+`release()` 只释放当前所有者持有的锁，`forceRelease()` 会忽略所有权。仅当驱动支持时，
+`refresh($ttl)` 才能刷新过期时间；TTL 不为正数时返回 `false`。`isExpired()` 和
+`getRemainingLifetime()` 返回锁实例跟踪的过期状态。
+
+## 注解
+
+### 属性注入
+
+`#[Lock]` 用于属性，并在应用启动时注入锁实例。参数为 `name`、`seconds`、`owner` 和
+`driver`。
 
 ```php
 use FriendsOfHyperf\Lock\Annotation\Lock;
@@ -68,14 +119,28 @@ use FriendsOfHyperf\Lock\Driver\LockInterface;
 
 class Foo
 {
-    #[Lock(name:"foo", seconds:10)]
+    #[Lock(name: 'foo', seconds: 10, driver: 'default')]
     protected LockInterface $lock;
+}
+```
 
-    public function bar()
+### 阻塞方法
+
+`#[Blockable]` 用于方法。当 `seconds` 大于 `0` 时，它会创建锁并最多等待 `seconds` 秒获取
+锁，然后在方法返回或抛出异常后自动释放。`ttl` 是锁有效期，`driver` 用于选择锁配置。
+`prefix` 和 `value` 会结合方法参数格式化为锁名称。
+
+`Blockable` 使用 `Hyperf\Cache\Helper\StringHelper`，因此使用此注解前需安装
+`hyperf/cache`。
+
+```php
+use FriendsOfHyperf\Lock\Annotation\Blockable;
+
+class Foo
+{
+    #[Blockable(prefix: 'user', value: '#{id}', seconds: 5, ttl: 30, driver: 'default')]
+    public function update(int $id): void
     {
-        $this->lock->get(function () {
-            // 获取无限期锁并自动释放...
-        });
     }
 }
 ```

--- a/src/macros/README.md
+++ b/src/macros/README.md
@@ -1,5 +1,7 @@
 # Macros
 
+[中文说明](README_CN.md)
+
 [![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/macros)](https://packagist.org/packages/friendsofhyperf/macros)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/macros)](https://packagist.org/packages/friendsofhyperf/macros)
 [![License](https://img.shields.io/packagist/l/friendsofhyperf/macros)](https://github.com/friendsofhyperf/macros)

--- a/src/macros/README_CN.md
+++ b/src/macros/README_CN.md
@@ -1,0 +1,150 @@
+# Macros
+
+[English](README.md)
+
+该组件为 Hyperf 的集合、上下文、请求和字符串类添加常用宏。组件的 `ConfigProvider` 会在应用启动时
+自动注册 mixin，无需发布配置文件。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/macros
+```
+
+## 可选依赖
+
+已注册的宏会直接使用以下可选包：
+
+- `hyperf/http-server`：所有 `Request` 宏。
+- `league/commonmark`：`Str::markdown`、`Str::inlineMarkdown` 及对应的 `Stringable` 方法。
+- `voku/portable-ascii`：`Str::transliterate`。
+- `friendsofhyperf/encryption`：`Stringable::encrypt` 和 `Stringable::decrypt`；同时需要配置
+  encryption 组件。
+
+`composer.json` 还建议安装用于生成 UUID 的 `ramsey/uuid`、用于生成 ULID 的 `symfony/uid` 和
+`opis/closure`。当前 mixin 源码不会直接调用这三个包。
+
+## 支持方法
+
+### Hyperf\Collection\Arr
+
+- `Arr::arrayable($value)`
+- `Arr::array(ArrayAccess|array $array, null|string|int $key, ?array $default = null)`
+- `Arr::boolean(ArrayAccess|array $array, null|string|int $key, ?bool $default = null)`
+- `Arr::every($array, callable $callback)`
+- `Arr::float(ArrayAccess|array $array, null|string|int $key, ?float $default = null)`
+- `Arr::from($items)`
+- `Arr::hasAll($array, $keys)`
+- `Arr::integer(ArrayAccess|array $array, null|string|int $key, ?int $default = null)`
+- `Arr::some($array, callable $callback)`
+- `Arr::sortByMany($array, $comparisons = [])`
+- `Arr::string(ArrayAccess|array $array, null|string|int $key, ?string $default = null)`
+
+带类型的读取方法支持点号路径；解析出的值不符合目标类型时会抛出 `InvalidArgumentException`。
+`Arr::from` 可将受支持的数组、Enumerable/Arrayable 对象、可遍历对象、支持 JSON 的对象和普通对象
+转换为数组，但拒绝标量值。
+
+### Hyperf\Collection\Collection
+
+- `Collection::collapseWithKeys()`
+
+### Hyperf\Collection\LazyCollection
+
+- `LazyCollection::collapseWithKeys()`
+
+`collapseWithKeys` 在保留键的同时展平嵌套数组或集合。非数组和非集合值会被忽略，后出现的重复键会
+覆盖先前的值。
+
+### Hyperf\Context\Context
+
+- `Context::decrement(string $id, int $step = 1, ?int $coroutineId = null)`
+- `Context::increment(string $id, int $step = 1, ?int $coroutineId = null)`
+
+两个方法都通过 `Context::override` 更新选定上下文中的值。缺失的值会先按零处理，再应用步长。
+
+### Hyperf\HttpServer\Request
+
+- `Request::allFiles()`
+- `Request::anyFilled($keys)`
+- `Request::boolean(string $key = '', $default = false)`
+- `Request::collect($key = null)`
+- `Request::date(string $key, $format = null, $tz = null)`
+- `Request::enum($key, $enumClass)`
+- `Request::except($keys)`
+- `Request::exists($key)`
+- `Request::fake($closure = null)`
+- `Request::filled($key)`
+- `Request::float($key, $default = null)`
+- `Request::fluent($key = null)`
+- `Request::getHost()`
+- `Request::getHttpHost()`
+- `Request::getPort()`
+- `Request::getPsrRequest()`
+- `Request::getScheme()`
+- `Request::getSchemeAndHttpHost()`
+- `Request::hasAny($keys)`
+- `Request::host()`
+- `Request::httpHost()`
+- `Request::integer($key, $default = null)`
+- `Request::isEmptyString($key)`
+- `Request::isJson()`
+- `Request::isNotFilled($key)`
+- `Request::isSecure()`
+- `Request::keys()`
+- `Request::merge(array $input)`
+- `Request::mergeIfMissing(array $input)`
+- `Request::missing($key)`
+- `Request::only($keys)`
+- `Request::schemeAndHttpHost()`
+- `Request::str($key, $default = null)`
+- `Request::string($key, $default = null)`
+- `Request::validate(array $rules, ...$params)`
+- `Request::validateWithBag($errorBag, $rules, ...$params)`
+- `Request::wantsJson()`
+- `Request::whenFilled($key, callable $callback, ?callable $default = null)`
+- `Request::whenHas($key, callable $callback, ?callable $default = null)`
+
+`Request::fake` 创建独立的 PSR-7 `ServerRequest`，并可选择将其传给回调。`merge` 和
+`mergeIfMissing` 会更新当前上下文中存储的解析后输入。`validate` 和 `validateWithBag` 会从容器
+解析 Hyperf 的 `ValidatorFactoryInterface`。
+
+### Hyperf\Stringable\Str
+
+- `Str::createUuidsNormally()`
+- `Str::createUuidsUsing(?callable $factory = null)`
+- `Str::deduplicate(string $string, string $character = ' ')`
+- `Str::doesntEndWith($haystack, $needles)`
+- `Str::doesntStartWith($haystack, $needles)`
+- `Str::inlineMarkdown($string, array $options = [])`
+- `Str::markdown($string, array $options = [], array $extensions = [])`
+- `Str::transliterate($string, $unknown = '?', $strict = false)`
+
+### Hyperf\Stringable\Stringable
+
+- `Stringable::decrypt(bool $serialize = false)`
+- `Stringable::deduplicate(string $character = ' ')`
+- `Stringable::doesntEndWith($needles)`
+- `Stringable::doesntStartWith($needles)`
+- `Stringable::encrypt(bool $serialize = false)`
+- `Stringable::hash(string $algorithm)`
+- `Stringable::inlineMarkdown(array $options = [])`
+- `Stringable::markdown(array $options = [], array $extensions = [])`
+- `Stringable::toHtmlString()`
+- `Stringable::whenIsAscii($callback, $default = null)`
+
+多数 `Stringable` 转换宏返回新的 `Stringable` 实例，因此可以链式调用。两个 `doesnt*` 方法返回
+布尔值，`toHtmlString` 返回 `FriendsOfHyperf\Support\HtmlString`。
+
+## 示例
+
+```php
+use Hyperf\Collection\Arr;
+use Hyperf\Context\Context;
+use Hyperf\Stringable\Str;
+
+$users = Arr::sortByMany($users, ['name', ['age', false]]);
+
+Context::increment('processed');
+
+$slug = Str::deduplicate('docs///macros', '/');
+```

--- a/src/mail/README.md
+++ b/src/mail/README.md
@@ -1,5 +1,7 @@
 # Mail
 
+[中文说明](README_CN.md)
+
 The mail component sends view, Markdown, HTML, and plain-text messages through Symfony Mailer
 transports.
 

--- a/src/mail/README_CN.md
+++ b/src/mail/README_CN.md
@@ -1,0 +1,154 @@
+# Mail
+
+[English](README.md)
+
+Mail 组件通过 Symfony Mailer 传输发送视图、Markdown、HTML 和纯文本邮件。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/mail
+php bin/hyperf.php vendor:publish friendsofhyperf/mail
+```
+
+发布组件会创建 `config/autoload/mail.php`，并将邮件视图组件复制到 `storage/views/mail`。
+如果应用尚无 Hyperf 视图配置，请另行发布：
+
+```shell
+php bin/hyperf.php vendor:publish hyperf/view
+```
+
+组件要求 PHP 8.1 或更高版本。部分功能需要可选依赖：
+
+- `hyperf/devtool` 提供 `gen:mail` 命令。
+- `aws/aws-sdk-php` 是 `ses` 和 `ses-v2` 传输的必要依赖。
+- Symfony API 邮件传输需要 `symfony/http-client`。
+- `symfony/mailgun-mailer` 和 `symfony/postmark-mailer` 提供对应传输。
+
+## 配置
+
+发布的配置默认使用 `log` mailer。通过 `MAIL_MAILER` 选择 mailer，并在 `mail.mailers` 下配置。
+支持的传输包括 `smtp`、`sendmail`、`mail`、`mailgun`、`ses`、`ses-v2`、`postmark`、`log`、
+`array`、`failover` 和 `roundrobin`。可使用 `Mail::extend()` 注册自定义传输。
+
+```php
+// config/autoload/mail.php
+use function Hyperf\Support\env;
+
+return [
+    'default' => env('MAIL_MAILER', 'log'),
+    'mailers' => [
+        'smtp' => [
+            'transport' => 'smtp',
+            'url' => env('MAIL_URL'),
+            'host' => env('MAIL_HOST', '127.0.0.1'),
+            'port' => env('MAIL_PORT', 2525),
+            'encryption' => env('MAIL_ENCRYPTION', 'tls'),
+            'username' => env('MAIL_USERNAME'),
+            'password' => env('MAIL_PASSWORD'),
+            'timeout' => null,
+            'local_domain' => env('MAIL_EHLO_DOMAIN'),
+            'scheme' => env('MAIL_SCHEME', 'smtp'),
+        ],
+        'log' => [
+            'transport' => 'log',
+            'group' => env('MAIL_LOG_GROUP', 'default'),
+            'name' => env('MAIL_LOG_NAME', 'mail'),
+        ],
+    ],
+    'from' => [
+        'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
+        'name' => env('MAIL_FROM_NAME', 'Example'),
+    ],
+    'markdown' => [
+        'theme' => env('MAIL_MARKDOWN_THEME', 'default'),
+        'paths' => [
+            BASE_PATH . '/storage/views/mail',
+        ],
+    ],
+];
+```
+
+mailer 专属的 `from`、`reply_to`、`to` 或 `return_path` 会覆盖对应全局地址。全局 `to` 地址还会在
+发送前移除原始 To、Cc 和 Bcc 收件人，适合开发环境使用。
+
+## 创建 Mailable
+
+安装 `hyperf/devtool` 后，可生成基于视图的 mailable；使用 `--markdown` 会同时创建 Markdown 模板：
+
+```shell
+php bin/hyperf.php gen:mail TestMail
+php bin/hyperf.php gen:mail TestMail --markdown
+```
+
+`Envelope` 定义地址、主题、标签、元数据和 Symfony 消息回调。`Content` 接受 `view`（或其 `html`
+别名）、`text`、`markdown`、`htmlString` 和 `with`。mailable 中声明的 public 属性也会暴露给视图。
+
+```php
+namespace App\Mail;
+
+use FriendsOfHyperf\Mail\Mailable;
+use FriendsOfHyperf\Mail\Mailable\Attachment;
+use FriendsOfHyperf\Mail\Mailable\Content;
+use FriendsOfHyperf\Mail\Mailable\Envelope;
+
+class TestMail extends Mailable
+{
+    public function __construct(public readonly string $name)
+    {
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(subject: 'Test Mail');
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'mail.test',
+            with: ['name' => $this->name],
+        );
+    }
+
+    public function attachments(): array
+    {
+        return [
+            Attachment::fromPath(BASE_PATH . '/storage/report.pdf')
+                ->as('report.pdf')
+                ->withMime('application/pdf'),
+        ];
+    }
+}
+```
+
+附件还可通过 `Attachment::fromData()`、`fromStorage()` 或 `fromStorageDisk()` 创建。可复用的附件
+对象可以实现 `FriendsOfHyperf\Mail\Contract\Attachable`。
+
+## 发送邮件
+
+`Mail::mailer()` 选择已配置的 mailer；省略参数时使用 `mail.default`。`to()`、`cc()` 和 `bcc()`
+返回待发送邮件对象，其 `send()` 接受 `FriendsOfHyperf\Mail\Contract\Mailable`。发送成功时返回
+`SentMessage`；当 `MessageSending` 监听器中止发送时返回 `null`。
+
+```php
+use App\Mail\TestMail;
+use FriendsOfHyperf\Mail\Facade\Mail;
+
+Mail::mailer('smtp')
+    ->to('user@example.com', 'Example User')
+    ->cc('team@example.com')
+    ->send(new TestMail('Hyperf'));
+```
+
+对于无需 mailable 类的邮件，mailer 还提供 `html()`、`raw()`、`plain()`，以及接受视图名或视图数组的
+`send()`。回调会收到 `FriendsOfHyperf\Mail\Message`，其未知方法会转发给底层 Symfony `Email`。
+
+```php
+use FriendsOfHyperf\Mail\Facade\Mail;
+use FriendsOfHyperf\Mail\Message;
+
+Mail::html('<h1>Hello</h1>', function (Message $message) {
+    $message->to('user@example.com')->subject('Greeting');
+});
+```

--- a/src/model-factory/README.md
+++ b/src/model-factory/README.md
@@ -1,5 +1,7 @@
 # model-factory
 
+[中文说明](README_CN.md)
+
 [![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/model-factory)](https://packagist.org/packages/friendsofhyperf/model-factory)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/model-factory)](https://packagist.org/packages/friendsofhyperf/model-factory)
 [![License](https://img.shields.io/packagist/l/friendsofhyperf/model-factory)](https://github.com/friendsofhyperf/model-factory)

--- a/src/model-factory/README_CN.md
+++ b/src/model-factory/README_CN.md
@@ -1,0 +1,102 @@
+# Model Factory
+
+[English](README.md)
+
+此组件用于加载 Hyperf 模型工厂定义，并提供
+`FriendsOfHyperf\ModelFactory\factory()` 辅助函数。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/model-factory --dev
+```
+
+此包要求 PHP `^8.0`、Faker，以及 Hyperf 的 config、database 和 stringable 组件，
+没有声明可选依赖。
+
+发布配置和示例工厂文件：
+
+```shell
+php bin/hyperf.php vendor:publish friendsofhyperf/model-factory
+```
+
+该命令会创建 `config/autoload/model_factory.php` 和 `factories/model_factory.php`。
+
+## 配置
+
+```php
+<?php
+
+declare(strict_types=1);
+
+return [
+    'path' => BASE_PATH . '/factories/',
+];
+```
+
+从容器解析 `Hyperf\Database\Model\Factory` 时，会加载配置的目录。仅当目录存在时，
+才会加载其中的 PHP 文件。此组件使用 `en_US` 区域设置创建 Faker。
+
+## 定义工厂
+
+配置目录中的文件可以使用 `$factory` 变量：
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use App\Model\User;
+use Faker\Generator;
+
+$factory->define(User::class, function (Generator $faker) {
+    return [
+        'name' => $faker->name,
+        'email' => $faker->unique()->safeEmail,
+    ];
+});
+```
+
+可以向 `define()` 传入第三个参数来定义命名工厂：
+
+```php
+$factory->define(User::class, function (Generator $faker) {
+    return ['name' => 'Administrator'];
+}, 'admin');
+
+$factory->state(User::class, 'suspended', ['active' => false]);
+```
+
+## 使用辅助函数
+
+使用前先导入辅助函数：
+
+```php
+use App\Model\User;
+
+use function FriendsOfHyperf\ModelFactory\factory;
+
+factory(User::class)->create();
+factory(User::class)->create(['name' => 'Admin']);
+factory(User::class, 20)->create();
+factory(User::class, 'admin')->create();
+factory(User::class, 'admin', 5)->create();
+```
+
+辅助函数接收模型类，之后可以传入数量，或传入命名工厂及可选数量。
+第二个参数为字符串时，它会选择命名工厂，而不是应用工厂状态。
+应在返回的构建器上应用已注册的状态：
+
+```php
+factory(User::class)->state('suspended')->create();
+```
+
+辅助函数返回 `Hyperf\Database\Model\FactoryBuilder`。常用的终止方法包括：
+
+- `make()`：构建模型但不持久化。
+- `create()`：构建并持久化模型。
+- `raw()`：返回生成的属性数组。
+
+未指定数量时，这些方法返回单个结果；指定数量时，返回模型集合或原始属性数组列表。
+传给这些方法的属性数组会覆盖生成的值。如果应用容器不可用，
+`factory()` 返回 `null`。

--- a/src/model-hashids/README.md
+++ b/src/model-hashids/README.md
@@ -1,5 +1,7 @@
 # model-hashids
 
+[中文说明](README_CN.md)
+
 > Using hashids instead of integer ids in urls and list items can be more
 appealing and clever. For more information visit [hashids.org](https://hashids.org/).
 

--- a/src/model-hashids/README_CN.md
+++ b/src/model-hashids/README_CN.md
@@ -1,0 +1,157 @@
+# Model Hashids
+
+[English](README.md)
+
+Model Hashids 按需编码和解码模型主键。hashid 不会存储到数据库中，因此查询仍然使用模型的主键列。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/model-hashids
+```
+
+此组件依赖 `hashids/hashids`，以及 Hyperf 3.2 的 config、database 和 stringable 组件。仅在需要
+自定义 hashid 设置时发布配置文件：
+
+```shell
+php bin/hyperf.php vendor:publish friendsofhyperf/model-hashids
+```
+
+## 设置
+
+在模型中使用 `HasHashid`。如果隐式路由绑定也需要使用 hashid，再添加 `HashidRouting`：
+
+```php
+use FriendsOfHyperf\ModelHashids\Concerns\HasHashid;
+use FriendsOfHyperf\ModelHashids\Concerns\HashidRouting;
+use Hyperf\Database\Model\Model;
+
+class Item extends Model
+{
+    use HasHashid;
+    use HashidRouting;
+}
+```
+
+## 配置
+
+发布后的文件为 `config/autoload/hashids.php`。`default` 用于选择连接，每个连接可设置 `salt`、
+`length` 和 `alphabet`：
+
+```php
+return [
+    'default' => 'main',
+    'connections' => [
+        'main' => [
+            'salt' => '',
+            'length' => 0,
+            'alphabet' => 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890',
+        ],
+    ],
+];
+```
+
+未发布配置时，组件使用 `main` 连接、空 salt、最小长度 `0` 和上面显示的字符表。
+
+如需为某个模型选择其他连接，请覆写受保护的 `getHashidsConnection()` 方法：
+
+```php
+class Item extends Model
+{
+    use HasHashid;
+
+    protected function getHashidsConnection()
+    {
+        return 'alternative';
+    }
+}
+```
+
+## 使用
+
+### 编码和查询
+
+```php
+// Encode the model's primary key.
+$item->hashid();
+
+// Access the same value through the hashid accessor.
+$item->hashid;
+
+// Encode an ID or decode a valid hashid.
+$item->idToHashid($id);
+$item->hashidToId($hashid);
+
+// Add a primary-key constraint decoded from the hashid.
+Item::query()->byHashid($hashid)->get();
+
+// Return the first matching model, null, or throw ModelNotFoundException.
+Item::findByHashid($hashid);
+Item::findByHashidOrFail($hashid);
+```
+
+`hashidToId()` 返回 `hashids/hashids` 解码出的第一个 ID；请传入使用相同连接设置生成的有效
+hashid。
+
+### 序列化 Hashid
+
+`hashid` 访问器不会自动追加。可将它添加到模型的 `$appends` 属性：
+
+```php
+class Item extends Model
+{
+    use HasHashid;
+
+    protected $appends = ['hashid'];
+}
+```
+
+也可以仅在需要时追加：
+
+```php
+return $item->append('hashid')->toJson();
+```
+
+### 隐式路由绑定
+
+`HashidRouting` 将模型的 hashid 作为默认路由键，并通过 `byHashid` 解析：
+
+```php
+Route::get('/items/{item}', function (Item $item) {
+    return $item;
+});
+```
+
+当路由明确指定其他字段时，解析会交给模型的父类实现：
+
+```php
+Route::get('/items/{item:slug}', function (Item $item) {
+    return $item;
+});
+```
+
+也可以将其他字段设为默认路由键，同时在特定路由中指定 `hashid`：
+
+```php
+class Item extends Model
+{
+    use HasHashid;
+    use HashidRouting;
+
+    public function getRouteKeyName()
+    {
+        return 'slug';
+    }
+
+    public function getRouteKey()
+    {
+        return $this->slug;
+    }
+}
+```
+
+```php
+Route::get('/items/{item:hashid}', function (Item $item) {
+    return $item;
+});
+```

--- a/src/model-morph-addon/README.md
+++ b/src/model-morph-addon/README.md
@@ -1,5 +1,7 @@
 # model-morph-addon
 
+[中文说明](README_CN.md)
+
 [![Latest Stable Version](https://poser.pugx.org/friendsofhyperf/model-morph-addon/v/stable.svg)](https://packagist.org/packages/friendsofhyperf/model-morph-addon)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/model-morph-addon)](https://packagist.org/packages/friendsofhyperf/model-morph-addon)
 [![License](https://img.shields.io/packagist/l/friendsofhyperf/model-morph-addon)](https://github.com/friendsofhyperf/model-morph-addon)

--- a/src/model-morph-addon/README_CN.md
+++ b/src/model-morph-addon/README_CN.md
@@ -1,0 +1,97 @@
+# Model Morph Addon
+
+[English](README.md)
+
+Model Morph Addon 允许声明 `morphTo` 关联的模型自行解析多态别名，而不必只依赖全局多态映射。
+
+## 要求
+
+- Hyperf 3.2
+- `hyperf/database` ~3.2
+- `hyperf/di` ~3.2
+
+## 安装
+
+```shell
+composer require friendsofhyperf/model-morph-addon
+```
+
+包的 `ConfigProvider` 会自动注册两个 AOP 切面。它没有需要发布的配置文件，也没有可选的集成依赖。
+
+## 定义模型局部多态映射
+
+在声明 `morphTo()` 的模型上重写 `getActualClassNameForMorph()`。每个关联模型应通过
+`getMorphClass()` 返回数据库中存储的别名。
+
+```php
+namespace App\Model;
+
+use Hyperf\Database\Model\Model;
+
+class Image extends Model
+{
+    public function imageable()
+    {
+        return $this->morphTo();
+    }
+
+    public static function getActualClassNameForMorph($class)
+    {
+        $morphMap = [
+            'user' => User::class,
+            'book' => Book::class,
+        ];
+
+        return $morphMap[$class] ?? $class;
+    }
+}
+
+class Book extends Model
+{
+    public function images()
+    {
+        return $this->morphMany(Image::class, 'imageable');
+    }
+
+    public function getMorphClass()
+    {
+        return 'book';
+    }
+}
+
+class User extends Model
+{
+    public function images()
+    {
+        return $this->morphMany(Image::class, 'imageable');
+    }
+
+    public function getMorphClass()
+    {
+        return 'user';
+    }
+}
+```
+
+解析器应为每个输入返回有效的模型类。未知别名返回原值，可以保留 Hyperf 的默认回退行为。
+
+## 查询所有多态类型
+
+当 `hasMorph()` 接收到通配符类型列表 `['*']` 时，组件也会应用模型局部解析器。委托给
+`hasMorph()` 的方法（例如 `whereHasMorph()` 和 `doesntHaveMorph()`）具有相同行为。
+
+```php
+$images = Image::query()
+    ->whereHasMorph('imageable', ['*'])
+    ->get();
+```
+
+对于 `['*']`，Hyperf 会发现模型表中存储的不同且非空的多态类型值。组件会先通过
+`Image::getActualClassNameForMorph()` 解析每个值，再由 Hyperf 构建关联查询。
+
+## 行为
+
+- 加载 `Image::imageable` 关联时，会通过 `Image::getActualClassNameForMorph()` 解析其存储类型。
+- 多态别名属于声明 `morphTo()` 的模型；不同模型可以用不同方式解析同一别名。
+- 传给多态查询方法的显式类型列表保持 Hyperf 的默认行为。查询切面只改变完全匹配的通配符列表
+  `['*']`。

--- a/src/model-observer/README.md
+++ b/src/model-observer/README.md
@@ -1,5 +1,7 @@
 # model-observer
 
+[中文说明](README_CN.md)
+
 [![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/model-observer)](https://packagist.org/packages/friendsofhyperf/model-observer)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/model-observer)](https://packagist.org/packages/friendsofhyperf/model-observer)
 [![License](https://img.shields.io/packagist/l/friendsofhyperf/model-observer)](https://github.com/friendsofhyperf/model-observer)

--- a/src/model-observer/README_CN.md
+++ b/src/model-observer/README_CN.md
@@ -1,0 +1,171 @@
+# Model Observer
+
+[English](README.md)
+
+Model Observer 组件用于注册处理 Hyperf 模型事件的类。观察者可以在观察者类上绑定，也可以在模型类上绑定。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/model-observer
+```
+
+组件会通过 ConfigProvider 自动注册。与 Hyperf 模型一起使用时需要安装 `hyperf/database`：
+
+```shell
+composer require hyperf/database
+```
+
+## 生成观察者
+
+向 `gen:observer` 传入模型类，可在默认的 `App\Observer` 命名空间中生成观察者：
+
+```shell
+php bin/hyperf.php gen:observer UserObserver --model="App\\Model\\User"
+```
+
+该命令还支持：
+
+```shell
+php bin/hyperf.php gen:observer UserObserver \
+  --model="App\\Model\\User" \
+  --namespace="App\\ModelObserver" \
+  --force
+```
+
+- `--model`、`-M`：用于生成属性和方法签名的模型类。
+- `--namespace`、`-N`：生成的观察者命名空间。
+- `--force`、`-f`：覆盖已存在的观察者文件。
+
+可以在 `config/autoload/devtool.php` 中修改默认命名空间或模板：
+
+```php
+return [
+    'generator' => [
+        'observer' => [
+            'namespace' => 'App\\ModelObserver',
+            'stub' => BASE_PATH . '/stubs/observer.stub',
+        ],
+    ],
+];
+```
+
+## 从观察者绑定
+
+在观察者类上使用 `#[Observer]`。`model` 参数接受一个模型类或模型类数组：
+
+```php
+namespace App\Observer;
+
+use App\Model\User;
+use FriendsOfHyperf\ModelObserver\Annotation\Observer;
+
+#[Observer(model: User::class)]
+class UserObserver
+{
+    public function creating(User $model): void
+    {
+        // 创建用户前执行。
+    }
+
+    public function created(User $model): void
+    {
+        // 创建用户后执行。
+    }
+}
+```
+
+```php
+namespace App\Observer;
+
+use App\Model\Post;
+use App\Model\User;
+use FriendsOfHyperf\ModelObserver\Annotation\Observer;
+use Hyperf\Database\Model\Model;
+
+#[Observer(model: [User::class, Post::class])]
+class SearchIndexObserver
+{
+    public function saved(Model $model): void
+    {
+        // 更新搜索索引。
+    }
+}
+```
+
+`#[Observer]` 可以重复声明。使用 `priority` 可让优先级较高的观察者先执行：
+
+```php
+#[Observer(model: User::class, priority: 100)]
+#[Observer(model: Post::class, priority: 50)]
+class AuditObserver
+{
+    // ...
+}
+```
+
+## 从模型绑定
+
+使用 `#[ObservedBy]` 在模型上声明观察者。它的 `classes` 参数接受一个观察者类或观察者类数组，
+并且该属性可以重复声明：
+
+```php
+namespace App\Model;
+
+use App\Observer\AuditObserver;
+use App\Observer\UserObserver;
+use FriendsOfHyperf\ModelObserver\Annotation\ObservedBy;
+use Hyperf\Database\Model\Model;
+
+#[ObservedBy([UserObserver::class, AuditObserver::class], priority: 100)]
+class User extends Model
+{
+    // ...
+}
+```
+
+来自 `#[Observer]` 和 `#[ObservedBy]` 的绑定会合并。同一模型的重复观察者类只会调用一次。
+
+## 在协程中运行观察者
+
+如果观察者上所有可调用的事件方法都应在新协程中运行，请实现 `ShouldCoroutine`：
+
+```php
+namespace App\Observer;
+
+use App\Model\User;
+use FriendsOfHyperf\ModelObserver\Annotation\Observer;
+use FriendsOfHyperf\ModelObserver\Contract\ShouldCoroutine;
+
+#[Observer(model: User::class)]
+class UserObserver implements ShouldCoroutine
+{
+    public function created(User $model): void
+    {
+        // 在新创建的协程中运行。
+    }
+}
+```
+
+协程观察者异步运行，不要依赖它们在模型操作返回前执行完毕。
+
+## 支持的事件
+
+观察者只需定义需要的方法。每个可调用方法都会接收模型实例：
+
+- `booting`
+- `booted`
+- `retrieved`
+- `creating`
+- `created`
+- `updating`
+- `updated`
+- `saving`
+- `saved`
+- `restoring`
+- `restored`
+- `deleting`
+- `deleted`
+- `forceDeleted`
+
+组件通过 Hyperf 事件分发这些方法。观察者方法的返回值会被忽略，不能用于取消模型操作。

--- a/src/model-scope/README.md
+++ b/src/model-scope/README.md
@@ -1,5 +1,7 @@
 # model-scope
 
+[中文说明](README_CN.md)
+
 [![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/model-scope)](https://packagist.org/packages/friendsofhyperf/model-scope)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/model-scope)](https://packagist.org/packages/friendsofhyperf/model-scope)
 [![License](https://img.shields.io/packagist/l/friendsofhyperf/model-scope)](https://github.com/friendsofhyperf/model-scope)

--- a/src/model-scope/README_CN.md
+++ b/src/model-scope/README_CN.md
@@ -1,0 +1,91 @@
+# Model Scope
+
+[English](README.md)
+
+Model Scope 组件通过可重复使用的 `#[ScopedBy]` 注解注册 Hyperf 模型全局
+Scope。
+
+## 使用要求
+
+- Hyperf 3.2
+- `hyperf/database` ~3.2；使用模型 Scope 时必须安装，但本组件仅将其声明为
+  Composer 建议依赖
+
+## 安装
+
+```shell
+composer require friendsofhyperf/model-scope
+```
+
+组件的 `ConfigProvider` 会自动注册 Scope 监听器，无需发布配置文件。
+
+## 定义 Scope
+
+每个 Scope 都必须实现 `Hyperf\Database\Model\Scope`。
+
+```php
+namespace App\Model\Scope;
+
+use Hyperf\Database\Model\Builder;
+use Hyperf\Database\Model\Model;
+use Hyperf\Database\Model\Scope;
+
+class AncientScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        $builder->where('created_at', '<', now()->subYears(2000));
+    }
+}
+```
+
+## 将 Scope 绑定到模型
+
+在模型类上添加 `#[ScopedBy]`。应用启动时，该 Scope 会被注册为全局 Scope。
+
+```php
+namespace App\Model;
+
+use App\Model\Scope\AncientScope;
+use FriendsOfHyperf\ModelScope\Annotation\ScopedBy;
+use Hyperf\Database\Model\Model;
+
+#[ScopedBy(AncientScope::class)]
+class User extends Model
+{
+}
+```
+
+## 注册多个 Scope
+
+`classes` 参数可以接收单个 Scope 类或 Scope 类数组，该注解也可以重复使用。
+`priority` 默认为 `0`；优先级越高的 Scope 越先注册。同一个注解中传入的所有
+类共用一个优先级。
+
+```php
+namespace App\Model;
+
+use App\Model\Scope\ActiveScope;
+use App\Model\Scope\AncientScope;
+use App\Model\Scope\TenantScope;
+use FriendsOfHyperf\ModelScope\Annotation\ScopedBy;
+use Hyperf\Database\Model\Model;
+
+#[ScopedBy([AncientScope::class, ActiveScope::class], priority: 10)]
+#[ScopedBy(TenantScope::class, priority: 100)]
+class User extends Model
+{
+}
+```
+
+## 注册行为
+
+触发 `BootApplication` 时，组件会读取所有带有 `#[ScopedBy]` 注解的模型类。
+对于每个声明的 Scope 类，组件会：
+
+1. 验证类存在并实现 `Hyperf\Database\Model\Scope`；
+2. 检查容器中是否存在该类；
+3. 从容器解析实例，并将其传给 `Model::addGlobalScope()`。
+
+未通过任一检查的 Scope 条目会被跳过。Scope 构造函数可以使用容器能够解析的
+依赖。相同优先级的 Scope 之间不保证注册顺序。

--- a/src/mysql-grammar-addon/README.md
+++ b/src/mysql-grammar-addon/README.md
@@ -1,5 +1,7 @@
 # mysql-grammar-addon
 
+[中文说明](README_CN.md)
+
 [![Latest Stable Version](https://poser.pugx.org/friendsofhyperf/mysql-grammar-addon/v/stable.svg)](https://packagist.org/packages/friendsofhyperf/mysql-grammar-addon)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/mysql-grammar-addon)](https://packagist.org/packages/friendsofhyperf/mysql-grammar-addon)
 [![License](https://img.shields.io/packagist/l/friendsofhyperf/mysql-grammar-addon)](https://github.com/friendsofhyperf/mysql-grammar-addon)

--- a/src/mysql-grammar-addon/README_CN.md
+++ b/src/mysql-grammar-addon/README_CN.md
@@ -1,0 +1,50 @@
+# MySQL Grammar Addon
+
+[English](README.md)
+
+该组件用于避免 Hyperf 读取 MySQL 表结构元数据时，非 ASCII 字段注释出现乱码。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/mysql-grammar-addon --dev
+```
+
+该包要求 `hyperf/database` 和 `hyperf/di` 的版本为 `~3.2.0`，且未声明可选依赖。Hyperf 包
+自动发现会自动注册该组件的切面，无需额外配置。
+
+## 行为
+
+该切面会拦截以下 MySQL 表结构语法方法：
+
+- `Hyperf\Database\Schema\Grammars\MySqlGrammar::compileColumnListing()`
+- `Hyperf\Database\Schema\Grammars\MySqlGrammar::compileColumns()`
+
+它会修改生成的元数据查询，以二进制形式读取字段注释：
+
+```sql
+binary `column_comment`
+```
+
+这样，读取 MySQL 表结构元数据的代码可以保留注释的原始字节。该组件不会添加查询构造器方法，
+也没有需要应用代码调用的公开 API。
+
+## 示例
+
+安装该组件之前，生成的模型注解可能包含乱码：
+
+```php
+/**
+ * @property int $user_id ??id
+ * @property string $event_name ????
+ */
+```
+
+安装该组件之后，可以保留原始注释：
+
+```php
+/**
+ * @property int $user_id 用户id
+ * @property string $event_name 事件名称
+ */
+```

--- a/src/notification-easysms/README.md
+++ b/src/notification-easysms/README.md
@@ -1,5 +1,7 @@
 # Notification EasySms Channel
 
+[中文说明](README_CN.md)
+
 This component sends notifications through [EasySms](https://github.com/overtrue/easy-sms).
 
 ## Installation

--- a/src/notification-easysms/README_CN.md
+++ b/src/notification-easysms/README_CN.md
@@ -1,0 +1,112 @@
+# Notification EasySms Channel
+
+[English](README.md)
+
+此组件通过 [EasySms](https://github.com/overtrue/easy-sms) 发送通知。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/notification-easysms
+```
+
+组件依赖 `friendsofhyperf/notification` 和 `overtrue/easy-sms:^3.0`，Composer 会自动安装。
+
+## 配置
+
+发布 `config/autoload/easy_sms.php`，然后参照 EasySms 文档配置默认策略、默认网关和网关凭据：
+
+```shell
+php bin/hyperf.php vendor:publish friendsofhyperf/notification-easysms
+```
+
+组件会使用完整的 `easy_sms` 配置数组创建 `EasySms` 实例。
+
+## 使用
+
+应用启动时，组件会以 `easy-sms` 通道名注册 `EasySmsChannel`。
+
+### 定义通知路由
+
+在接收者中使用 `Notifiable` trait，并定义 `routeNotificationForSms()`。该方法应返回手机号码字符串。
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model;
+
+use FriendsOfHyperf\Notification\Traits\Notifiable;
+use Hyperf\DbConnection\Model\Model;
+
+class User extends Model
+{
+    use Notifiable;
+
+    public function routeNotificationForSms(): string
+    {
+        return $this->phone;
+    }
+}
+```
+
+虽然通知通道名为 `easy-sms`，但它会通过 `routeNotificationFor('sms', $notification)` 获取接收者，
+因此实际调用的方法是 `routeNotificationForSms()`。
+
+### 创建短信通知
+
+通知必须实现 `Smsable`。`via()` 应返回 `easy-sms`，`toSms()` 应返回 EasySms 接受的数组或
+`Overtrue\EasySms\Message`。
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification;
+
+use FriendsOfHyperf\Notification\EasySms\Contract\Smsable;
+use FriendsOfHyperf\Notification\Notification;
+use Overtrue\EasySms\Message;
+
+class VerificationCodeNotification extends Notification implements Smsable
+{
+    public function __construct(private string $code)
+    {
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['easy-sms'];
+    }
+
+    public function toSms(mixed $notifiable): array|Message
+    {
+        return [
+            'content' => "您的验证码是 {$this->code}。",
+            'template' => 'SMS_123456789',
+            'data' => [
+                'code' => $this->code,
+            ],
+        ];
+    }
+}
+```
+
+EasySms 会将数组载荷转换为 `Message`。支持的消息属性包括 `content`、`template`、`data`、`type`
+和 `gateways`。需要通过 `setGateways()` 等方法配置消息时，可直接返回 `Message`：
+
+```php
+public function toSms(mixed $notifiable): array|Message
+{
+    return (new Message())
+        ->setTemplate('SMS_123456789')
+        ->setData(['code' => $this->code])
+        ->setGateways(['aliyun']);
+}
+```
+
+消息未指定网关时，EasySms 会使用 `config/autoload/easy_sms.php` 中的 `default.gateways`。发送结果是
+EasySms 返回的网关结果数组，并会传给通知调度器。如果通知未实现 `Smsable`，通道会抛出
+`RuntimeException`。

--- a/src/notification-mail/README.md
+++ b/src/notification-mail/README.md
@@ -1,5 +1,7 @@
 # Notification Mail Channel
 
+[中文说明](README_CN.md)
+
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/friendsofhyperf/notification-mail.svg?style=flat-square)](https://packagist.org/packages/friendsofhyperf/notification-mail)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/notification-mail.svg?style=flat-square)](https://packagist.org/packages/friendsofhyperf/notification-mail)
 [![GitHub license](https://img.shields.io/github/license/friendsofhyperf/notification-mail)](https://github.com/friendsofhyperf/notification-mail)

--- a/src/notification-mail/README_CN.md
+++ b/src/notification-mail/README_CN.md
@@ -1,0 +1,112 @@
+# Notification Mail Channel
+
+[English](README.md)
+
+## 安装
+
+```shell
+composer require friendsofhyperf/notification-mail
+```
+
+## 使用
+
+### Use `Notifiable` trait in Model
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model;
+
+use FriendsOfHyperf\Notification\Traits\Notifiable;
+use Hyperf\DbConnection\Model\Model;
+
+/**
+ * @property int $id
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ */
+class User extends Model
+{
+    use Notifiable;
+
+    /**
+     * The table associated with the model.
+     */
+    protected ?string $table = 'user';
+
+
+
+    // 通知邮箱
+    public function routeNotificationForMail(): string
+    {
+        return $this->mail;
+    }
+}
+```
+
+### Mail Notifications
+
+```shell
+php bin/hyperf.php gen:markdown-mail Test
+```
+
+output
+
+```php
+
+namespace App\Mail;
+
+use FriendsOfHyperf\Notification\Mail\Message\MailMessage;
+use FriendsOfHyperf\Notification\Notification;
+
+class Test extends Notification
+{
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)->from('xxx@xxx.cn','Hyperf')->replyTo('xxx@qq.com','zds')->markdown('email');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            //
+        ];
+    }
+
+}
+```
+
+### Mail Template
+
+```php
+// storage/view/email.blade.php
+xxx
+```

--- a/src/notification/README.md
+++ b/src/notification/README.md
@@ -1,5 +1,7 @@
 # Notification
 
+[中文说明](README_CN.md)
+
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/friendsofhyperf/notification.svg?style=flat-square)](https://packagist.org/packages/friendsofhyperf/notification)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/notification.svg?style=flat-square)](https://packagist.org/packages/friendsofhyperf/notification)
 [![GitHub license](https://img.shields.io/github/license/friendsofhyperf/notification)](https://github.com/friendsofhyperf/notification)

--- a/src/notification/README_CN.md
+++ b/src/notification/README_CN.md
@@ -1,0 +1,243 @@
+# Notification
+
+[English](README.md)
+
+## 安装
+
+```shell
+composer require friendsofhyperf/notification
+```
+
+## 使用
+
+### 在 Model 中使用 `Notifiable` trait
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model;
+
+use FriendsOfHyperf\Notification\Traits\Notifiable;
+use Hyperf\DbConnection\Model\Model;
+
+/**
+ * @property int $id
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ */
+class User extends Model
+{
+    use Notifiable;
+
+    /**
+     * The table associated with the model.
+     */
+    protected ?string $table = 'user';
+
+    /**
+     * The attributes that are mass assignable.
+     */
+    protected array $fillable = ['id', 'created_at', 'updated_at'];
+
+    /**
+     * The attributes that should be cast to native types.
+     */
+    protected array $casts = ['id' => 'integer', 'created_at' => 'datetime', 'updated_at' => 'datetime'];
+
+}
+```
+
+### Database Notifications
+
+```shell
+# Install the database package
+composer require hyperf/database:~3.2.0
+
+# Publish the migration file
+php bin/hyperf.php notification:table
+
+# Run the migration
+php bin/hyperf.php migrate
+
+# Create a notification
+php bin/hyperf.php gen:notification TestNotification
+```
+
+---
+
+```php
+<?php
+
+namespace App\Notification;
+
+use FriendsOfHyperf\Notification\Notification;
+
+class TestNotification extends Notification
+{
+    public function __construct(
+        private string $message
+    ){}
+
+    public function via()
+    {
+        return [
+           // database channel
+            'database'
+        ];
+    }
+
+    public function toDatabase(mixed $notifiable): array
+    {
+        return [
+            'message' => $this->message,
+        ];
+    }
+}
+```
+
+---
+
+```php
+// Your controller or service
+// 通知一条消息
+$user->notify(new TestNotification('系统通知:xxx'));
+$noReadCount = $user->unreadNotifications()->count();
+$this->output->success('发送成功,未读消息数:' . $noReadCount);
+$notifications = $user->unreadNotifications()->first();
+$this->output->success('消息内容:' . $notifications->data['message']);
+$notifications->markAsRead();
+$noReadCount = $user->unreadNotifications()->count();
+$this->output->success('标记已读,未读消息数:' . $noReadCount);
+```
+
+### SMS Notifications
+
+- [notification-easy-sms](https://github.com/friendsofhyperf/notification-easysms)
+
+### Symfony Notifications
+
+Send notifications using Symfony Notifier.
+
+Email, SMS, Slack, Telegram, etc.
+
+```shell
+composer require symfony/notifier
+```
+
+#### Email
+
+```shell
+composer require symfony/mailer
+```
+
+---
+
+```php
+<?php
+// app/Factory/Notifier.php
+namespace App\Factory;
+
+use Hyperf\Contract\StdoutLoggerInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Mailer\Transport;
+use Symfony\Component\Notifier\Channel\ChannelInterface;
+use Symfony\Component\Notifier\Channel\EmailChannel;
+use function Hyperf\Support\env;
+
+class Notifier
+{
+    public function __construct(
+        protected EventDispatcherInterface $dispatcher,
+        protected StdoutLoggerInterface $logger,
+    )
+    {
+    }
+
+    public function __invoke()
+    {
+        return new \Symfony\Component\Notifier\Notifier($this->channels());
+    }
+
+    /**
+     * @return ChannelInterface[]
+     */
+    public function channels(): array
+    {
+        return [
+            'email' =>  new EmailChannel(
+                transport: Transport::fromDsn(
+                   // MAIL_DSN=smtp://user:password@localhost:1025
+                    env('MAIL_DSN'),
+                    dispatcher: $this->dispatcher,
+                    logger: $this->logger
+                ),
+                from: 'root@imoi.cn'
+            ),
+        ];
+    }
+}
+```
+
+```php
+<?php
+// app/Notification/TestNotification.php
+namespace App\Notification;
+
+use App\Model\User;
+use FriendsOfHyperf\Notification\Notification;
+use Symfony\Component\Notifier\Recipient\Recipient;
+
+class TestNotification extends Notification
+{
+    public function __construct(
+        private string $message
+    ){}
+
+    public function via()
+    {
+        return [
+            'symfony'
+        ];
+    }
+
+    public function toSymfony(User $user)
+    {
+        return (new \Symfony\Component\Notifier\Notification\Notification($this->message,['email']))->content('The introduction to the notification.');
+    }
+
+    public function toRecipient(User $user)
+    {
+        return new Recipient('2771717608@qq.com');
+    }
+
+
+}
+```
+
+```php
+<?php
+// config/autoload/dependencies.php
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+return [
+    \Symfony\Component\Notifier\NotifierInterface::class => \App\Factory\Notifier::class
+];
+
+```
+
+#### 在控制器中使用
+
+```php
+$user = User::create();
+// 通知一条消息
+$user->notify(new TestNotification('系统通知:xxx'));
+```

--- a/src/oauth2-server/README.md
+++ b/src/oauth2-server/README.md
@@ -1,5 +1,7 @@
 # FriendsOfHyperf OAuth2 Server
 
+[中文说明](README_CN.md)
+
 A complete OAuth2 server implementation for Hyperf framework, based on [league/oauth2-server](https://oauth2.thephpleague.com/).
 
 ## Features

--- a/src/oauth2-server/README_CN.md
+++ b/src/oauth2-server/README_CN.md
@@ -1,0 +1,100 @@
+# OAuth2 Server
+
+[English](README.md)
+
+使用 `league/oauth2-server` 为 Hyperf 构建 OAuth 2.0 授权服务器。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/oauth2-server
+php bin/hyperf.php vendor:publish friendsofhyperf/oauth2-server
+php bin/hyperf.php migrate
+```
+
+发布命令会创建 `config/autoload/oauth2-server.php`。在该文件中配置私钥、公钥、加密密钥、
+令牌有效期、启用的授权类型和 scopes。
+
+配置私钥和公钥路径后生成密钥对：
+
+```shell
+php bin/hyperf.php oauth2-server:generate-keypair
+```
+
+## 配置
+
+常用配置项包括：
+
+| 配置项 | 说明 |
+| --- | --- |
+| `authorization_server.private_key` | 用于签发令牌的私钥路径。 |
+| `authorization_server.private_key_passphrase` | 可选的私钥密码。 |
+| `authorization_server.encryption_key` | 授权服务器使用的加密密钥。 |
+| `authorization_server.encryption_key_type` | `plain` 或其他支持的 `EncryptionKeyType`。 |
+| `authorization_server.access_token_ttl` | Access token 有效期，类型为 `DateInterval`。 |
+| `authorization_server.refresh_token_ttl` | Refresh token 有效期，类型为 `DateInterval`。 |
+| `authorization_server.persist_access_token` | 是否持久化已签发的 access token。 |
+| `resource_server.public_key` | 用于验证令牌的公钥路径。 |
+| `resource_server.jwt_leeway` | 可选的 JWT 时钟偏移宽限时间。 |
+| `scopes.available` | 允许请求的 scopes。 |
+| `scopes.default` | 未请求 scope 时默认分配的 scopes。 |
+
+## 命令
+
+| 命令 | 说明 |
+| --- | --- |
+| `oauth2-server:clear-expired-tokens` | 清理过期的 access token 和 refresh token。 |
+| `oauth2-server:create-client` | 创建 OAuth2 客户端。 |
+| `oauth2-server:delete-client` | 删除 OAuth2 客户端。 |
+| `oauth2-server:generate-keypair` | 生成私钥/公钥密钥对。 |
+| `oauth2-server:list-clients` | 列出 OAuth2 客户端。 |
+| `oauth2-server:update-client` | 更新 OAuth2 客户端。 |
+
+按应用需要创建客户端：
+
+```shell
+php bin/hyperf.php oauth2-server:create-client "My App" \
+    --redirect-uri="https://myapp.example/callback" \
+    --grant-type="authorization_code" \
+    --grant-type="refresh_token"
+```
+
+## Token Endpoint
+
+组件提供授权服务器工厂。可以在自己的控制器或路由处理器中处理 token 请求：
+
+```php
+use FriendsOfHyperf\Oauth2\Server\Factory\AuthorizationServerFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class TokenController
+{
+    public function __construct(private AuthorizationServerFactory $factory)
+    {
+    }
+
+    public function token(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        return $this->factory->build()->respondToAccessTokenRequest($request, $response);
+    }
+}
+```
+
+## 保护资源
+
+在需要保护的路由上使用 `ResourceServerMiddleware`：
+
+```php
+use FriendsOfHyperf\Oauth2\Server\Middleware\ResourceServerMiddleware;
+use Hyperf\HttpServer\Router\Router;
+
+Router::addGroup('/api', function () {
+    Router::get('user', [UserController::class, 'index']);
+}, [
+    'middleware' => [ResourceServerMiddleware::class],
+]);
+```
+
+如果需要直接验证请求，可以通过 `ResourceServerFactory` 构建 resource server 并调用
+`validateAuthenticatedRequest()`。

--- a/src/openai-client/README.md
+++ b/src/openai-client/README.md
@@ -1,5 +1,7 @@
 # Hyperf OpenAI Client
 
+[中文说明](README_CN.md)
+
 [![Latest Test](https://github.com/friendsofhyperf/openai-client/workflows/tests/badge.svg)](https://github.com/friendsofhyperf/openai-client/actions)
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/friendsofhyperf/openai-client.svg?style=flat-square)](https://packagist.org/packages/friendsofhyperf/openai-client)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/openai-client.svg?style=flat-square)](https://packagist.org/packages/friendsofhyperf/openai-client)

--- a/src/openai-client/README_CN.md
+++ b/src/openai-client/README_CN.md
@@ -1,0 +1,110 @@
+# OpenAI Client
+
+[English](README.md)
+
+此组件将 [openai-php/client](https://github.com/openai-php/client) 集成到 Hyperf，
+向依赖注入容器注册上游客户端，并提供静态门面。
+
+## 依赖要求
+
+此包面向 Hyperf 3.2，依赖 `hyperf/config`、`hyperf/di`、`hyperf/guzzle` 和 0.10.0 或更高版本的
+`openai-php/client`，未声明可选依赖。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/openai-client
+```
+
+发布配置文件：
+
+```shell
+php bin/hyperf.php vendor:publish friendsofhyperf/openai-client
+```
+
+此命令会创建 `config/autoload/openai.php`。
+
+## 配置
+
+发布的配置文件会读取以下环境变量：
+
+```env
+OPENAI_BASE_URI=api.openai.com/v1
+OPENAI_API_KEY=sk-...
+OPENAI_ORGANIZATION=
+OPENAI_REQUEST_TIMEOUT=30
+```
+
+| 配置项 | 默认值 | 说明 |
+| --- | --- | --- |
+| `openai.base_uri` | `api.openai.com/v1` | 传给上游客户端工厂的基础 URI。 |
+| `openai.api_key` | 空字符串 | 用于 Bearer 身份验证的 API 密钥。 |
+| `openai.organization` | `null` | 可选的 OpenAI 组织标识。 |
+| `openai.request_timeout` | `30` | 传给 Hyperf Guzzle 客户端的超时时间，单位为秒。 |
+
+## 容器绑定与运行行为
+
+组件会将 `OpenAI\Client` 和 `OpenAI\Contracts\ClientContract` 绑定到同一个
+客户端实例。工厂会：
+
+- 通过 `Hyperf\Guzzle\ClientFactory` 创建 HTTP 客户端；
+- 应用配置的基础 URI、API 密钥、组织和请求超时时间；
+- 发送 `OpenAI-Beta: assistants=v2` 请求头。
+
+API 密钥必须是字符串，组织必须是 `null` 或字符串。类型不正确时会抛出
+`FriendsOfHyperf\OpenAi\Exception\ApiKeyIsMissing`。空 API 密钥仍是字符串，因此不会
+触发此异常；API 请求会改为因身份验证失败而报错。
+
+## 使用
+
+### 容器
+
+可以从容器解析契约或具体客户端。资源方法、请求参数和响应对象由已安装的
+`openai-php/client` 版本提供。
+
+```php
+use OpenAI\Contracts\ClientContract;
+
+$response = di(ClientContract::class)->chat()->create([
+    'model' => 'YOUR_MODEL',
+    'messages' => [
+        ['role' => 'user', 'content' => 'Briefly explain dependency injection.'],
+    ],
+]);
+
+echo $response->choices[0]->message->content;
+```
+
+### 门面
+
+`FriendsOfHyperf\OpenAi\Facade\OpenAI` 会将静态调用转发给容器绑定的 `ClientContract`。
+
+```php
+use FriendsOfHyperf\OpenAi\Facade\OpenAI;
+
+$models = OpenAI::models()->list();
+```
+
+## Azure 与自定义客户端
+
+组件工厂始终配置 Bearer 身份验证，且未提供自定义请求头或查询参数的配置。
+Azure OpenAI 等需要 `api-key` 请求头和 `api-version` 查询参数的服务，必须使用
+上游工厂手动创建客户端：
+
+```php
+use OpenAI;
+
+$client = OpenAI::factory()
+    ->withBaseUri('{your-resource-name}.openai.azure.com/openai/deployments/{deployment-id}')
+    ->withHttpHeader('api-key', '{your-api-key}')
+    ->withQueryParam('api-version', '{version}')
+    ->make();
+```
+
+手动创建的客户端不会自动注册到 Hyperf 容器。由于 Azure 基础 URI 已包含部署，
+因此针对该部署的调用无需传入 `model` 参数。
+
+## 上游 API 指南
+
+有关支持的资源和使用示例，请参阅与已安装版本匹配的
+[openai-php/client 文档](https://github.com/openai-php/client)。

--- a/src/pretty-console/README.md
+++ b/src/pretty-console/README.md
@@ -1,5 +1,7 @@
 # Pretty Console
 
+[中文说明](README_CN.md)
+
 [![Latest Test](https://github.com/friendsofhyperf/pretty-console/workflows/tests/badge.svg)](https://github.com/friendsofhyperf/pretty-console/actions)
 [![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/pretty-console)](https://packagist.org/packages/friendsofhyperf/pretty-console)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/pretty-console)](https://packagist.org/packages/friendsofhyperf/pretty-console)

--- a/src/pretty-console/README_CN.md
+++ b/src/pretty-console/README_CN.md
@@ -1,0 +1,38 @@
+# Pretty Console
+
+[English](README.md)
+
+用于 Hyperf 的精美控制台组件。
+
+![Pretty Console](https://user-images.githubusercontent.com/5457236/178333036-b11abb56-ba70-4c0d-a2f6-79afe3a0a78c.png)
+
+## 安装
+
+```shell
+composer require friendsofhyperf/pretty-console
+```
+
+## 使用
+
+```php
+<?php
+use FriendsOfHyperf\PrettyConsole\Traits\Prettyable;
+use Hyperf\Command\Command as HyperfCommand;
+use Hyperf\Command\Annotation\Command;
+
+#[Command]
+class FooCommand extends HyperfCommand
+{
+    use Prettyable;
+
+    public function function handle()
+    {
+        $this->components->info('Your message here.');
+    }
+}
+```
+
+## 鸣谢
+
+- [nunomaduro/termwind](https://github.com/nunomaduro/termwind)
+- [The idea from pr of laravel](https://github.com/laravel/framework/pull/43065)

--- a/src/purifier/README.md
+++ b/src/purifier/README.md
@@ -1,5 +1,7 @@
 # Purifier
 
+[中文说明](README_CN.md)
+
 [![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/purifier)](https://packagist.org/packages/friendsofhyperf/purifier)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/purifier)](https://packagist.org/packages/friendsofhyperf/purifier)
 [![License](https://img.shields.io/packagist/l/friendsofhyperf/purifier)](https://github.com/friendsofhyperf/purifier)

--- a/src/purifier/README_CN.md
+++ b/src/purifier/README_CN.md
@@ -1,8 +1,6 @@
 # Purifier
 
-[![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/purifier)](https://packagist.org/packages/friendsofhyperf/purifier)
-[![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/purifier)](https://packagist.org/packages/friendsofhyperf/purifier)
-[![License](https://img.shields.io/packagist/l/friendsofhyperf/purifier)](https://github.com/friendsofhyperf/purifier)
+[English](README.md)
 
 HTML 过滤器. 派生于 [mews/purifier](https://github.com/mewebstudio/Purifier).
 
@@ -67,10 +65,10 @@ use FriendsOfHyperf\Purifier\Casts\CleanHtmlOutput;
 
 class Monster extends Model
 {
-    protected array $casts = [
-        'bio' => CleanHtml::class, // 在获取和设置值时都会进行清理
-        'description' => CleanHtmlInput::class, // 设置值时清理
-        'history' => CleanHtmlOutput::class, // 获取值时进行清理
+    protected $casts = [
+        'bio'            => CleanHtml::class, // 在获取和设置值时都会进行清理
+        'description'    => CleanHtmlInput::class, // 设置值时清理
+        'history'        => CleanHtmlOutput::class, // 获取值时进行清理
     ];
 }
 ```
@@ -79,33 +77,33 @@ class Monster extends Model
 
 要使用您自己的设置，请发布配置.
 
-```sehll
+```shell
 php bin/hyperf.php vendor:publish friendsofhyperf/purifier
 ```
 
-配置文件 `config/autoload/purifier.php` 内容如下:
+配置文件 `config/autoload/purifier.php` 内容如下：
 
 ```php
 
 return [
-    'encoding' => 'UTF-8',
-    'finalize' => true,
-    'ignore_non_strings' => false,
-    'cache_path' => storage_path('app/purifier'),
-    'cache_file_mode' => 0755,
-    'settings' => [
+    'encoding'           => 'UTF-8',
+    'finalize'           => true,
+    'ignore_non_strings'   => false,
+    'cache_path'          => BASE_PATH . '/storage/app/purifier',
+    'cache_file_mode'      => 0755,
+    'settings'      => [
         'default' => [
-            'HTML.Doctype' => 'HTML 4.01 Transitional',
-            'HTML.Allowed' => 'div,b,strong,i,em,u,a[href|title],ul,ol,li,p[style],br,span[style],img[width|height|alt|src]',
-            'CSS.AllowedProperties' => 'font,font-size,font-weight,font-style,font-family,text-decoration,padding-left,color,background-color,text-align',
+            'HTML.Doctype'             => 'HTML 4.01 Transitional',
+            'HTML.Allowed'             => 'div,b,strong,i,em,u,a[href|title],ul,ol,li,p[style],br,span[style],img[width|height|alt|src]',
+            'CSS.AllowedProperties'    => 'font,font-size,font-weight,font-style,font-family,text-decoration,padding-left,color,background-color,text-align',
             'AutoFormat.AutoParagraph' => true,
-            'AutoFormat.RemoveEmpty' => true,
+            'AutoFormat.RemoveEmpty'   => true,
         ],
-        'test' => [
+        'test'    => [
             'Attr.EnableID' => 'true',
         ],
         "youtube" => [
-            "HTML.SafeIframe" => 'true',
+            "HTML.SafeIframe"      => 'true',
             "URI.SafeIframeRegexp" => "%^(http://|https://|//)(www.youtube.com/embed/|player.vimeo.com/video/)%",
         ],
         'custom_definition' => [
@@ -120,11 +118,14 @@ return [
                 ['aside',   'Block', 'Flow', 'Common'],
                 ['header',  'Block', 'Flow', 'Common'],
                 ['footer',  'Block', 'Flow', 'Common'],
+
                 ['address', 'Block', 'Flow', 'Common'],
                 ['hgroup', 'Block', 'Required: h1 | h2 | h3 | h4 | h5 | h6', 'Common'],
+
                 // https://developers.whatwg.org/grouping-content.html
                 ['figure', 'Block', 'Optional: (figcaption, Flow) | (Flow, figcaption) | Flow', 'Common'],
                 ['figcaption', 'Inline', 'Flow', 'Common'],
+
                 // https://developers.whatwg.org/the-video-element.html#the-video-element
                 ['video', 'Block', 'Optional: (source, Flow) | (Flow, source) | Flow', 'Common', [
                     'src' => 'URI',
@@ -139,6 +140,7 @@ return [
                     'src' => 'URI',
                     'type' => 'Text',
                 ]],
+
                 // https://developers.whatwg.org/text-level-semantics.html
                 ['s',    'Inline', 'Inline', 'Common'],
                 ['var',  'Inline', 'Inline', 'Common'],
@@ -146,6 +148,7 @@ return [
                 ['sup',  'Inline', 'Inline', 'Common'],
                 ['mark', 'Inline', 'Inline', 'Common'],
                 ['wbr',  'Inline', 'Empty', 'Core'],
+
                 // https://developers.whatwg.org/edits.html
                 ['ins', 'Block', 'Flow', 'Common', ['cite' => 'URI', 'datetime' => 'CDATA']],
                 ['del', 'Block', 'Flow', 'Common', ['cite' => 'URI', 'datetime' => 'CDATA']],

--- a/src/rate-limit/README.md
+++ b/src/rate-limit/README.md
@@ -1,5 +1,7 @@
 # Rate Limit
 
+[中文说明](README_CN.md)
+
 [![Latest Stable Version](https://poser.pugx.org/friendsofhyperf/rate-limit/v)](https://packagist.org/packages/friendsofhyperf/rate-limit)
 [![Total Downloads](https://poser.pugx.org/friendsofhyperf/rate-limit/downloads)](https://packagist.org/packages/friendsofhyperf/rate-limit)
 [![License](https://poser.pugx.org/friendsofhyperf/rate-limit/license)](https://packagist.org/packages/friendsofhyperf/rate-limit)

--- a/src/rate-limit/README_CN.md
+++ b/src/rate-limit/README_CN.md
@@ -1,8 +1,6 @@
 # Rate Limit
 
-[![Latest Stable Version](https://poser.pugx.org/friendsofhyperf/rate-limit/v)](https://packagist.org/packages/friendsofhyperf/rate-limit)
-[![Total Downloads](https://poser.pugx.org/friendsofhyperf/rate-limit/downloads)](https://packagist.org/packages/friendsofhyperf/rate-limit)
-[![License](https://poser.pugx.org/friendsofhyperf/rate-limit/license)](https://packagist.org/packages/friendsofhyperf/rate-limit)
+[English](README.md)
 
 Hyperf 的限流组件，支持多种算法（固定窗口、滑动窗口、令牌桶、漏桶）。
 
@@ -134,7 +132,7 @@ class UserController
 }
 ```
 
-#### 注解参数
+### 注解参数
 
 | 参数 | 类型 | 默认值 | 说明 |
 |-----------|------|---------|-------------|
@@ -143,10 +141,10 @@ class UserController
 | `decay` | `int` | `60` | 时间窗口（秒） |
 | `algorithm` | `Algorithm` | `Algorithm::FIXED_WINDOW` | 算法：fixed_window, sliding_window, token_bucket, leaky_bucket |
 | `pool` | `?string` | `null` | 使用的 Redis 连接池 |
-| `response` | `string` | `'Too Many Attempts.'` | 超出限流时的自定义响应 |
+| `response` | `string` | `'Too Many Attempts, Please try again in %d seconds.'` | 超出限流时的自定义响应 |
 | `responseCode` | `int` | `429` | 超出限流时的 HTTP 状态码 |
 
-#### 使用 AutoSort 实现多限流规则智能排序
+### 使用 AutoSort 实现多限流规则智能排序
 
 当同一个方法需要多个限流规则时（例如每分钟和每小时的限制），可以使用 `AutoSort` 注解自动按严格程度排序：
 
@@ -189,7 +187,7 @@ class ApiController
 - **可选**：仅在显式使用 `AutoSort` 的方法上生效
 - **向后兼容**：现有代码无需修改即可继续工作
 
-#### 键占位符
+### 键占位符
 
 `key` 参数支持动态占位符，会被方法参数替换：
 
@@ -246,9 +244,9 @@ return [
 ];
 ```
 
-### 限流算法
+## 限流算法
 
-#### 固定窗口（默认）
+### 固定窗口（默认）
 
 最简单的算法，在固定时间窗口内计数请求。
 
@@ -259,7 +257,7 @@ return [
 **优点**：简单，内存高效
 **缺点**：可能在窗口边界处允许突发请求
 
-#### 滑动窗口
+### 滑动窗口
 
 比固定窗口更准确，均匀分布请求。
 
@@ -270,7 +268,7 @@ return [
 **优点**：平滑突发流量，更准确
 **缺点**：稍微复杂一些
 
-#### 令牌桶
+### 令牌桶
 
 允许突发流量，同时保持平均速率。
 
@@ -281,7 +279,7 @@ return [
 **优点**：允许突发流量，灵活
 **缺点**：需要更多配置
 
-#### 漏桶
+### 漏桶
 
 以恒定速率处理请求，排队突发流量。
 
@@ -292,7 +290,7 @@ return [
 **优点**：平滑输出速率，防止突发
 **缺点**：可能延迟请求
 
-### 自定义限流器
+## 自定义限流器
 
 你可以通过实现 `RateLimiterInterface` 来实现自己的限流器：
 
@@ -468,7 +466,3 @@ class ReportController
     }
 }
 ```
-
-## 许可证
-
-[MIT](LICENSE)

--- a/src/recaptcha/README.md
+++ b/src/recaptcha/README.md
@@ -1,5 +1,7 @@
 # ReCaptcha
 
+[中文说明](README_CN.md)
+
 A Google ReCaptcha component for Hyperf.
 
 ## Installation

--- a/src/recaptcha/README_CN.md
+++ b/src/recaptcha/README_CN.md
@@ -1,0 +1,87 @@
+# ReCaptcha
+
+[English](README.md)
+
+适用于 Hyperf 的 Google ReCaptcha 组件。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/recaptcha
+```
+
+## 配置
+
+使用中间件或验证规则前，先发布 `config/autoload/recaptcha.php`：
+
+```shell
+php bin/hyperf.php vendor:publish friendsofhyperf/recaptcha
+```
+
+通过 `RECAPTCHA_SECRET_V2_KEY` 配置 reCAPTCHA v2 密钥，通过 `RECAPTCHA_SECRET_V3_KEY`
+配置 reCAPTCHA v3 密钥，也可以直接修改发布文件中的 `v2.secret_key` 与 `v3.secret_key`。
+`default` 用于选择未显式传入版本时使用的版本。
+
+## 使用
+
+- 定义中间件
+
+```php
+namespace App\Middleware;
+
+use FriendsOfHyperf\ReCaptcha\Middleware\ReCaptchaMiddleware;
+
+class V3CaptchaMiddleware extends ReCaptchaMiddleware
+{
+    protected string $version = 'v3';
+    protected string $action = 'register';
+    protected float $score = 0.35;
+    protected string $hostname;
+}
+
+class V2CaptchaMiddleware extends ReCaptchaMiddleware
+{
+    protected string $version = 'v2';
+    protected string $action = 'register';
+    protected float $score = 0.35;
+    protected string $hostname;
+}
+```
+
+- 验证器使用
+
+```php
+<?php
+
+namespace App\Controller;
+
+use Hyperf\Di\Annotation\Inject;
+use Hyperf\HttpServer\Contract\RequestInterface;
+use Hyperf\Validation\Contract\ValidatorFactoryInterface;
+
+class IndexController
+{
+    #[Inject]
+    protected ValidatorFactoryInterface $validationFactory;
+
+    public function foo(RequestInterface $request)
+    {
+        $validator = $this->validationFactory->make(
+            $request->all(),
+            [
+                'g-recaptcha' => 'required|recaptcha:register,0.34,hostname,v3',
+            ],
+            [
+                'g-recaptcha.required' => 'g-recaptcha is required',
+                'g-recaptcha.recaptcha' => 'Google ReCaptcha Verify Fails',
+            ]
+        );
+
+        if ($validator->fails()){
+            // Handle exception
+            $errorMessage = $validator->errors()->first();
+        }
+        // Do something
+    }
+}
+```

--- a/src/redis-subscriber/README.md
+++ b/src/redis-subscriber/README.md
@@ -1,5 +1,7 @@
 # Redis Subscriber
 
+[中文说明](README_CN.md)
+
 [![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/redis-subscriber)](https://packagist.org/packages/friendsofhyperf/redis-subscriber)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/redis-subscriber)](https://packagist.org/packages/friendsofhyperf/redis-subscriber)
 [![License](https://img.shields.io/packagist/l/friendsofhyperf/redis-subscriber)](https://github.com/friendsofhyperf/redis-subscriber)

--- a/src/redis-subscriber/README_CN.md
+++ b/src/redis-subscriber/README_CN.md
@@ -1,22 +1,16 @@
 # Redis Subscriber
 
-[![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/redis-subscriber)](https://packagist.org/packages/friendsofhyperf/redis-subscriber)
-[![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/redis-subscriber)](https://packagist.org/packages/friendsofhyperf/redis-subscriber)
-[![License](https://img.shields.io/packagist/l/friendsofhyperf/redis-subscriber)](https://github.com/friendsofhyperf/redis-subscriber)
+[English](README.md)
 
-Forked from [mix-php/redis-subscriber](https://github.com/mix-php/redis-subscriber)
+基于 Swoole 协程的 Redis 原生协议订阅器，代码从 [mix-php/redis-subscriber](https://github.com/mix-php/redis-subscriber) 复刻而来。
 
-Redis native protocol Subscriber based on Swoole coroutine
-
-基于 Swoole 协程的 Redis 原生协议订阅库
-
-使用 Socket 直接连接 Redis 服务器，不依赖 phpredis 扩展，该订阅器有如下优点：
+基于 Swoole 协程的 Redis 原生协议订阅库，使用 Socket 直接连接 Redis 服务器，不依赖 phpredis 扩展，该订阅器有如下优点：
 
 - 平滑修改：可随时增加、取消订阅通道，实现无缝切换通道的需求。
 - 跨协程安全关闭：可在任意时刻关闭订阅。
 - 通道获取消息：该库封装风格参考 golang 语言 [go-redis](https://github.com/go-redis/redis) 库封装，通过 channel 获取订阅的消息。
 
-## Installation
+## 安装
 
 ```shell
 composer require friendsofhyperf/redis-subscriber
@@ -65,7 +59,3 @@ object(FriendsOfHyperf\Redis\Subscriber\Message)#8 (2) {
 | punsubscribe(string ...$channels) : void | 取消通配订阅 |
 | channel() : Hyperf\Engine\Channel | 获取消息通道 |
 | close() : void | 关闭订阅 |
-
-## License
-
-MIT

--- a/src/sentry/README.md
+++ b/src/sentry/README.md
@@ -1,5 +1,7 @@
 # Sentry
 
+[中文说明](README_CN.md)
+
 [![Latest Version](https://img.shields.io/packagist/v/friendsofhyperf/sentry.svg?style=flat-square)](https://packagist.org/packages/friendsofhyperf/sentry)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/sentry.svg?style=flat-square)](https://packagist.org/packages/friendsofhyperf/sentry)
 [![GitHub license](https://img.shields.io/github/license/friendsofhyperf/sentry)](https://github.com/friendsofhyperf/sentry)

--- a/src/sentry/README_CN.md
+++ b/src/sentry/README_CN.md
@@ -1,0 +1,105 @@
+# Sentry
+
+[English](README.md)
+
+Hyperf 的 Sentry 组件。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/sentry
+```
+
+## 发布配置
+
+```shell
+php bin/hyperf.php vendor:publish friendsofhyperf/sentry
+```
+
+## 注册 LoggerHandler
+
+```php
+<?php
+
+# use it send customer log to sentry
+//\FriendsOfHyperf\Helpers\logs('project-name', 'sentry')->warning('this is a test warning issue!');
+
+return [
+    // ...
+    'sentry' => [
+        'handler' => [
+            'class' => \FriendsOfHyperf\Sentry\Monolog\LogsHandler::class,
+            'constructor' => [
+                'group' => 'sentry',
+                'level' => \Sentry\Logs\LogLevel::debug(),
+                'bubble' => true,
+            ],
+        ],
+        'formatter' => [
+            'class' => \Monolog\Formatter\LineFormatter::class,
+            'constructor' => [
+                'format' => null,
+                'dateFormat' => null,
+                'allowInlineLineBreaks' => true,
+            ]
+        ],
+    ],
+    // ...
+];
+
+```
+
+## 配置 Sentry 运行日志
+
+```php
+<?php
+
+# config/autoload/sentry.php
+return [
+    // ...
+    'logger' => Hyperf\Contract\StdoutLoggerInterface::class,
+    // ...
+];
+```
+
+## 注解
+
+```php
+<?php
+namespace App;
+
+use FriendsOfHyperf\Sentry\Annotation\Breadcrumb;
+
+class Foo
+{
+    #[Breadcrumb(category: 'foo')]
+    public function bar($a = 1, $b = 2)
+    {
+        return __METHOD__;
+    }
+}
+```
+
+## 链路追踪
+
+```env
+SENTRY_TRACING_ENABLE_AMQP=true
+SENTRY_TRACING_ENABLE_ASYNC_QUEUE=true
+SENTRY_TRACING_ENABLE_COMMAND=true
+SENTRY_TRACING_ENABLE_CRONTAB=true
+SENTRY_TRACING_ENABLE_KAFKA=true
+SENTRY_TRACING_ENABLE_MISSING_ROUTES=true
+SENTRY_TRACING_ENABLE_REQUEST=true
+SENTRY_TRACING_SPANS_COROUTINE=true
+SENTRY_TRACING_SPANS_DB=true
+SENTRY_TRACING_SPANS_ELASTICSEARCH=true
+SENTRY_TRACING_SPANS_GUZZLE=true
+SENTRY_TRACING_SPANS_RPC=true
+SENTRY_TRACING_SPANS_REDIS=true
+SENTRY_TRACING_SPANS_SQL_QUERIES=true
+```
+
+## Sentry 开发文档
+
+- OpenTelemetry 语义约定 [semantic-conventions](https://github.com/open-telemetry/semantic-conventions/tree/main)
+- Sentry Span 操作命名规范 [span-operations](https://develop.sentry.dev/sdk/performance/span-operations/#database)

--- a/src/support/README.md
+++ b/src/support/README.md
@@ -1,5 +1,7 @@
 # Support
 
+[中文说明](README_CN.md)
+
 [![Latest Version](https://img.shields.io/packagist/v/friendsofhyperf/support.svg?style=flat-square)](https://packagist.org/packages/friendsofhyperf/support)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/support.svg?style=flat-square)](https://packagist.org/packages/friendsofhyperf/support)
 [![GitHub license](https://img.shields.io/github/license/friendsofhyperf/support)](https://github.com/friendsofhyperf/support)

--- a/src/support/README_CN.md
+++ b/src/support/README_CN.md
@@ -1,0 +1,108 @@
+# Support
+
+[English](README.md)
+
+Support 组件提供 FriendsOfHyperf 各组件共享的工具，包括流式派发 API、可序列化闭包任务和
+重试退避策略。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/support
+```
+
+AMQP、Kafka 和异步队列集成为可选功能。派发对应消息类型前，请先安装相应的 Hyperf 组件。
+
+## 流式派发
+
+`dispatch()` 辅助函数会根据传入值的类型选择待派发对象：
+
+- `Closure` 会创建 `CallQueuedClosure` 并使用异步队列派发器。
+- `ProducerMessageInterface` 使用 AMQP 生产者派发器。
+- `ProduceMessage` 使用 Kafka 生产者派发器。
+- 其他值会被拒绝，并抛出 `InvalidArgumentException`。
+
+### 异步队列
+
+```php
+use function FriendsOfHyperf\Support\dispatch;
+
+dispatch(function (UserService $users) {
+    $users->synchronize();
+})
+    ->onPool('default')
+    ->delay(30)
+    ->setMaxAttempts(3);
+```
+
+闭包支持依赖注入。待派发对象会在销毁时派发任务。
+
+### AMQP 与 Kafka
+
+```php
+dispatch($amqpMessage)
+    ->onPool('default')
+    ->setExchange('events')
+    ->setRoutingKey('user.updated')
+    ->setTimeout(5)
+    ->setConfirm(true);
+
+dispatch($kafkaMessage)->onPool('default');
+```
+
+### 条件配置
+
+所有待派发对象都支持 `when()` 和 `unless()`：
+
+```php
+dispatch($job)
+    ->when($highPriority, fn ($pending) => $pending->onPool('high-priority'))
+    ->unless($canRunNow, fn ($pending) => $pending->delay(60));
+```
+
+## 闭包任务
+
+需要将闭包任务传递给其他 API 时，可以直接创建可序列化的异步队列任务：
+
+```php
+use FriendsOfHyperf\Support\CallQueuedClosure;
+
+$job = CallQueuedClosure::create(function () {
+    return 'completed';
+});
+$job->setMaxAttempts(3);
+```
+
+## 退避策略
+
+退避策略实现会返回下一次等待的毫秒数，并提供 `next()`、`reset()`、`getAttempt()` 和
+`sleep()` 方法。
+
+### 数组退避
+
+```php
+use FriendsOfHyperf\Support\Backoff\ArrayBackoff;
+
+$custom = new ArrayBackoff([100, 500, 1000, 2000]);
+$short = ArrayBackoff::fromPattern('short');
+$fromString = ArrayBackoff::fromString('100, 500, 1000');
+```
+
+如果希望数组耗尽后返回 `0`，而不是重复最后一个值，请将构造函数第二个参数设为 `false`。
+
+### 可用策略
+
+- `FixedBackoff`：固定等待时间。
+- `LinearBackoff`：按固定步长增加等待时间。
+- `ExponentialBackoff`：指数增长，可选抖动。
+- `FibonacciBackoff`：使用斐波那契数列等待时间。
+- `PoissonBackoff`：基于泊松分布生成等待时间。
+- `DecorrelatedJitterBackoff`：为分布式重试提供去相关抖动。
+- `ArrayBackoff`：使用调用方定义的等待序列。
+
+## 其他工具
+
+此组件还包含 `retry()` 和 `once()` 辅助函数，以及 `ConfigurationUrlParser`、`Env`、
+`HtmlString`、`Number`、`Once`、`Sleep`、`Timebox`、`UuidContainer`、`RedisCommand`、
+管道辅助功能和可复用 Trait。在其他组件新增重复工具前，请先检查
+`FriendsOfHyperf\Support` 下已有的类。

--- a/src/tcp-sender/README.md
+++ b/src/tcp-sender/README.md
@@ -1,5 +1,7 @@
 # TcpSender
 
+[中文说明](README_CN.md)
+
 [![Latest Version](https://img.shields.io/packagist/v/friendsofhyperf/tcp-sender.svg?style=flat-square)](https://packagist.org/packages/friendsofhyperf/tcp-sender)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/tcp-sender.svg?style=flat-square)](https://packagist.org/packages/friendsofhyperf/tcp-sender)
 [![GitHub license](https://img.shields.io/github/license/friendsofhyperf/tcp-sender)](https://github.com/friendsofhyperf/tcp-sender)

--- a/src/tcp-sender/README_CN.md
+++ b/src/tcp-sender/README_CN.md
@@ -1,0 +1,151 @@
+# Tcp Sender
+
+[English](README.md)
+
+## 简介
+
+`friendsofhyperf/tcp-sender` 是一个类似 `hyperf/websocket-server` 的 TCP 服务组件，可以用于向指定的 fd 发送消息。
+无需额外关注底层的实现，只需关注业务逻辑即可。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/tcp-sender
+```
+
+## 使用
+
+### 配置 config/autoload/servers.php
+
+```php
+'servers' => [
+        [
+            'name' => 'tcp',
+            'type' => Server::SERVER_BASE,
+            'host' => '0.0.0.0',
+            'port' => 9401,
+            'sock_type' => SWOOLE_SOCK_TCP,
+            'callbacks' => [
+                Event::ON_CONNECT => [TcpServer::class,'onConnect'],
+                Event::ON_CLOSE => [TcpServer::class,'onClose'],
+                Event::ON_RECEIVE => [TcpServer::class,'onReceive'],
+            ],
+            'options' => [
+                // Whether to enable request lifecycle event
+                'enable_request_lifecycle' => false,
+            ],
+        ]
+    ],
+```
+
+### 异步风格
+
+```php
+<?php
+
+namespace App;
+
+use Hyperf\Contract\OnCloseInterface;
+use Hyperf\Contract\OnReceiveInterface;
+use FriendsOfHyperf\TcpSender\Sender;
+use Swoole\Server;
+
+class TcpServer implements OnCloseInterface,OnReceiveInterface
+{
+    public function __construct(private Sender $sender)
+    {
+    }
+
+    /**
+     * @param Server $server
+     */
+    public function onConnect($server, $fd, $reactorId): void
+    {
+        $server->send($fd, sprintf('Client %s connected.'.PHP_EOL, $fd));
+    }
+
+    public function onClose($server, int $fd, int $reactorId): void
+    {
+        $server->send($fd, sprintf('Client %s closed.'.PHP_EOL, $fd));
+    }
+
+    public function onReceive($server, int $fd, int $reactorId, string $data): void
+    {
+        $server->send($fd, sprintf('Client %s send: %s'.PHP_EOL, $fd, $data));
+        var_dump($data);
+    }
+
+
+}
+```
+
+### 协程风格
+
+```php
+namespace App;
+
+use Hyperf\Contract\OnReceiveInterface;
+use FriendsOfHyperf\TcpSender\Sender;
+use Swoole\Coroutine\Server\Connection;
+use Swoole\Server;
+
+class TcpServer implements OnReceiveInterface
+{
+    public function __construct(private Sender $sender)
+    {
+    }
+
+    public function onConnect(Connection $connection, $fd): void
+    {
+        // 设置 fd 和 connection 的映射关系
+        $this->sender->setResponse($fd,$connection);
+        $connection->send(sprintf('Client %s connected.'.PHP_EOL, $fd));
+    }
+
+    public function onClose($connection, int $fd): void
+    {
+        // 删除 fd 和 connection 的映射关系
+        $this->sender->setResponse($fd,null);
+    }
+
+    public function onReceive($server, int $fd, int $reactorId, string $data): void
+    {
+        $server->send($fd, sprintf('Client %s send: %s'.PHP_EOL, $fd, $data));
+    }
+
+
+}
+```
+
+## 在控制器中使用
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use FriendsOfHyperf\TcpSender\Sender;
+
+class IndexController extends AbstractController
+{
+    public function __construct(private Sender $sender)
+    {
+    }
+
+    public function index()
+    {
+        // 向指定的fd发送消息
+        $this->sender->send(1, 'Hello Hyperf.');
+        $user = $this->request->input('user', 'Hyperf');
+        $method = $this->request->getMethod();
+
+        return [
+            'method' => $method,
+            'message' => "Hello {$user}.",
+        ];
+    }
+}
+
+```

--- a/src/telescope-elasticsearch/README.md
+++ b/src/telescope-elasticsearch/README.md
@@ -1,5 +1,7 @@
 # Telescope Elasticsearch Driver
 
+[中文说明](README_CN.md)
+
 [![Latest Version](https://img.shields.io/packagist/v/friendsofhyperf/telescope-elasticsearch.svg?style=flat-square)](https://packagist.org/packages/friendsofhyperf/telescope-elasticsearch)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/telescope-elasticsearch.svg?style=flat-square)](https://packagist.org/packages/friendsofhyperf/telescope-elasticsearch)
 [![GitHub license](https://img.shields.io/github/license/friendsofhyperf/telescope-elasticsearch)](https://github.com/friendsofhyperf/telescope-elasticsearch)

--- a/src/telescope-elasticsearch/README_CN.md
+++ b/src/telescope-elasticsearch/README_CN.md
@@ -1,0 +1,36 @@
+# Telescope Elasticsearch Driver
+
+[English](README.md)
+
+它允许您从 SQL 数据库切换到 Elasticsearch 作为数据存储的驱动程序，并且它将消除死锁，使 Telescope 成为一个可用于生产环境的日志系统。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/telescope-elasticsearch
+```
+
+## 发布配置
+
+```shell
+php bin/hyperf.php vendor:publish friendsofhyperf/telescope --id=config
+```
+
+## 配置
+
+```php
+// config/autoload/telescope.php
+return [
+    'driver' => 'elasticsearch',
+    'storage' => [
+        'elasticsearch' => [
+            'driver' => FriendsOfHyperf\TelescopeElasticsearch\Storage\ElasticsearchEntriesRepository::class,
+            'index' => 'telescope_entries',
+
+            'hosts' => ['127.0.0.1'],
+            'username' => null,
+            'password' => null,
+        ],
+    ],
+];
+```

--- a/src/telescope/README.md
+++ b/src/telescope/README.md
@@ -1,5 +1,7 @@
 # Telescope
 
+[中文说明](README_CN.md)
+
 ## Available Listeners
 
 - [x] Request Monitor

--- a/src/telescope/README_CN.md
+++ b/src/telescope/README_CN.md
@@ -1,0 +1,118 @@
+# Telescope
+
+[English](README.md)
+
+## 可用监听器
+
+- [x] 请求监视器
+- [x] 异常监视器
+- [x] 数据查询监视器
+- [x] gRPC请求监视器
+- [x] Redis监视器
+- [x] 日志监视器
+- [x] 命令行监视器
+- [x] 事件监视器
+- [x] HTTP Client 监视器
+- [x] 缓存监视器
+- [x] 定时任务监视器
+
+## 安装
+
+```shell
+composer require friendsofhyperf/telescope
+```
+
+使用 `vendor:publish`  命令来发布其公共资源
+
+```shell
+php bin/hyperf.php vendor:publish friendsofhyperf/telescope
+```
+
+运行 `migrate` 命令执行数据库变更来创建和保存 Telescope 需要的数据
+
+```shell
+php bin/hyperf.php migrate
+```
+
+## 使用
+
+### 中间件（可选，仅用于gRPC）
+
+在 `config/autoload/middlewares.php`配置文件加上中间件
+
+如需gRPC的额外功能，请使用`grpc`中间件
+
+```php
+<?php
+
+return [
+    'grpc' => [
+        FriendsOfHyperf\Telescope\Middleware\TelescopeMiddleware::class,
+    ],
+];
+```
+
+> 注意: 请求跟踪功能已通过 RequestHandledListener 自动启用。TelescopeMiddleware 仅用于 gRPC 的额外功能。
+
+## 查看仪表板
+
+`http://127.0.0.1:9501/telescope`
+
+## 数据库配置
+
+在 `config/autoload/telescope.php`管理数据库连接配置，默认使用`default`连接
+
+```php
+'connection' => env('TELESCOPE_DB_CONNECTION', 'default'),
+```
+
+## 标签
+
+您可能希望将自己的自定义标签附加到条目。为此，您可以使用 **`Telescope::tag`**  方法。
+
+## 批量过滤
+
+您可能只想记录某些特殊条件下的条目。为此，您可以使用 **`Telescope::filter`** 方法。
+
+例子
+
+```php
+use FriendsOfHyperf\Telescope\Telescope;
+use Hyperf\Event\Contract\ListenerInterface;
+use Hyperf\Framework\Event\BootApplication;
+use FriendsOfHyperf\Telescope\IncomingEntry;
+
+class TelescopeInitListener implements ListenerInterface
+{
+    public function listen(): array
+    {
+        return [
+            BootApplication::class,
+        ];
+    }
+
+    public function process(object $event): void
+    {
+        // attach your own custom tags
+        Telescope::tag(function (IncomingEntry $entry) {
+            if ($entry->type === 'request') {
+                return [
+                    'status:' . $entry->content['response_status'],
+                    'uri:'. $entry->content['uri'],
+                ];
+            }
+        });
+
+        // filter entry
+        Telescope::filter(function (IncomingEntry $entry): bool {
+            if ($entry->type === 'request'){
+                if ($entry->content['uri'] == 'xxxx') {
+                    return false;
+                }
+            }
+            return true;
+        });
+
+    }
+}
+```

--- a/src/tinker/README.md
+++ b/src/tinker/README.md
@@ -1,5 +1,7 @@
 # Tinker
 
+[中文说明](README_CN.md)
+
 [![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/tinker)](https://packagist.org/packages/friendsofhyperf/tinker)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/tinker)](https://packagist.org/packages/friendsofhyperf/tinker)
 [![License](https://img.shields.io/packagist/l/friendsofhyperf/tinker)](https://github.com/friendsofhyperf/tinker)

--- a/src/tinker/README_CN.md
+++ b/src/tinker/README_CN.md
@@ -1,0 +1,191 @@
+# Tinker
+
+[English](README.md)
+
+Hyperf 的强大的 REPL 工具。
+
+## 安装
+
+```shell
+composer require friendsofhyperf/tinker
+```
+
+## 发布配置
+
+```shell
+php bin/hyperf.php vendor:publish friendsofhyperf/tinker
+```
+
+## 使用
+
+```shell
+php bin/hyperf.php tinker
+```
+
+## 命令
+
+- 运行命令
+
+````shell
+Psy Shell v0.10.4 (PHP 7.3.11 — cli)
+>>> $a=1
+=> 1
+>>> $a
+=> 1
+>>> define('VERSION', 'v1.0.1')
+=> true
+>>> VERSION
+=> "v1.0.1"
+>>>
+````
+
+- 查看命令帮助
+
+```shell
+>>> help
+  help             Show a list of commands. Type `help [foo]` for information about [foo].      Aliases: ?
+  ls               List local, instance or class variables, methods and constants.              Aliases: dir
+  dump             Dump an object or primitive.
+  doc              Read the documentation for an object, class, constant, method or property.   Aliases: rtfm, man
+  show             Show the code for an object, class, constant, method or property.
+  wtf              Show the backtrace of the most recent exception.                             Aliases: last-exception, wtf?
+  whereami         Show where you are in the code.
+  throw-up         Throw an exception or error out of the Psy Shell.
+  timeit           Profiles with a timer.
+  trace            Show the current call stack.
+  buffer           Show (or clear) the contents of the code input buffer.                       Aliases: buf
+  clear            Clear the Psy Shell screen.
+  edit             Open an external editor. Afterwards, get produced code in input buffer.
+  sudo             Evaluate PHP code, bypassing visibility restrictions.
+  history          Show the Psy Shell history.                                                  Aliases: hist
+  exit             End the current session and return to caller.                                Aliases: quit, q
+  clear-compiled   Remove the compiled class file
+  down             Put the application into maintenance mode
+  env              Display the current framework environment
+  optimize         Cache the framework bootstrap files
+  up               Bring the application out of maintenance mode
+  migrate          Run the database migrations
+  inspire          Display an inspiring quote
+```
+
+- 获取环境变量
+
+```shell
+Psy Shell v0.10.4 (PHP 7.2.34 — cli)
+>>> env("APP_NAME")
+=> "skeleton"
+>>>
+```
+
+- 模型操作
+
+```shell
+➜  t.hyperf.com git:(master) ✗ php bin/hyperf.php tinker
+[DEBUG] Event Hyperf\Framework\Event\BootApplication handled by Hyperf\Config\Listener\RegisterPropertyHandlerListener listener.
+[DEBUG] Event Hyperf\Framework\Event\BootApplication handled by Hyperf\Paginator\Listener\PageResolverListener listener.
+[DEBUG] Event Hyperf\Framework\Event\BootApplication handled by Hyperf\ExceptionHandler\Listener\ExceptionHandlerListener listener.
+[DEBUG] Event Hyperf\Framework\Event\BootApplication handled by Hyperf\DbConnection\Listener\RegisterConnectionResolverListener listener.
+Psy Shell v0.10.4 (PHP 7.2.34 — cli) by Justin Hileman
+Unable to check for updates
+>>> $user = App\Model\User::find(1)
+[DEBUG] Event Hyperf\Database\Model\Events\Booting handled by Hyperf\ModelListener\Listener\ModelHookEventListener listener.
+[DEBUG] Event Hyperf\Database\Model\Events\Booting handled by Hyperf\ModelListener\Listener\ModelEventListener listener.
+[DEBUG] Event Hyperf\Database\Model\Events\Booted handled by Hyperf\ModelListener\Listener\ModelHookEventListener listener.
+[DEBUG] Event Hyperf\Database\Model\Events\Booted handled by Hyperf\ModelListener\Listener\ModelEventListener listener.
+[DEBUG] Event Hyperf\Database\Events\QueryExecuted handled by App\Listener\DbQueryExecutedListener listener.
+[DEBUG] Event Hyperf\Database\Model\Events\Retrieved handled by Hyperf\ModelListener\Listener\ModelHookEventListener listener.
+[DEBUG] Event Hyperf\Database\Model\Events\Retrieved handled by Hyperf\ModelListener\Listener\ModelEventListener listener.
+=> App\Model\User {#81816
+     +incrementing: true,
+     +exists: true,
+     +wasRecentlyCreated: false,
+     +timestamps: true,
+   }
+>>> var_dump($user)
+object(App\Model\User)#81816 (28) {
+  ["table":protected]=>
+  string(5) "users"
+  ["fillable":protected]=>
+  array(2) {
+    [0]=>
+    string(2) "id"
+    [1]=>
+    string(4) "name"
+  }
+  ["casts":protected]=>
+  array(0) {
+  }
+  ["incrementing"]=>
+  bool(true)
+  ["exists"]=>
+  bool(true)
+
+  ["attributes":protected]=>
+  array(4) {
+    ["id"]=>
+    int(1)
+    ["name"]=>
+    string(5) "arvin"
+    ["created_at"]=>
+    string(19) "2020-11-23 18:38:00"
+    ["updated_at"]=>
+    string(19) "2020-11-23 18:38:03"
+  }
+  ["original":protected]=>
+  array(4) {
+    ["id"]=>
+    int(1)
+    ["name"]=>
+    string(5) "arvin"
+    ["created_at"]=>
+    string(19) "2020-11-23 18:38:00"
+    ["updated_at"]=>
+    string(19) "2020-11-23 18:38:03"
+  }
+
+}
+=> null
+```
+
+- 查看文档
+
+```shell
+>>> doc md5
+function md5($str, $raw_output = unknown)
+
+PHP manual not found
+    To document core PHP functionality, download the PHP reference manual:
+    https://github.com/bobthecow/psysh/wiki/PHP-manual
+>>>
+```
+
+- 查看源码
+
+```shell
+>>> show App\Model\User
+ 7: /**
+ 8:  */
+ 9: class User extends Model
+10: {
+11:     /**
+12:      * The table associated with the model.
+13:      *
+14:      * @var string
+15:      */
+16:     protected $table = 'users';
+17:     /**
+18:      * The attributes that are mass assignable.
+19:      *
+20:      * @var array
+21:      */
+22:     protected $fillable = ['id','name'];
+23:     /**
+24:      * The attributes that should be cast to native types.
+25:      *
+26:      * @var array
+27:      */
+28:     protected $casts = [];
+29: }
+
+>>>
+```

--- a/src/trigger/README.md
+++ b/src/trigger/README.md
@@ -1,5 +1,7 @@
 # Trigger
 
+[中文说明](README_CN.md)
+
 [![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/trigger)](https://packagist.org/packages/friendsofhyperf/trigger)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/trigger)](https://packagist.org/packages/friendsofhyperf/trigger)
 [![License](https://img.shields.io/packagist/l/friendsofhyperf/trigger)](https://github.com/friendsofhyperf/trigger)

--- a/src/trigger/README_CN.md
+++ b/src/trigger/README_CN.md
@@ -1,0 +1,75 @@
+# Trigger
+
+[English](README.md)
+
+## 安装
+
+- 安装
+
+```shell
+composer require friendsofhyperf/trigger
+```
+
+- 发布配置
+
+```shell
+php bin/hyperf.php vendor:publish friendsofhyperf/trigger
+```
+
+## 添加监听器
+
+```php
+// config/autoload/listeners.php
+
+return [
+    FriendsOfHyperf\Trigger\Listener\BindTriggerProcessesListener::class => PHP_INT_MAX,
+];
+```
+
+## 定义触发器
+
+```php
+namespace App\Trigger;
+
+use FriendsOfHyperf\Trigger\Annotation\Trigger;
+use FriendsOfHyperf\Trigger\Trigger\AbstractTrigger;
+use MySQLReplication\Event\DTO\EventDTO;
+
+#[Trigger(table:"table", events:["*"], connection:"default")]
+class FooTrigger extends AbstractTrigger
+{
+    public function onWrite(array $new)
+    {
+        var_dump($new);
+    }
+
+    public function onUpdate(array $old, array $new)
+    {
+        var_dump($old, $new);
+    }
+
+    public function onDelete(array $old)
+    {
+        var_dump($old);
+    }
+}
+```
+
+## 定义订阅者
+
+```php
+namespace App\Subscriber;
+
+use FriendsOfHyperf\Trigger\Annotation\Subscriber;
+use FriendsOfHyperf\Trigger\Subscriber\AbstractSubscriber;
+use MySQLReplication\Event\DTO\EventDTO;
+
+#[Subscriber(connection:"default")]
+class BarSubscriber extends AbstractSubscriber
+{
+    protected function allEvents(EventDTO $event): void
+    {
+        // 一些代码
+    }
+}
+```

--- a/src/validated-dto/README.md
+++ b/src/validated-dto/README.md
@@ -1,5 +1,7 @@
 # Validated DTO
 
+[中文说明](README_CN.md)
+
 [![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/validated-dto)](https://packagist.org/packages/friendsofhyperf/validated-dto)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/validated-dto)](https://packagist.org/packages/friendsofhyperf/validated-dto)
 [![License](https://img.shields.io/packagist/l/friendsofhyperf/validated-dto)](https://github.com/friendsofhyperf/validated-dto)

--- a/src/validated-dto/README_CN.md
+++ b/src/validated-dto/README_CN.md
@@ -1,0 +1,659 @@
+# Validated DTO
+
+[English](README.md)
+
+## 官方文档
+
+[Laravel Validated DTO 官方文档](https://wendell-adriel.gitbook.io/laravel-validated-dto)
+
+## 安装
+
+```shell
+composer require friendsofhyperf/validated-dto
+```
+
+## 创建 DTO
+
+你可以使用 `gen:dto` 命令创建 `DTO`：
+
+```shell
+php bin/hyperf.php gen:dto UserDTO
+```
+
+`DTO` 将会被创建在 `app/DTO` 目录下。
+
+## 定义验证规则
+
+你可以像验证 `Request` 数据一样验证数据：
+
+```php
+<?php
+
+namespace App\DTO;
+
+use FriendsOfHyperf\ValidatedDTO\ValidatedDTO;
+
+class UserDTO extends ValidatedDTO
+{
+    protected function rules(): array
+    {
+        return [
+            'name'     => ['required', 'string'],
+            'email'    => ['required', 'email'],
+            'password' => ['required'],
+        ];
+    }
+}
+```
+
+## 创建 DTO 实例
+
+你可以通过多种方式创建 `DTO` 实例：
+
+### 从数组创建
+
+```php
+$dto = UserDTO::fromArray([
+    'name' => 'Deeka Wong',
+    'email' => 'deeka@example.com',
+    'password' => 'D3Crft!@1b2A'
+]);
+```
+
+### 从 JSON 字符串创建
+
+```php
+$dto = UserDTO::fromJson('{"name": "Deeka Wong", "email": "deeka@example.com", "password": "D3Crft!@1b2A"}');
+```
+
+### 从请求对象创建
+
+```php
+public function store(RequestInterface $request): JsonResponse
+{
+    $dto = UserDTO::fromRequest($request);
+}
+```
+
+### 从模型创建
+
+```php
+$user = new User([
+    'name' => 'Deeka Wong',
+    'email' => 'deeka@example.com',
+    'password' => 'D3Crft!@1b2A'
+]);
+
+$dto = UserDTO::fromModel($user);
+```
+
+注意，模型中 `$hidden` 属性的字段不会被用于 `DTO`。
+
+### 从 Artisan 命令创建
+
+你有三种方式从 `Artisan Command` 创建 `DTO` 实例：
+
+#### 从命令参数创建
+
+```php
+<?php
+
+use App\DTO\UserDTO;
+use Hyperf\Command\Command;
+
+class CreateUserCommand extends Command
+{
+    protected ?string $signature = 'create:user {name} {email} {password}';
+
+    protected string $description = 'Create a new User';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     *
+     * @throws ValidationException
+     */
+    public function handle()
+    {
+        $dto = UserDTO::fromCommandArguments($this);
+    }
+}
+```
+
+#### 从命令选项创建
+
+```php
+<?php
+
+use App\DTO\UserDTO;
+use Hyperf\Command\Command;
+
+class CreateUserCommand extends Command
+{
+    protected ?string $signature = 'create:user { --name= : The user name } { --email= : The user email } { --password= : The user password }';
+
+    protected string $description = 'Create a new User';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     * @throws ValidationException
+     */
+    public function handle()
+    {
+        $dto = UserDTO::fromCommandOptions($this);
+    }
+}
+```
+
+#### 从命令参数和选项创建
+
+```php
+<?php
+
+use App\DTO\UserDTO;
+use Hyperf\Command\Command;
+
+class CreateUserCommand extends Command
+{
+    protected ?string $signature = 'create:user {name}
+                                        { --email= : The user email }
+                                        { --password= : The user password }';
+
+    protected string $description = 'Create a new User';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     *
+     * @throws ValidationException
+     */
+    public function handle()
+    {
+        $dto = UserDTO::fromCommand($this);
+    }
+}
+```
+
+## 导出 DTO 类型
+
+使用 `dto:export` 可以将 DTO 类导出为 TypeScript。传入完整 DTO 类名，也可以指定输出文件：
+
+```shell
+php bin/hyperf.php dto:export 'App\DTO\UserDTO'
+php bin/hyperf.php dto:export 'App\DTO\UserDTO' --output=resources/types/user.dto.ts --force
+```
+
+`--lang` 选项支持 `typescript` 或 `ts`。
+
+## 访问 DTO 数据
+
+创建 `DTO` 实例后，你可以像访问 `object` 一样访问任何属性：
+
+```php
+$dto = UserDTO::fromArray([
+    'name' => 'Deeka Wong',
+    'email' => 'deeka@example.com',
+    'password' => 'D3Crft!@1b2A'
+]);
+
+$dto->name; // 'Deeka Wong'
+$dto->email; // 'deeka@example.com'
+$dto->password; // 'D3Crft!@1b2A'
+```
+
+如果你传递的属性不在 `DTO` 的 `rules` 方法中，这些数据将被忽略，并且不会在 `DTO` 中可用：
+
+```php
+$dto = UserDTO::fromArray([
+    'name' => 'Deeka Wong',
+    'email' => 'deeka@example.com',
+    'password' => 'D3Crft!@1b2A',
+    'username' => 'john_doe',
+]);
+
+$dto->username; // 这个属性在 DTO 中不可用
+```
+
+## 定义默认值
+
+有时我们可能有一些可选属性，并且可以有默认值。你可以在 `defaults` 方法中定义 `DTO` 属性的默认值：
+
+```php
+<?php
+
+namespace App\DTO;
+
+use Hyperf\Stringable\Str;
+
+class UserDTO extends ValidatedDTO
+{
+    protected function rules(): array
+    {
+        return [
+            'name'     => ['required', 'string'],
+            'email'    => ['required', 'email'],
+            'username' => ['sometimes', 'string'],
+            'password' => ['required'],
+        ];
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'username' => Str::snake($this->name),
+        ];
+    }
+}
+```
+
+使用上面的 `DTO` 定义，你可以运行：
+
+```php
+$dto = UserDTO::fromArray([
+    'name' => 'Deeka Wong',
+    'email' => 'deeka@example.com',
+    'password' => 'D3Crft!@1b2A'
+]);
+
+$dto->username; // 'deeka_wong'
+```
+
+## 转换 DTO 数据
+
+你可以将你的 DTO 转换为一些格式：
+
+### 转换为数组
+
+```php
+$dto = UserDTO::fromArray([
+    'name' => 'Deeka Wong',
+    'email' => 'deeka@example.com',
+    'password' => 'D3Crft!@1b2A',
+]);
+
+$dto->toArray();
+// [
+//     "name" => "Deeka Wong",
+//     "email" => "deeka@example.com",
+//     "password" => "D3Crft!@1b2A",
+// ]
+```
+
+### 转换为 JSON 字符串
+
+```php
+$dto = UserDTO::fromArray([
+    'name' => 'Deeka Wong',
+    'email' => 'deeka@example.com',
+    'password' => 'D3Crft!@1b2A',
+]);
+
+$dto->toJson();
+// '{"name":"Deeka Wong","email":"deeka@example.com","password":"D3Crft!@1b2A"}'
+
+$dto->toJson(true); // 你可以这样调用它来美化打印你的 JSON
+// {
+//     "name": "Deeka Wong",
+//     "email": "deeka@example.com",
+//     "password": "D3Crft!@1b2A"
+// }
+```
+
+### 转换为 Eloquent 模型
+
+```php
+$dto = UserDTO::fromArray([
+    'name' => 'Deeka Wong',
+    'email' => 'deeka@example.com',
+    'password' => 'D3Crft!@1b2A',
+]);
+
+$dto->toModel(\App\Model\User::class);
+// App\Model\User {#3776
+//     name: "Deeka Wong",
+//     email: "deeka@example.com",
+//     password: "D3Crft!@1b2A",
+// }
+
+```
+
+## 自定义错误消息、属性和异常
+
+你可以通过在 `DTO` 类中实现 `messages` 和 `attributes` 方法来定义自定义消息和属性：
+
+```php
+/**
+ * 定义验证器错误的自定义消息。
+ */
+protected function messages() {
+    return [];
+}
+
+/**
+ * 定义验证器错误的自定义属性。
+ */
+protected function attributes() {
+    return [];
+}
+```
+
+## 自定义规则
+
+你可以在 `afterValidatorResolving` 方法中添加 DTO 专用的自定义规则，也可以通过 Hyperf 的 `ValidatorFactoryResolved` 事件添加全局自定义规则。
+
+这取决于你的代码维护习惯，如果规则仅在单一 DTO 中使用，那么建议在 `afterValidatorResolving` 方法中添加，根据 `就近原则` 将会使得源码更易读。
+
+```php
+
+use Hyperf\Contract\ValidatorInterface;
+use Hyperf\Validation\Validator;
+
+protected function afterValidatorResolving(ValidatorInterface $validator): void
+{
+    if (! $validator instanceof Validator) {
+        return;
+    }
+
+    $validator->addExtension('diy_rule', function ($attribute, $value, $parameters, $validator) {
+        return $value === 'diy_rule';
+    });
+}
+```
+
+## 类型转换
+
+你可以通过在 `DTO` 中定义 `casts` 方法轻松转换你的 DTO 属性：
+
+```php
+/**
+ * 定义 DTO 属性的类型转换。
+ *
+ * @return array
+ */
+protected function casts(): array
+{
+    return [
+        'name' => new StringCast(),
+        'age'  => new IntegerCast(),
+        'created_at' => new CarbonImmutableCast(),
+    ];
+}
+```
+
+## 可用类型
+
+### 数组
+
+对于 JSON 字符串，它将转换为数组，对于其他类型，它将包装在数组中。
+
+```php
+protected function casts(): array
+{
+    return [
+        'property' => new ArrayCast(),
+    ];
+}
+```
+
+### 布尔值
+
+对于字符串值，这使用 `filter_var` 函数和 `FILTER_VALIDATE_BOOLEAN` 标志。
+
+```php
+protected function casts(): array
+{
+    return [
+        'property' => new BooleanCast(),
+    ];
+}
+```
+
+### Carbon
+
+这接受 `Carbon` 构造函数接受的任何值。如果发现无效值，它将抛出 `\FriendsOfHyperf\ValidatedDTO\Exception\CastException` 异常。
+
+```php
+protected function casts(): array
+{
+    return [
+        'property' => new CarbonCast(),
+    ];
+}
+```
+
+你也可以在定义转换时传递一个时区，如果需要的话，它将在转换值时使用。
+
+```php
+protected function casts(): array
+{
+    return [
+        'property' => new CarbonCast('Europe/Lisbon'),
+    ];
+}
+```
+
+你也可以在定义转换时传递一个格式来用于转换值。如果属性的格式与指定的不同，它将抛出 `\FriendsOfHyperf\ValidatedDTO\Exception\CastException` 异常。
+
+```php
+protected function casts(): array
+{
+    return [
+        'property' => new CarbonCast('Europe/Lisbon', 'Y-m-d'),
+    ];
+}
+```
+
+### CarbonImmutable
+
+这接受 `CarbonImmutable` 构造函数接受的任何值。如果发现无效值，它将抛出 `\FriendsOfHyperf\ValidatedDTO\Exception\CastException` 异常。
+
+```php
+protected function casts(): array
+{
+    return [
+        'property' => new CarbonImmutableCast(),
+    ];
+}
+```
+
+你也可以在定义转换时传递一个时区，如果需要的话，它将在转换值时使用。
+
+```php
+protected function casts(): array
+{
+    return [
+        'property' => new CarbonImmutableCast('Europe/Lisbon'),
+    ];
+}
+```
+
+你也可以在定义转换时传递一个格式来用于转换值。如果属性的格式与指定的不同，它将抛出 `\FriendsOfHyperf\ValidatedDTO\Exception\CastException` 异常。
+
+```php
+protected function casts(): array
+{
+    return [
+        'property' => new CarbonImmutableCast('Europe/Lisbon', 'Y-m-d'),
+    ];
+}
+```
+
+### 集合
+
+对于 JSON 字符串，它将首先转换为数组，然后包装到 `Collection` 对象中。
+
+```php
+protected function casts(): array
+{
+    return [
+        'property' => new CollectionCast(),
+    ];
+}
+```
+
+如果你想转换 `Collection` 中的所有元素，你可以将 `Castable` 传递给 `CollectionCast` 构造函数。假设你想将 `Collection` 中的所有项目转换为整数：
+
+```php
+protected function casts(): array
+{
+    return [
+        'property' => new CollectionCast(new IntegerCast()),
+    ];
+}
+```
+
+这适用于所有 `Castable`，包括 `DTOCast` 和 `ModelCast` 用于嵌套数据。
+
+### DTO
+
+这适用于数组和 JSON 字符串。这将验证数据并为给定的 DTO 转换数据。
+
+如果数据对 DTO 无效，这将抛出 `Hyperf\Validation\ValidationException` 异常。
+
+如果属性不是有效的数组或有效的 JSON 字符串，这将抛出 `FriendsOfHyperf\ValidatedDTO\Exception\CastException` 异常。
+
+如果传递给 `DTOCast` 构造函数的类不是 `ValidatedDTO` 实例，这将抛出 `FriendsOfHyperf\ValidatedDTO\Exception\CastTargetException` 异常。
+
+```php
+protected function casts(): array
+{
+    return [
+        'property' => new DTOCast(UserDTO::class),
+    ];
+}
+```
+
+### 浮点数
+
+如果发现非数字值，它将抛出 `FriendsOfHyperf\ValidatedDTO\Exception\CastException` 异常。
+
+```php
+protected function casts(): array
+{
+    return [
+        'property' => new FloatCast(),
+    ];
+}
+```
+
+### 整数
+
+如果发现非数字值，它将抛出 `FriendsOfHyperf\ValidatedDTO\Exception\CastException` 异常。
+
+```php
+protected function casts(): array
+{
+    return [
+        'property' => new IntegerCast(),
+    ];
+}
+```
+
+### 模型
+
+这适用于数组和 JSON 字符串。
+
+如果属性不是有效的数组或有效的 JSON 字符串，这将抛出 `FriendsOfHyperf\ValidatedDTO\Exception\CastException` 异常。
+
+如果传递给 `ModelCast` 构造函数的类不是 `Model` 实例，这将抛出 `FriendsOfHyperf\ValidatedDTO\Exception\CastTargetException` 异常。
+
+```php
+protected function casts(): array
+{
+    return [
+        'property' => new ModelCast(User::class),
+    ];
+}
+```
+
+### 对象
+
+这适用于数组和 JSON 字符串。
+
+如果属性不是有效的数组或有效的 JSON 字符串，这将抛出 `FriendsOfHyperf\ValidatedDTO\Exception\CastException` 异常。
+
+```php
+protected function casts(): array
+{
+    return [
+        'property' => new ObjectCast(),
+    ];
+}
+```
+
+### 字符串
+
+如果数据不能转换为字符串，这将抛出 `FriendsOfHyperf\ValidatedDTO\Exception\CastException` 异常。
+
+```php
+protected function casts(): array
+{
+    return [
+        'property' => new StringCast(),
+    ];
+}
+```
+
+## 创建你自己的类型转换
+
+你可以通过实现 `FriendsOfHyperf\ValidatedDTO\Casting\Castable` 接口轻松为你的项目创建新的 `Castable` 类型。这个接口有一个必须实现的方法：
+
+```php
+/**
+ * 转换给定的值。
+ *
+ * @param  string  $property
+ * @param  mixed  $value
+ * @return mixed
+ */
+public function cast(string $property, mixed $value): mixed;
+```
+
+假设你的项目中有一个 `URLWrapper` 类，并且你希望在将 URL 传递给你的 `DTO` 时，它总是返回一个 `URLWrapper` 实例而不是一个简单的字符串：
+
+```php
+class URLCast implements Castable
+{
+    /**
+     * @param  string  $property
+     * @param  mixed  $value
+     * @return URLWrapper
+     */
+    public function cast(string $property, mixed $value): URLWrapper
+    {
+        return new URLWrapper($value);
+    }
+}
+```
+
+然后你可以将其应用到你的 DTO：
+
+```php
+use FriendsOfHyperf\ValidatedDTO\ValidatedDTO;
+
+class CustomDTO extends ValidatedDTO
+{
+    protected function rules(): array
+    {
+        return [
+            'url' => ['required', 'url'],
+        ];
+    }
+
+    protected function defaults(): array
+    {
+        return [];
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'url' => new URLCast(),
+        ];
+    }
+}
+```

--- a/src/web-tinker/README.md
+++ b/src/web-tinker/README.md
@@ -1,5 +1,7 @@
 # Web Tinker
 
+[中文说明](README_CN.md)
+
 [![Latest Stable Version](https://img.shields.io/packagist/v/friendsofhyperf/web-tinker)](https://packagist.org/packages/friendsofhyperf/web-tinker)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofhyperf/web-tinker)](https://packagist.org/packages/friendsofhyperf/web-tinker)
 [![License](https://img.shields.io/packagist/l/friendsofhyperf/web-tinker)](https://github.com/friendsofhyperf/web-tinker)

--- a/src/web-tinker/README_CN.md
+++ b/src/web-tinker/README_CN.md
@@ -1,0 +1,31 @@
+# Web Tinker
+
+[English](README.md)
+
+## 安装
+
+```shell
+composer require friendsofhyperf/web-tinker --dev
+```
+
+## 发布配置
+
+```shell
+php bin/hyperf.php vendor:publish friendsofhyperf/web-tinker
+```
+
+或
+
+```shell
+php bin/hyperf.php web-tinker:install
+```
+
+## 启动
+
+```shell
+php bin/hyperf.php start
+```
+
+## 访问
+
+访问 `http://127.0.0.1:9501/tinker` 即可进入 Web Tinker 页面。


### PR DESCRIPTION
## Summary
- add `README_CN.md` for component packages from existing `docs/zh-cn/components` content
- add language links between English and Chinese component README files

## Background
- component packages are independently installable and published from `src/<component>`
- Chinese component docs already exist under `docs/zh-cn/components`, but most package directories did not include `README_CN.md`

## Changes
- created missing Chinese README files for component packages
- updated existing Chinese README files to align with the zh-cn component docs and include an English link
- added `[中文说明](README_CN.md)` to English component README files that did not already link to Chinese docs

## Test Plan
- `git diff --check -- src/*/README.md src/*/README_CN.md`
- verified all 48 component directories, excluding `src/.github`, have both README files
- verified every English README links to `README_CN.md` and every Chinese README links to `README.md`
- subagent reviewed the final diff scope and README parity checks

## Risks
- documentation-only change
- English README bodies were not rewritten; they only received language links


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 为超过60个组件添加完整的中文说明文档，涵盖安装、配置、使用示例和API说明
  * 在所有英文README中新增指向中文文档的链接，方便中文用户快速切换

<!-- end of auto-generated comment: release notes by coderabbit.ai -->