### PR TITLE
fix(sentry): prevent duplicate metric timer ticks

### DIFF
--- a/src/sentry/src/Metrics/Listener/OnBeforeHandle.php
+++ b/src/sentry/src/Metrics/Listener/OnBeforeHandle.php
@@ -31,11 +31,14 @@ class OnBeforeHandle implements ListenerInterface
 
     protected Timer $timer;
 
+    private bool $ticking = false;
+
     public function __construct(
         protected ContainerInterface $container,
-        protected Feature $feature
+        protected Feature $feature,
+        ?Timer $timer = null,
     ) {
-        $this->timer = new Timer();
+        $this->timer = $timer ?? new Timer();
     }
 
     public function listen(): array
@@ -94,6 +97,12 @@ class OnBeforeHandle implements ListenerInterface
             'ru_stime_tv_usec',
             'ru_stime_tv_sec',
         ];
+
+        if ($this->ticking) {
+            return;
+        }
+
+        $this->ticking = true;
 
         $this->timer->tick(
             $this->feature->getMetricsInterval(),

--- a/src/sentry/src/Metrics/Listener/OnMetricFactoryReady.php
+++ b/src/sentry/src/Metrics/Listener/OnMetricFactoryReady.php
@@ -32,11 +32,14 @@ class OnMetricFactoryReady implements ListenerInterface
 
     private Timer $timer;
 
+    private bool $ticking = false;
+
     public function __construct(
         protected ContainerInterface $container,
         protected Feature $feature,
+        ?Timer $timer = null,
     ) {
-        $this->timer = new Timer();
+        $this->timer = $timer ?? new Timer();
     }
 
     public function listen(): array
@@ -80,6 +83,12 @@ class OnMetricFactoryReady implements ListenerInterface
             'metric_process_memory_usage',
             'metric_process_memory_peak_usage',
         ];
+
+        if ($this->ticking) {
+            return;
+        }
+
+        $this->ticking = true;
 
         $serverStatsFactory = null;
 

