### PR TITLE
fix(compoships): support Hyperf database 3.2.3 generics

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "hyperf/context": "~3.2.0",
         "hyperf/coroutine": "~3.2.0",
         "hyperf/crontab": "~3.2.0",
-        "hyperf/database": "~3.2.0",
+        "hyperf/database": "~3.2.3",
         "hyperf/db": "~3.2.0",
         "hyperf/db-connection": "~3.2.0",
         "hyperf/devtool": "~3.2.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,38 +26,8 @@ parameters:
 			path: src/compoships/src/Database/Eloquent/Model.php
 
 		-
-			message: "#^Return type \\(FriendsOfHyperf\\\\Compoships\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsTo\\) of method FriendsOfHyperf\\\\Compoships\\\\Database\\\\Eloquent\\\\Model\\:\\:belongsTo\\(\\) should be compatible with return type \\(Hyperf\\\\Database\\\\Model\\\\Relations\\\\BelongsTo\\<Hyperf\\\\Database\\\\Model\\\\Model, \\$this\\(Hyperf\\\\Database\\\\Model\\\\Model\\)\\>\\) of method Hyperf\\\\Database\\\\Model\\\\Model\\:\\:belongsTo\\(\\)$#"
-			count: 1
-			path: src/compoships/src/Database/Eloquent/Model.php
-
-		-
-			message: "#^Return type \\(FriendsOfHyperf\\\\Compoships\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsTo\\) of method FriendsOfHyperf\\\\Compoships\\\\Database\\\\Eloquent\\\\Model\\:\\:newBelongsTo\\(\\) should be compatible with return type \\(Hyperf\\\\Database\\\\Model\\\\Relations\\\\BelongsTo\\<Hyperf\\\\Database\\\\Model\\\\Model, \\$this\\(Hyperf\\\\Database\\\\Model\\\\Model\\)\\>\\) of method Hyperf\\\\Database\\\\Model\\\\Model\\:\\:newBelongsTo\\(\\)$#"
-			count: 1
-			path: src/compoships/src/Database/Eloquent/Model.php
-
-		-
-			message: "#^Return type \\(FriendsOfHyperf\\\\Compoships\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\) of method FriendsOfHyperf\\\\Compoships\\\\Database\\\\Eloquent\\\\Model\\:\\:hasMany\\(\\) should be compatible with return type \\(Hyperf\\\\Database\\\\Model\\\\Relations\\\\HasMany\\<Hyperf\\\\Database\\\\Model\\\\Model, \\$this\\(Hyperf\\\\Database\\\\Model\\\\Model\\)\\>\\) of method Hyperf\\\\Database\\\\Model\\\\Model\\:\\:hasMany\\(\\)$#"
-			count: 1
-			path: src/compoships/src/Database/Eloquent/Model.php
-
-		-
-			message: "#^Return type \\(FriendsOfHyperf\\\\Compoships\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\) of method FriendsOfHyperf\\\\Compoships\\\\Database\\\\Eloquent\\\\Model\\:\\:newHasMany\\(\\) should be compatible with return type \\(Hyperf\\\\Database\\\\Model\\\\Relations\\\\HasMany\\<Hyperf\\\\Database\\\\Model\\\\Model, Hyperf\\\\Database\\\\Model\\\\Model\\>\\) of method Hyperf\\\\Database\\\\Model\\\\Model\\:\\:newHasMany\\(\\)$#"
-			count: 1
-			path: src/compoships/src/Database/Eloquent/Model.php
-
-		-
-			message: "#^Return type \\(FriendsOfHyperf\\\\Compoships\\\\Database\\\\Eloquent\\\\Relations\\\\HasOne\\) of method FriendsOfHyperf\\\\Compoships\\\\Database\\\\Eloquent\\\\Model\\:\\:hasOne\\(\\) should be compatible with return type \\(Hyperf\\\\Database\\\\Model\\\\Relations\\\\HasOne\\<Hyperf\\\\Database\\\\Model\\\\Model, \\$this\\(Hyperf\\\\Database\\\\Model\\\\Model\\)\\>\\) of method Hyperf\\\\Database\\\\Model\\\\Model\\:\\:hasOne\\(\\)$#"
-			count: 1
-			path: src/compoships/src/Database/Eloquent/Model.php
-
-		-
 			message: "#^Call to function is_array\\(\\) with string will always evaluate to false\\.$#"
 			count: 9
