### PR TITLE
🐛 fix(sentry): flush metrics in watchers and release captured refs in defer

### DIFF
--- a/src/sentry/publish/sentry.php
+++ b/src/sentry/publish/sentry.php
@@ -43,6 +43,9 @@ return [
     // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#enable_logs
     'enable_logs' => env('SENTRY_ENABLE_LOGS', true),
 
+    // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#log_flush_threshold
+    'log_flush_threshold' => env('SENTRY_LOG_FLUSH_THRESHOLD') === null ? null : (int) env('SENTRY_LOG_FLUSH_THRESHOLD'),
+
     // @see: https://docs.sentry.io/platforms/php/configuration/options/#before_send_log
     // 'before_send_log' => function (Sentry\Logs\Log $log): Sentry\Logs\Log {
     //     return $log;

--- a/src/sentry/src/Crons/Listener/EventHandleListener.php
+++ b/src/sentry/src/Crons/Listener/EventHandleListener.php
@@ -66,7 +66,6 @@ class EventHandleListener implements ListenerInterface
 
     protected function handleCrontabTaskStarting(Event\BeforeExecute $event, array $options): void
     {
-        $hub = SentrySdk::getCurrentHub();
         $slug = $event->crontab->getName();
         $rule = $event->crontab->getRule();
         $rules = explode(' ', $rule);
@@ -83,7 +82,7 @@ class EventHandleListener implements ListenerInterface
             $monitorConfig = $this->createMonitorConfig($event, $options, $rule);
         }
 
-        $checkInId = $hub->captureCheckIn(
+        $checkInId = SentrySdk::getCurrentHub()->captureCheckIn(
             slug: $slug,
             status: CheckInStatus::inProgress(),
             monitorConfig: $monitorConfig,
@@ -100,10 +99,9 @@ class EventHandleListener implements ListenerInterface
             return;
         }
 
-        $hub = SentrySdk::getCurrentHub();
         $slug = $event->crontab->getName();
 
-        $hub->captureCheckIn(
+        SentrySdk::getCurrentHub()->captureCheckIn(
             slug: $slug,
             status: CheckInStatus::ok(),
             checkInId: $checkInId,
@@ -118,10 +116,9 @@ class EventHandleListener implements ListenerInterface
             return;
         }
 
-        $hub = SentrySdk::getCurrentHub();
         $slug = $event->crontab->getName();
 
-        $hub->captureCheckIn(
+        SentrySdk::getCurrentHub()->captureCheckIn(
             slug: $slug,
             status: CheckInStatus::error(),
             checkInId: $checkInId,

--- a/src/sentry/src/Metrics/Listener/OnBeforeHandle.php
+++ b/src/sentry/src/Metrics/Listener/OnBeforeHandle.php
@@ -113,6 +113,8 @@ class OnBeforeHandle implements ListenerInterface
                     ['worker' => '0'],
                     Unit::megabyte()
                 );
+
+                metrics()->flush();
             }
         );
     }

--- a/src/sentry/src/Metrics/Listener/OnCoroutineServerStart.php
+++ b/src/sentry/src/Metrics/Listener/OnCoroutineServerStart.php
@@ -111,6 +111,8 @@ class OnCoroutineServerStart implements ListenerInterface
                     ['worker' => '0'],
                     Unit::megabyte()
                 );
+
+                metrics()->flush();
             }
         );
     }

--- a/src/sentry/src/Metrics/Listener/OnMetricFactoryReady.php
+++ b/src/sentry/src/Metrics/Listener/OnMetricFactoryReady.php
@@ -128,6 +128,8 @@ class OnMetricFactoryReady implements ListenerInterface
                     ['worker' => (string) $workerId],
                     Unit::megabyte()
                 );
+
+                metrics()->flush();
             }
         );
     }

--- a/src/sentry/src/Metrics/Listener/OnWorkerStart.php
+++ b/src/sentry/src/Metrics/Listener/OnWorkerStart.php
@@ -118,6 +118,8 @@ class OnWorkerStart implements ListenerInterface
                     ['worker' => (string) ($event->workerId ?? 0)],
                     Unit::megabyte()
                 );
+
+                metrics()->flush();
             }
         );
     }

--- a/src/sentry/src/Metrics/Listener/PoolWatcher.php
+++ b/src/sentry/src/Metrics/Listener/PoolWatcher.php
@@ -88,6 +88,8 @@ abstract class PoolWatcher implements ListenerInterface
                         'worker' => (string) $workerId,
                     ]
                 );
+
+                metrics()->flush();
             }
         );
     }

