### PR TITLE
fix(sentry): stop flushing metrics on every request

### DIFF
--- a/src/sentry/publish/sentry.php
+++ b/src/sentry/publish/sentry.php
@@ -56,6 +56,14 @@ return [
     // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#enable_metrics
     'enable_metrics' => env('SENTRY_ENABLE_METRICS', false),
 
+    // Metrics are buffered in memory and are no longer flushed on every request
+    // or annotation call. They are reported when:
+    // - the SDK `metric_flush_threshold` is reached (automatic flush), or
+    // - the request runtime context ends (endContext flush), or
+    // - the periodic flush kicks in as a fallback (`metrics_interval`).
+    // Forcing a flush per request/call amplifies transport channel pressure and
+    // increases the risk of memory exhaustion under high traffic.
+
     // @see: https://docs.sentry.io/platforms/php/configuration/options/#before_send_metric
     // 'before_send_metric' => function (Sentry\Metrics\Types\Metric $metric): ?Sentry\Metrics\Types\Metric {
     //     return $metric;

--- a/src/sentry/src/Metrics/Aspect/CounterAspect.php
+++ b/src/sentry/src/Metrics/Aspect/CounterAspect.php
@@ -49,8 +49,6 @@ class CounterAspect extends AbstractAspect
                 'class' => $proceedingJoinPoint->className,
                 'method' => $proceedingJoinPoint->methodName,
             ]);
-
-            metrics()->flush();
         }
 
         return $proceedingJoinPoint->process();

--- a/src/sentry/src/Metrics/Aspect/HistogramAspect.php
+++ b/src/sentry/src/Metrics/Aspect/HistogramAspect.php
@@ -54,7 +54,7 @@ class HistogramAspect extends AbstractAspect
         ]);
 
         return tap($proceedingJoinPoint->process(), function () use ($timer) {
-            defer(fn () => $timer->end(true));
+            defer(fn () => $timer->end());
         });
     }
 

--- a/src/sentry/src/Metrics/Listener/RequestWatcher.php
+++ b/src/sentry/src/Metrics/Listener/RequestWatcher.php
@@ -62,7 +62,7 @@ class RequestWatcher implements ListenerInterface
                 ++$this->stats->response_count;
                 --$this->stats->connection_num;
 
-                $timer->end(true);
+                $timer->end();
 
                 unset($timer);
             });

--- a/tests/Sentry/Metrics/RequestWatcherTest.php
+++ b/tests/Sentry/Metrics/RequestWatcherTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of friendsofhyperf/components.
+ *
+ * @link     https://github.com/friendsofhyperf/components
+ * @document https://github.com/friendsofhyperf/components/blob/main/README.md
+ * @contact  huangdijia@gmail.com
+ */
+
+namespace FriendsOfHyperf\Tests\Sentry\Metrics;
+
+use FriendsOfHyperf\Sentry\Feature;
+use FriendsOfHyperf\Sentry\Metrics\CoroutineServerStats;
+use FriendsOfHyperf\Sentry\Metrics\Listener\RequestWatcher;
+use Hyperf\HttpMessage\Server\Request;
+use Hyperf\HttpServer\Event\RequestReceived;
+use Mockery as m;
+
+function waitForCoroutine(int $cid): void
+{
+    if (\Swoole\Coroutine::getCid() === -1) {
+        return; // Top level: the created coroutine already finished synchronously.
+    }
+
+    while (\Swoole\Coroutine::exists($cid)) {
+        \Swoole\Coroutine::sleep(0.001);
+    }
+}
+
+test('process request received increments counters without throwing', function () {
+    $stats = new CoroutineServerStats();
+    $feature = m::mock(Feature::class);
+    $feature->shouldReceive('isMetricsEnabled')->andReturn(true);
+
+    $watcher = new RequestWatcher($stats, $feature);
+    $request = new Request('GET', 'http://127.0.0.1:9501/health');
+
+    $snapshot = null;
+    $cid = \Swoole\Coroutine::create(function () use ($watcher, $request, $stats, &$snapshot) {
+        $watcher->process(new RequestReceived($request, null));
+        $snapshot = [
+            'accept_count' => $stats->accept_count,
+            'request_count' => $stats->request_count,
+            'connection_num' => $stats->connection_num,
+        ];
+    });
+
+    waitForCoroutine($cid);
+
+    expect(\Swoole\Coroutine::exists($cid))->toBeFalse()
+        ->and($snapshot['accept_count'])->toBe(1)
+        ->and($snapshot['request_count'])->toBe(1)
+        ->and($snapshot['connection_num'])->toBe(1);
+});
+
+test('defer closes the request counters after the coroutine ends', function () {
+    $stats = new CoroutineServerStats();
+    $feature = m::mock(Feature::class);
+    $feature->shouldReceive('isMetricsEnabled')->andReturn(true);
+
+    $watcher = new RequestWatcher($stats, $feature);
+    $request = new Request('GET', 'http://127.0.0.1:9501/health');
+
+    $cid = \Swoole\Coroutine::create(function () use ($watcher, $request) {
+        $watcher->process(new RequestReceived($request, null));
+    });
+
+    waitForCoroutine($cid);
+
+    expect($stats->close_count)->toBe(1)
+        ->and($stats->response_count)->toBe(1)
+        ->and($stats->connection_num)->toBe(0);
+});