-			path: src/compoships/src/Database/Eloquent/Relations/BelongsTo.php
-
-		-
-			message: "#^Generic type Hyperf\\\\Database\\\\Model\\\\Relations\\\\BelongsTo\\<Hyperf\\\\Database\\\\Model\\\\Model\\> in PHPDoc tag @extends does not specify all template types of class Hyperf\\\\Database\\\\Model\\\\Relations\\\\BelongsTo\\: TRelatedModel, TDeclaringModel$#"
-			count: 1
 			path: src/compoships/src/Database/Eloquent/Relations/BelongsTo.php
 
 		-
@@ -91,32 +61,12 @@ parameters:
 			path: src/compoships/src/Database/Eloquent/Relations/BelongsTo.php
 
 		-
-			message: "#^Call to an undefined method FriendsOfHyperf\\\\Compoships\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<TRelatedModel of FriendsOfHyperf\\\\Compoships\\\\Database\\\\Eloquent\\\\Relations\\\\Model\\>\\:\\:qualifyRelatedColumn\\(\\)\\.$#"
-			count: 1
-			path: src/compoships/src/Database/Eloquent/Relations/HasMany.php
-
-		-
-			message: "#^Call to an undefined method FriendsOfHyperf\\\\Compoships\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<TRelatedModel of FriendsOfHyperf\\\\Compoships\\\\Database\\\\Eloquent\\\\Relations\\\\Model\\>\\:\\:qualifySubSelectColumn\\(\\)\\.$#"
-			count: 1
-			path: src/compoships/src/Database/Eloquent/Relations/HasMany.php
-
-		-
-			message: "#^Call to an undefined static method Hyperf\\\\Database\\\\Model\\\\Relations\\\\HasMany\\<TRelatedModel of FriendsOfHyperf\\\\Compoships\\\\Database\\\\Eloquent\\\\Relations\\\\Model, Hyperf\\\\Database\\\\Model\\\\Model\\>\\:\\:addOneOfManyJoinSubQueryConstraints\\(\\)\\.$#"
-			count: 1
-			path: src/compoships/src/Database/Eloquent/Relations/HasMany.php
-
-		-
 			message: "#^Call to function is_array\\(\\) with string will always evaluate to false\\.$#"
 			count: 9
 			path: src/compoships/src/Database/Eloquent/Relations/HasMany.php
 
 		-
 			message: "#^Call to method getTable\\(\\) on an unknown class FriendsOfHyperf\\\\Compoships\\\\Database\\\\Eloquent\\\\Relations\\\\Model\\.$#"
-			count: 1
-			path: src/compoships/src/Database/Eloquent/Relations/HasMany.php
-
-		-
-			message: "#^Generic type Hyperf\\\\Database\\\\Model\\\\Relations\\\\HasMany\\<FriendsOfHyperf\\\\Compoships\\\\Database\\\\Eloquent\\\\Relations\\\\Model\\> in PHPDoc tag @extends does not specify all template types of class Hyperf\\\\Database\\\\Model\\\\Relations\\\\HasMany\\: TRelatedModel, TDeclaringModel$#"
 			count: 1
 			path: src/compoships/src/Database/Eloquent/Relations/HasMany.php
 
@@ -156,28 +106,8 @@ parameters:
 			path: src/compoships/src/Database/Eloquent/Relations/HasMany.php
 
 		-
-			message: "#^Call to an undefined method FriendsOfHyperf\\\\Compoships\\\\Database\\\\Eloquent\\\\Relations\\\\HasOne\\<TRelatedModel of Hyperf\\\\Database\\\\Model\\\\Model\\>\\:\\:qualifyRelatedColumn\\(\\)\\.$#"
-			count: 1
-			path: src/compoships/src/Database/Eloquent/Relations/HasOne.php
-
-		-
-			message: "#^Call to an undefined method FriendsOfHyperf\\\\Compoships\\\\Database\\\\Eloquent\\\\Relations\\\\HasOne\\<TRelatedModel of Hyperf\\\\Database\\\\Model\\\\Model\\>\\:\\:qualifySubSelectColumn\\(\\)\\.$#"
-			count: 1
-			path: src/compoships/src/Database/Eloquent/Relations/HasOne.php
-
-		-
-			message: "#^Call to an undefined static method Hyperf\\\\Database\\\\Model\\\\Relations\\\\HasOne\\<TRelatedModel of Hyperf\\\\Database\\\\Model\\\\Model, Hyperf\\\\Database\\\\Model\\\\Model\\>\\:\\:addOneOfManyJoinSubQueryConstraints\\(\\)\\.$#"
-			count: 1
-			path: src/compoships/src/Database/Eloquent/Relations/HasOne.php
-
-		-
 			message: "#^Call to function is_array\\(\\) with string will always evaluate to false\\.$#"
 			count: 11
