### PR TITLE
fix(sentry): report skipped result when channel push fails

### DIFF
--- a/src/sentry/src/Transport/CoHttpTransport.php
+++ b/src/sentry/src/Transport/CoHttpTransport.php
@@ -70,7 +70,7 @@ class CoHttpTransport implements TransportInterface
 
         $chan = $this->chan;
         // push event to channel, if timeout is set, it will wait for the specified time
-        $result = $chan?->push($event, $this->timeout) ? ResultStatus::success() : ResultStatus::skipped();
+        $result = $chan?->push($event, $this->timeout) ? ResultStatus::success() : ResultStatus::failed();
 
         return new Result($result, $event);
     }

--- a/src/sentry/src/Transport/CoHttpTransport.php
+++ b/src/sentry/src/Transport/CoHttpTransport.php
@@ -70,7 +70,7 @@ class CoHttpTransport implements TransportInterface
 
         $chan = $this->chan;
         // push event to channel, if timeout is set, it will wait for the specified time
-        $result = $chan?->push($event, $this->timeout) ? ResultStatus::success() : ResultStatus::failed();
+        $result = $chan?->push($event, $this->timeout) ? ResultStatus::success() : ResultStatus::skipped();
 
         return new Result($result, $event);
     }

--- a/src/sentry/src/Transport/CoHttpTransport.php
+++ b/src/sentry/src/Transport/CoHttpTransport.php
@@ -70,9 +70,9 @@ class CoHttpTransport implements TransportInterface
 
         $chan = $this->chan;
         // push event to channel, if timeout is set, it will wait for the specified time
-        $chan?->push($event, $this->timeout);
+        $result = $chan?->push($event, $this->timeout) ? ResultStatus::success() : ResultStatus::skipped();
 
-        return new Result(ResultStatus::success(), $event);
+        return new Result($result, $event);
     }
 
     public function close(?int $timeout = null): Result


### PR DESCRIPTION
## Summary
- Report a skipped delivery result when `CoHttpTransport` cannot enqueue an event.

## Background
`CoHttpTransport::send()` previously returned `ResultStatus::success()` even when the channel push failed or the channel was unavailable, causing dropped events to be reported as delivered.

## Changes
- Capture the return value of `$chan?->push($event, $this->timeout)`.
- Return `ResultStatus::success()` when the event is accepted.
- Return `ResultStatus::skipped()` when the push fails or the channel is unavailable.

## Validation
- `git diff --check origin/main...HEAD` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进事件发送结果的反馈：系统现在会根据发送是否成功返回“成功”或“跳过”状态。
  * 即使发送通道不可用，也会正确记录并返回事件处理结果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->