### PR TITLE
ci(split): restrict workflow token permissions

### DIFF
--- a/.github/workflows/split.yaml
+++ b/.github/workflows/split.yaml
@@ -8,6 +8,9 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+
 jobs:
   split:
     name: Split on branch ${{ github.ref }}


### PR DESCRIPTION
## Summary
- Restrict the split workflow GITHUB_TOKEN to read-only contents access.

## Test Plan
- git diff --check
- actionlint .github/workflows/split.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **安全性**
  * 限制自动化工作流的权限范围，仅授予读取项目内容所需的权限。
  * 工作流的触发条件和执行逻辑保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->