-			path: src/compoships/src/Database/Eloquent/Relations/HasOne.php
-
-		-
-			message: "#^Generic type Hyperf\\\\Database\\\\Model\\\\Relations\\\\HasOne\\<Hyperf\\\\Database\\\\Model\\\\Model\\> in PHPDoc tag @extends does not specify all template types of class Hyperf\\\\Database\\\\Model\\\\Relations\\\\HasOne\\: TRelatedModel, TDeclaringModel$#"
-			count: 1
 			path: src/compoships/src/Database/Eloquent/Relations/HasOne.php
 
 		-

--- a/src/compoships/composer.json
+++ b/src/compoships/composer.json
@@ -25,7 +25,7 @@
         "pull-request": "https://github.com/friendsofhyperf/components/pulls"
     },
     "require": {
-        "hyperf/database": "~3.2.0",
+        "hyperf/database": "~3.2.3",
         "hyperf/stringable": "~3.2.0",
         "hyperf/support": "~3.2.0",
         "hyperf/tappable": "~3.2.0",

--- a/src/compoships/src/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/compoships/src/Database/Eloquent/Concerns/HasRelationships.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
  * @document https://github.com/friendsofhyperf/components/blob/main/README.md
  * @contact  huangdijia@gmail.com
  */
+// Keep named @var assertions that bridge invariant relation generics across Hyperf 3.2.x.
+// @php-cs-fixer-ignore return_assignment
 
 namespace FriendsOfHyperf\Compoships\Database\Eloquent\Concerns;
 
@@ -50,11 +52,13 @@ trait HasRelationships
     /**
      * Define a one-to-one relationship.
      *
-     * @param string $related
+     * @template TRelatedModel of Model
+     *
+     * @param class-string<TRelatedModel> $related
      * @param null|array|string $foreignKey
      * @param null|array|string $localKey
      *
-     * @return HasOne
+     * @return HasOne<TRelatedModel, static>
      */
     public function hasOne($related, $foreignKey = null, $localKey = null)
     {
@@ -62,6 +66,7 @@ trait HasRelationships
             $this->validateRelatedModel($related);
         }
 
+        /** @var TRelatedModel $instance */
         $instance = $this->newRelatedInstance($related);
 
         $foreignKey = $foreignKey ?: $this->getForeignKey();
@@ -78,17 +83,22 @@ trait HasRelationships
 
         $localKey = $localKey ?: $this->getKeyName();
 
-        return $this->newHasOne($instance->newQuery(), $this, $foreignKeys ?: $foreignKey, $localKey);
+        /** @var HasOne<TRelatedModel, static> $relation */
+        $relation = $this->newHasOne($instance->newQuery(), $this, $foreignKeys ?: $foreignKey, $localKey);
+
+        return $relation;
     }
 
     /**
      * Define a one-to-many relationship.
      *
-     * @param string $related
+     * @template TRelatedModel of Model
+     *
+     * @param class-string<TRelatedModel> $related
      * @param null|array|string $foreignKey
      * @param null|array|string $localKey
      *
-     * @return HasMany
+     * @return HasMany<TRelatedModel, static>
      */
     public function hasMany($related, $foreignKey = null, $localKey = null)
     {
@@ -96,6 +106,7 @@ trait HasRelationships
             $this->validateRelatedModel($related);
         }
 
+        /** @var TRelatedModel $instance */
         $instance = $this->newRelatedInstance($related);
 
         $foreignKey = $foreignKey ?: $this->getForeignKey();
@@ -112,18 +123,23 @@ trait HasRelationships
 
         $localKey = $localKey ?: $this->getKeyName();
 