--- a/src/sentry/src/Metrics/Listener/QueueWatcher.php
+++ b/src/sentry/src/Metrics/Listener/QueueWatcher.php
@@ -25,11 +25,14 @@ class QueueWatcher implements ListenerInterface
 {
     private Timer $timer;
 
+    private bool $ticking = false;
+
     public function __construct(
         protected ContainerInterface $container,
         protected Feature $feature,
+        ?Timer $timer = null,
     ) {
-        $this->timer = new Timer();
+        $this->timer = $timer ?? new Timer();
     }
 
     /**
@@ -50,6 +53,12 @@ class QueueWatcher implements ListenerInterface
         if (! $this->feature->isQueueMetricsEnabled()) {
             return;
         }
+
+        if ($this->ticking) {
+            return;
+        }
+
+        $this->ticking = true;
 
         $this->timer->tick(
             $this->feature->getMetricsInterval(),

--- a/tests/Sentry/Metrics/Listener/FakeTimer.php
+++ b/tests/Sentry/Metrics/Listener/FakeTimer.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of friendsofhyperf/components.
+ *
+ * @link     https://github.com/friendsofhyperf/components
+ * @document https://github.com/friendsofhyperf/components/blob/main/README.md
+ * @contact  huangdijia@gmail.com
+ */
+
+namespace FriendsOfHyperf\Tests\Sentry\Metrics\Listener;
+
+use Hyperf\Coordinator\Constants;
+use Hyperf\Coordinator\Timer;
+
+/**
+ * A Timer that records tick() calls without spawning coroutines.
+ *
+ * @internal
+ */
+class FakeTimer extends Timer
+{
+    /**
+     * @var array<int, array{0: float, 1: callable, 2: string}>
+     */
+    public array $ticks = [];
+
+    public function tick(float $timeout, callable $closure, string $identifier = Constants::WORKER_EXIT): int
+    {
+        $this->ticks[] = [$timeout, $closure, $identifier];
+
+        return count($this->ticks);
+    }
+}

--- a/tests/Sentry/Metrics/Listener/OnBeforeHandleTest.php
+++ b/tests/Sentry/Metrics/Listener/OnBeforeHandleTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of friendsofhyperf/components.
+ *
+ * @link     https://github.com/friendsofhyperf/components
+ * @document https://github.com/friendsofhyperf/components/blob/main/README.md
+ * @contact  huangdijia@gmail.com
+ */
+
+namespace FriendsOfHyperf\Tests\Sentry\Metrics\Listener;
+
+use FriendsOfHyperf\Sentry\Constants;
+use FriendsOfHyperf\Sentry\Feature;
+use FriendsOfHyperf\Sentry\Metrics\Listener\OnBeforeHandle;
+use Hyperf\Command\Command;
+use Hyperf\Command\Event\BeforeHandle;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Application;
+
+beforeEach(function () {
+    Constants::$runningInCommand = false;
+
+    $this->timer = new FakeTimer();
+    $this->container = $this->createMock(ContainerInterface::class);
+    $this->feature = $this->createMock(Feature::class);
+    $this->application = $this->createMock(Application::class);
+    $this->command = $this->createMock(Command::class);
+    $this->command->method('getApplication')->willReturn($this->application);
+
+    $this->event = new BeforeHandle($this->command);
+});
+
+test('ticks only once when process is called twice', function () {
+    $this->feature->method('isCommandMetricsEnabled')->willReturn(true);
+    $this->feature->method('isDefaultMetricsEnabled')->willReturn(true);
+    $this->feature->method('getMetricsInterval')->willReturn(10);
+    $this->container->method('has')->willReturn(false);
+    $this->application->method('isAutoExitEnabled')->willReturn(true);
+
+    $listener = new OnBeforeHandle($this->container, $this->feature, $this->timer);
+    $listener->process($this->event);
+    $listener->process($this->event);
+
+    expect($this->timer->ticks)->toHaveCount(1);
+});
+
+test('does not tick when metrics are disabled', function () {
+    $this->feature->method('isCommandMetricsEnabled')->willReturn(false);
+    $this->feature->method('isDefaultMetricsEnabled')->willReturn(false);
+    $this->application->method('isAutoExitEnabled')->willReturn(true);
+
+    $listener = new OnBeforeHandle($this->container, $this->feature, $this->timer);
+    $listener->process($this->event);
+
+    expect($this->timer->ticks)->toHaveCount(0);
+});
+
+test('does not tick when auto exit is disabled', function () {
+    $this->application->method('isAutoExitEnabled')->willReturn(false);
+
+    $listener = new OnBeforeHandle($this->container, $this->feature, $this->timer);
+    $listener->process($this->event);
+
+    expect($this->timer->ticks)->toHaveCount(0);
+});

--- a/tests/Sentry/Metrics/Listener/OnMetricFactoryReadyTest.php
+++ b/tests/Sentry/Metrics/Listener/OnMetricFactoryReadyTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of friendsofhyperf/components.
+ *
+ * @link     https://github.com/friendsofhyperf/components
+ * @document https://github.com/friendsofhyperf/components/blob/main/README.md
+ * @contact  huangdijia@gmail.com
+ */
+
+namespace FriendsOfHyperf\Tests\Sentry\Metrics\Listener;
+
+use FriendsOfHyperf\Sentry\Constants;
+use FriendsOfHyperf\Sentry\Feature;
+use FriendsOfHyperf\Sentry\Metrics\Event\MetricFactoryReady;
+use FriendsOfHyperf\Sentry\Metrics\Listener\OnMetricFactoryReady;
+use Psr\Container\ContainerInterface;
+
+beforeEach(function () {
+    Constants::$runningInCommand = false;
+
+    $this->timer = new FakeTimer();
+    $this->container = $this->createMock(ContainerInterface::class);
+    $this->feature = $this->createMock(Feature::class);
+
+    $this->event = new MetricFactoryReady();
+});
+
+test('ticks only once when process is called twice', function () {
+    $this->feature->method('isDefaultMetricsEnabled')->willReturn(true);
+    $this->feature->method('getMetricsInterval')->willReturn(10);
+    $this->container->method('has')->willReturn(false);
+
+    $listener = new OnMetricFactoryReady($this->container, $this->feature, $this->timer);
+    $listener->process($this->event);
+    $listener->process($this->event);
+
+    expect($this->timer->ticks)->toHaveCount(1);
+});
+
+test('does not tick when default metrics are disabled', function () {
+    $this->feature->method('isDefaultMetricsEnabled')->willReturn(false);
+
+    $listener = new OnMetricFactoryReady($this->container, $this->feature, $this->timer);
+    $listener->process($this->event);
+
+    expect($this->timer->ticks)->toHaveCount(0);
+});

--- a/tests/Sentry/Metrics/Listener/QueueWatcherTest.php
+++ b/tests/Sentry/Metrics/Listener/QueueWatcherTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of friendsofhyperf/components.
+ *
+ * @link     https://github.com/friendsofhyperf/components
+ * @document https://github.com/friendsofhyperf/components/blob/main/README.md
+ * @contact  huangdijia@gmail.com
+ */
+
+namespace FriendsOfHyperf\Tests\Sentry\Metrics\Listener;
+
+use FriendsOfHyperf\Sentry\Feature;
+use FriendsOfHyperf\Sentry\Metrics\Event\MetricFactoryReady;
+use FriendsOfHyperf\Sentry\Metrics\Listener\QueueWatcher;
+use Psr\Container\ContainerInterface;
+
+beforeEach(function () {
+    $this->timer = new FakeTimer();
+    $this->container = $this->createMock(ContainerInterface::class);
+    $this->feature = $this->createMock(Feature::class);
+
+    $this->event = new MetricFactoryReady();
+});
+
+test('ticks only once when process is called twice', function () {
+    $this->feature->method('isQueueMetricsEnabled')->willReturn(true);
+    $this->feature->method('getMetricsInterval')->willReturn(10);
+
+    $listener = new QueueWatcher($this->container, $this->feature, $this->timer);
+    $listener->process($this->event);
+    $listener->process($this->event);
+
+    expect($this->timer->ticks)->toHaveCount(1);
+});
+
+test('does not tick when queue metrics are disabled', function () {
+    $this->feature->method('isQueueMetricsEnabled')->willReturn(false);
+
+    $listener = new QueueWatcher($this->container, $this->feature, $this->timer);
+    $listener->process($this->event);
+
+    expect($this->timer->ticks)->toHaveCount(0);
+});


### PR DESCRIPTION
## 问题

`Hyperf\Coordinator\Timer::tick()` 每调用一次就会 spawn 一个永不退出的循环协程并持有闭包(闭包又引用 listener→container)。以下三个 listener 在每次事件派发时都会新增 tick,且没有去重,长驻进程内(如 tinker/自研调度器反复执行命令)会无限累积协程与内存:

- `OnBeforeHandle` —— 每次 `CommandEvent\BeforeHandle` 都 tick
- `QueueWatcher` / `OnMetricFactoryReady` —— 每次 `MetricFactoryReady` 事件都 tick

## 修改

- 三个 listener 各增加 `private bool $ticking = false;`,在调用 `$this->timer->tick(...)` 前 guard:首次进入置 true,后续 `process` 直接返回,不再重复注册定时器。
- `OnBeforeHandle` 现有 cron checkin / autoExit 检查逻辑保留,顺序不变(tick 注册之前)。
- 为可测试性,构造器增加可选参数 `?Hyperf\Coordinator\Timer $timer = null`,为 null 时保持原有 `new Timer()` 行为;Hyperf DI 仍可正常自动注入 Timer。

## 测试

新增 `tests/Sentry/Metrics/Listener/` 下三个测试文件(Pest 风格),使用 `FakeTimer extends \Hyperf\Coordinator\Timer` 记录 tick 调用而不真正 spawn 协程,并 mock ContainerInterface / Feature 等:

- `OnBeforeHandleTest`:process 两次仅 tick 一次;feature 关闭 0 次;autoExit 关闭 0 次
- `QueueWatcherTest`:process 两次仅 tick 一次;queue metrics 关闭 0 次
- `OnMetricFactoryReadyTest`:process 两次仅 tick 一次;default metrics 关闭 0 次

## 验证

- `vendor/bin/pest --group=sentry`:50 passed(原 43 + 新增 7)
- `php-cs-fixer fix --dry-run --diff`:0 文件需修复
- `git diff --check`:通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化指标采集任务的调度，避免重复注册或并发执行。
  * 修复重复处理事件导致指标被重复计时的问题。
  * 在相关指标或自动退出功能关闭时，不再启动不必要的计时任务。

* **Tests**
  * 新增指标监听器和队列监控相关测试，覆盖重复触发及功能开关场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->