### PR DESCRIPTION
## 问题

高流量下,每个请求/每次注解调用都会强制 `metrics()->flush()`,导致事件量等于请求量,持续放大传输通道背压,与传输阻塞引发的内存溢出风险形成正反馈。

涉及点:

- `Metrics/Listener/RequestWatcher.php` 在协程结束 defer 中 `$timer->end(true)` 每请求强制 flush;
- `Metrics/Aspect/CounterAspect.php` 每次注解计数后立即 `metrics()->flush()`;
- `Metrics/Aspect/HistogramAspect.php` 的 defer 中 `$timer->end(true)` 同样每次 flush。

## 修改

移除以上强制 flush,指标改为依赖以下机制上报:

- SDK 达到 `metric_flush_threshold` 时自动上报(阈值 flush);
- 请求级 runtime context 结束时上报(endContext flush,由另一 PR 提供);
- 周期 flush 兜底(`metrics_interval`)。

具体改动:

- `RequestWatcher.php`:defer 中 `$timer->end(true)` 改为 `$timer->end()`(其余 stats 计数、defer 结构、unset 不变);
- `CounterAspect.php`:删除 `metrics()->flush()`(count 仍保留 use function metrics);
- `HistogramAspect.php`:`defer(fn () => $timer->end(true))` 改为 `defer(fn () => $timer->end())`;
- `publish/sentry.php`:在 `enable_metrics` 附近补充注释,说明指标缓冲与上报时机(默认值不变);
- 新增 `tests/Sentry/Metrics/RequestWatcherTest.php`:验证 process 计数递增与协程结束后 defer 的关闭计数/连接回退。

## 测试

新增 `tests/Sentry/Metrics/RequestWatcherTest.php` 两个用例:

a. `process(RequestReceived)` 不抛异常,accept_count/request_count/connection_num 递增;
b. 协程结束后 close_count/response_count 递增、connection_num 回退(验证 defer 逻辑)。

用例在独立协程内执行并等待其结束,保证确定性、离线、不触发真实网络(无 client 时 Timer::end 仅进入聚合器缓冲)。

## 验证

- `vendor/bin/pest --group=sentry`:45 passed(43 基线 + 2 新增);
- `vendor/bin/php-cs-fixer fix --dry-run --diff`:改动文件 0 需修复;
- `git diff --check`:无空白错误。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化指标刷新机制，减少请求处理期间的即时刷新，降低高流量场景下的传输压力和内存风险。
  * 优化计时器结束处理，确保请求及指标统计在适当时机完成。

* **测试**
  * 新增协程环境下的请求监控测试，验证请求计数、响应计数及连接数能够正确更新和关闭。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->