-        return $this->newHasMany($instance->newQuery(), $this, $foreignKeys ?: $foreignKey, $localKey);
+        /** @var HasMany<TRelatedModel, static> $relation */
+        $relation = $this->newHasMany($instance->newQuery(), $this, $foreignKeys ?: $foreignKey, $localKey);
+
+        return $relation;
     }
 
     /**
      * Define an inverse one-to-one or many relationship.
      *
-     * @param string $related
+     * @template TRelatedModel of Model
+     *
+     * @param class-string<TRelatedModel> $related
      * @param null|array|string $foreignKey
      * @param null|array|string $ownerKey
      * @param string $relation
      *
-     * @return BelongsTo
+     * @return BelongsTo<TRelatedModel, static>
      */
     public function belongsTo($related, $foreignKey = null, $ownerKey = null, $relation = null)
     {
@@ -138,6 +154,7 @@ trait HasRelationships
             $relation = $this->guessBelongsToRelation();
         }
 
+        /** @var TRelatedModel $instance */
         $instance = $this->newRelatedInstance($related);
 
         // If no foreign key was supplied, we can use a backtrace to guess the proper
@@ -152,53 +169,78 @@ trait HasRelationships
         // actually be responsible for retrieving and hydrating every relations.
         $ownerKey = $ownerKey ?: $instance->getKeyName();
 
-        return $this->newBelongsTo($instance->newQuery(), $this, $foreignKey, $ownerKey, $relation);
+        /** @var BelongsTo<TRelatedModel, static> $belongsTo */
+        $belongsTo = $this->newBelongsTo($instance->newQuery(), $this, $foreignKey, $ownerKey, $relation);
+
+        return $belongsTo;
     }
 
     /**
      * Instantiate a new HasOne relationship.
      *
+     * @template TRelatedModel of Model
+     * @template TDeclaringModel of Model
+     *
+     * @param Builder<TRelatedModel> $query
+     * @param TDeclaringModel $parent
      * @param array|string $foreignKey
      * @param array|string $localKey
      *
-     * @return HasOne
+     * @return HasOne<TRelatedModel, TDeclaringModel>
      */
     protected function newHasOne(Builder $query, Model $parent, $foreignKey, $localKey)
     {
-        return new HasOne($query, $parent, $foreignKey, $localKey);
+        /** @var HasOne<TRelatedModel, TDeclaringModel> $relation */
+        $relation = new HasOne($query, $parent, $foreignKey, $localKey);
+
+        return $relation;
     }
 
     /**
      * Instantiate a new HasMany relationship.
      *
+     * @template TRelatedModel of Model
+     * @template TDeclaringModel of Model
+     *
+     * @param Builder<TRelatedModel> $query
+     * @param TDeclaringModel $parent
      * @param array|string $foreignKey
      * @param array|string $localKey
      *
-     * @return HasMany
+     * @return HasMany<TRelatedModel, TDeclaringModel>
      */
     protected function newHasMany(Builder $query, Model $parent, $foreignKey, $localKey)
     {
-        return new HasMany($query, $parent, $foreignKey, $localKey);
+        /** @var HasMany<TRelatedModel, TDeclaringModel> $relation */
+        $relation = new HasMany($query, $parent, $foreignKey, $localKey);
+
+        return $relation;
     }
 
     /**
      * Instantiate a new BelongsTo relationship.
      *
+     * @template TRelatedModel of Model
+     *
+     * @param Builder<TRelatedModel> $query
      * @param array|string $foreignKey
      * @param array|string $ownerKey
      * @param string $relation
      *
-     * @return BelongsTo
+     * @return BelongsTo<TRelatedModel, static>
      */
     protected function newBelongsTo(Builder $query, Model $child, $foreignKey, $ownerKey, $relation)
     {
-        return new BelongsTo($query, $child, $foreignKey, $ownerKey, $relation);
+        /** @var BelongsTo<TRelatedModel, static> $relationInstance */
+        $relationInstance = new BelongsTo($query, $child, $foreignKey, $ownerKey, $relation);
+
+        return $relationInstance;
     }
 
     /**
      * Honor DB::raw instances.
      *
-     * @param string $instance
+     * @param Model $instance
      * @param string $foreignKey
      *
      * @return Expression|string

--- a/src/compoships/src/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/compoships/src/Database/Eloquent/Relations/BelongsTo.php
@@ -19,7 +19,8 @@ use Hyperf\Database\Model\Relations\Constraint;
 
 /**
  * @template TRelatedModel of Model
- * @extends BaseBelongsTo<TRelatedModel>
+ * @template TDeclaringModel of Model
+ * @extends BaseBelongsTo<TRelatedModel, TDeclaringModel>
  */
 class BelongsTo extends BaseBelongsTo
 {

--- a/src/compoships/src/Database/Eloquent/Relations/HasMany.php
+++ b/src/compoships/src/Database/Eloquent/Relations/HasMany.php
@@ -12,11 +12,13 @@ declare(strict_types=1);
 namespace FriendsOfHyperf\Compoships\Database\Eloquent\Relations;
 
 use Hyperf\Database\Model\Collection;
+use Hyperf\Database\Model\Model;
 use Hyperf\Database\Model\Relations\HasMany as BaseHasMany;
 
 /**
  * @template TRelatedModel of Model
- * @extends BaseHasMany<TRelatedModel>
+ * @template TDeclaringModel of Model
+ * @extends BaseHasMany<TRelatedModel, TDeclaringModel>
  */
 class HasMany extends BaseHasMany
 {

--- a/src/compoships/src/Database/Eloquent/Relations/HasOne.php
+++ b/src/compoships/src/Database/Eloquent/Relations/HasOne.php
@@ -17,7 +17,8 @@ use Hyperf\Database\Model\Relations\HasOne as BaseHasOne;
 
 /**
  * @template TRelatedModel of Model
- * @extends BaseHasOne<TRelatedModel>
+ * @template TDeclaringModel of Model
+ * @extends BaseHasOne<TRelatedModel, TDeclaringModel>
  */
 class HasOne extends BaseHasOne
 {

--- a/src/compoships/src/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/compoships/src/Database/Eloquent/Relations/HasOneOrMany.php
@@ -15,7 +15,6 @@ use Hyperf\Database\Model\Builder;
 use Hyperf\Database\Model\Collection;
 use Hyperf\Database\Model\Model;
 use Hyperf\Database\Model\Relations\Constraint;
-use Hyperf\Database\Query\JoinClause;
 
 use function Hyperf\Collection\collect;
 use function Hyperf\Collection\last;
@@ -159,20 +158,6 @@ trait HasOneOrMany
                         return $hash . '.' . $k;
                     }, $this->getForeignKeyName()) : $hash . '.' . $this->getForeignKeyName()
             );