--- a/src/sentry/src/Metrics/Listener/QueueWatcher.php
+++ b/src/sentry/src/Metrics/Listener/QueueWatcher.php
@@ -82,6 +82,8 @@ class QueueWatcher implements ListenerInterface
                         ['queue' => $name]
                     );
                 }
+
+                metrics()->flush();
             }
         );
     }

--- a/src/sentry/src/Metrics/Listener/RequestWatcher.php
+++ b/src/sentry/src/Metrics/Listener/RequestWatcher.php
@@ -63,6 +63,8 @@ class RequestWatcher implements ListenerInterface
                 --$this->stats->connection_num;
 
                 $timer->end(true);
+
+                unset($timer);
             });
         }
     }

--- a/src/sentry/src/Tracing/Aspect/CoroutineAspect.php
+++ b/src/sentry/src/Tracing/Aspect/CoroutineAspect.php
@@ -27,9 +27,6 @@ use function FriendsOfHyperf\Sentry\trace;
 use function Hyperf\Coroutine\defer;
 use function Sentry\continueTrace;
 
-/**
- * Run after FriendsOfHyperf\Sentry\Aspect\CoroutineAspect.
- */
 class CoroutineAspect extends AbstractAspect
 {
     public const CONTEXT_KEYS = [
@@ -88,6 +85,7 @@ class CoroutineAspect extends AbstractAspect
                         defer(function () use ($transaction) {
                             $transaction->finish();
                             SentrySdk::endContext();
+                            unset($transaction);
                         });
 
                         return trace(

--- a/src/sentry/src/Tracing/Listener/EventHandleListener.php
+++ b/src/sentry/src/Tracing/Listener/EventHandleListener.php
@@ -336,6 +336,8 @@ class EventHandleListener implements ListenerInterface
 
             // Finish transaction
             $transaction->finish();
+
+            unset($transaction, $span);
         });
     }
 
@@ -532,6 +534,8 @@ class EventHandleListener implements ListenerInterface
 
             // Finish transaction
             $transaction->finish();
+
+            unset($transaction);
         });
     }
 
@@ -598,6 +602,8 @@ class EventHandleListener implements ListenerInterface
 
             // Finish transaction
             $transaction->finish();
+
+            unset($transaction);
         });
     }
 
@@ -663,6 +669,8 @@ class EventHandleListener implements ListenerInterface
 
             // Finish transaction
             $transaction->finish();
+
+            unset($transaction);
         });
     }
 
@@ -710,6 +718,8 @@ class EventHandleListener implements ListenerInterface
 
             // Finish transaction
             $transaction->finish();
+
+            unset($transaction);
         });
     }
 


### PR DESCRIPTION
## Summary
- 在多个 metrics watcher 的 tick 回调中调用 `metrics()->flush()`，确保指标及时上报到 Sentry
- 在 defer/闭包回调中 `unset()` 释放 `$transaction` / `$span` / `$timer` 等引用，避免闭包捕获延长对象生命周期（协程安全）
- 新增 `log_flush_threshold` 配置项
- Crons listener 中内联 `SentrySdk::getCurrentHub()` 调用

## Background
在 Swoole/Swow 协程环境下，闭包（defer/timer 回调）会捕获其作用域内的变量引用，可能导致 transaction/span 对象在协程结束前无法被回收，存在内存与上下文泄漏风险。同时部分 metrics watcher 在 tick 后未主动 flush，可能导致指标延迟上报或丢失。

## Changes
- `Metrics/Listener/*`：tick 回调末尾追加 `metrics()->flush()`
- `Tracing/Aspect/CoroutineAspect`：defer 回调中 `unset($transaction)`，移除冗余类注释
- `Tracing/Listener/EventHandleListener`：各 defer 回调中 `unset($transaction, $span)`
- `Metrics/Listener/RequestWatcher`：连接关闭回调中 `unset($timer)`
- `Crons/Listener/EventHandleListener`：移除局部 `\$hub` 变量，直接内联 `SentrySdk::getCurrentHub()`
- `publish/sentry.php`：新增 `log_flush_threshold` 配置项（默认 null）

## Test Plan
- [ ] 启动带 sentry 的 Hyperf 应用，触发定时任务/请求/队列，确认 Sentry 后台能收到 metrics 与 tracing 数据
- [ ] 长时间运行观察 worker 内存占用是否稳定
- [ ] 验证 `SENTRY_LOG_FLUSH_THRESHOLD` 环境变量生效

## Risks
- 改动集中在 sentry 组件，不影响其他组件
- `metrics()->flush()` 增加每次 tick 的上报频率，需关注 Sentry 配额
- 回滚：revert 本 commit 即可