-    }
-
-    /**
-     * Add join query constraints for one of many relationships.
-     */
-    public function addOneOfManyJoinSubQueryConstraints(JoinClause $join)
-    {
-        if (is_array($this->foreignKey)) {
-            foreach ($this->foreignKey as $key) {
-                $join->on($this->qualifySubSelectColumn($key), '=', $this->qualifyRelatedColumn($key));
-            }
-        } else {
-            parent::addOneOfManyJoinSubQueryConstraints($join);
-        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- align Compoships relation generics with Hyperf Database 3.2.3
- remove an unusable one-of-many hook that calls APIs Hyperf does not provide
- remove the obsolete PHPStan baseline entries instead of suppressing the failures

## Background
The scheduled CI started failing after Composer resolved hyperf/database v3.2.3. That release changed relation declaring-model return types from $this to static, exposing incomplete generic declarations in the custom Compoships relations.

Failing run: https://github.com/friendsofhyperf/components/actions/runs/31073259502

## Changes
- add related-model and declaring-model templates to HasOne, HasMany, and BelongsTo
- preserve precise generic types through relationship factory methods
- require hyperf/database ~3.2.3 in the component and root test environment
- delete the nonfunctional addOneOfManyJoinSubQueryConstraints implementation
- delete 14 resolved baseline entries; no PHPStan ignore entry was added or broadened

## Test Plan
- fresh isolated checkout: composer update -o
- confirmed hyperf/database v3.2.3
- composer analyse src: 722 files, no errors
- vendor/bin/php-cs-fixer fix src/compoships --dry-run --diff --verbose
- composer validate and component composer validation
- PHP syntax checks for all changed PHP files
- git diff --check

## Risks
- the minimum supported hyperf/database version for Compoships is now 3.2.3
- the removed one-of-many method was public, but it could not execute on Hyperf because all of its required parent/helper APIs are absent


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 完善模型关系的类型标注，提升静态分析准确性与开发体验。
  * 优化 `HasOne`、`HasMany` 和 `BelongsTo` 关系的模型类型识别。
  * 清理不再使用的关系处理代码，保持实现简洁。
* **维护**
  * 更新静态检查基线，减少无效告警并提升代码质量。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->