### PR TITLE
fix(sentry): guard runtime context lifecycle per coroutine

### DIFF
--- a/src/sentry/class_map/RuntimeContextManager.php
+++ b/src/sentry/class_map/RuntimeContextManager.php
@@ -26,6 +26,8 @@ use function Hyperf\Support\make;
  * - The manager keeps a lazily initialized global context as fallback.
  * - startContext() creates an isolated runtime context for the current
  *   execution key when no context is active yet.
+ * - startContext() only takes effect inside a coroutine; in non-coroutine
+ *   environments it is a no-op and the global fallback context is used.
  * - endContext() flushes context resources and removes that context.
  *
  * @internal
@@ -120,6 +122,13 @@ final class RuntimeContextManager
      */
     public function startContext(): void
     {
+        // The main coroutine (non-coroutine environment, Coroutine::id() <= 0)
+        // uses a process-level context store that is not reaped together with
+        // a coroutine, so falling back to the global context is safer there.
+        if (\Hyperf\Engine\Coroutine::id() <= 0) {
+            return;
+        }
+
         $executionContextKey = $this->getExecutionContextKey();
 
         if ($this->hasActiveContextForExecutionContextKey($executionContextKey)) {
@@ -279,8 +288,11 @@ final class RuntimeContextManager
 
     private function getExecutionContextKey(): string
     {
-        // All supported runtime modes currently use a process-local execution key.
-        return self::PROCESS_EXECUTION_CONTEXT_KEY;
+        // The key is scoped per coroutine so execution context mappings cannot
+        // leak across coroutines or linger on the main coroutine. CoArrayObject
+        // already stores values per current coroutine, so normal behavior is
+        // unchanged.
+        return \sprintf('%s.%d', self::PROCESS_EXECUTION_CONTEXT_KEY, \Hyperf\Engine\Coroutine::id());
     }
 
     private function getGlobalContext(): RuntimeContext

--- a/tests/Sentry/RuntimeContextLifecycleTest.php
+++ b/tests/Sentry/RuntimeContextLifecycleTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of friendsofhyperf/components.
+ *
+ * @link     https://github.com/friendsofhyperf/components
+ * @document https://github.com/friendsofhyperf/components/blob/main/README.md
+ * @contact  huangdijia@gmail.com
+ */
+
+namespace FriendsOfHyperf\Tests\Sentry;
+
+use FriendsOfHyperf\CoPHPUnit\Attributes\NonCoroutine;
+use FriendsOfHyperf\Tests\TestCase;
+use Mockery;
+use Sentry\ClientInterface;
+use Sentry\Options;
+use Sentry\State\HubInterface;
+use Sentry\State\RuntimeContextManager;
+use Sentry\Transport\Result;
+use Sentry\Transport\ResultStatus;
+use Swoole\Coroutine;
+use Swoole\Coroutine\Channel;
+
+// The SDK class is replaced via Hyperf's class_map injection at runtime, which
+// is not active in the test process, so load the replacement file explicitly
+// to exercise the coroutine-aware implementation under test.
+require_once __DIR__ . '/../../src/sentry/class_map/RuntimeContextManager.php';
+
+/**
+ * @internal
+ */
+class RuntimeContextLifecycleTest extends TestCase
+{
+    public function testStartAndEndContextInsideCoroutine(): void
+    {
+        $manager = $this->createRuntimeContextManager();
+
+        $manager->startContext();
+
+        $this->assertTrue($manager->hasActiveContext());
+
+        $manager->endContext();
+
+        $this->assertFalse($manager->hasActiveContext());
+    }
+
+    #[NonCoroutine]
+    public function testStartContextIsIgnoredOnMainCoroutine(): void
+    {
+        $this->assertSame(-1, Coroutine::getCid());
+
+        $manager = $this->createRuntimeContextManager();
+
+        $manager->startContext();
+
+        // The main coroutine uses a process-level context store that is never
+        // reaped, so startContext() is a no-op and the global fallback is used.
+        $this->assertFalse($manager->hasActiveContext());
+        $this->assertSame('global', $manager->getCurrentContext()->getId());
+    }
+
+    public function testContextsAreIsolatedAcrossCoroutines(): void
+    {
+        $manager = $this->createRuntimeContextManager();
+        $channelA = new Channel(1);
+        $channelB = new Channel(1);
+        $result = [];
+
+        Coroutine::create(function () use ($manager, $channelA, &$result): void {
+            $manager->startContext();
+            $result['a_id'] = $manager->getCurrentContext()->getId();
+            $result['a_active'] = $manager->hasActiveContext();
+            $channelA->push('started');
+            $channelA->pop(); // Wait for the "end A" signal.
+            $manager->endContext();
+            $result['a_active_after_end'] = $manager->hasActiveContext();
+            $channelA->push('done');
+        });
+
+        Coroutine::create(function () use ($manager, $channelB, &$result): void {
+            $manager->startContext();
+            $result['b_id'] = $manager->getCurrentContext()->getId();
+            $result['b_active'] = $manager->hasActiveContext();
+            $channelB->push('started');
+            $channelB->pop(); // Wait for the "A ended" signal.
+            $result['b_active_after_a_end'] = $manager->hasActiveContext();
+            $channelB->push('done');
+        });
+
+        $channelA->pop(); // A started.
+        $channelB->pop(); // B started.
+
+        $this->assertNotSame($result['a_id'], $result['b_id']);
+        $this->assertTrue($result['a_active']);
+        $this->assertTrue($result['b_active']);
+
+        $channelA->push('end');
+        $channelA->pop(); // A finished ending its context.
+
+        $channelB->push('check');
+        $channelB->pop(); // B verified its own context is still active.
+
+        $this->assertFalse($result['a_active_after_end']);
+        $this->assertTrue($result['b_active_after_a_end']);
+    }
+
+    public function testStartContextIsIdempotentWithinSameCoroutine(): void
+    {
+        $manager = $this->createRuntimeContextManager();
+
+        $manager->startContext();
+        $firstId = $manager->getCurrentContext()->getId();
+        $manager->startContext();
+
+        // A nested start for the same execution key is a no-op.
+        $this->assertSame($firstId, $manager->getCurrentContext()->getId());
+        $this->assertTrue($manager->hasActiveContext());
+
+        $manager->endContext();
+
+        $this->assertFalse($manager->hasActiveContext());
+    }
+
+    private function createRuntimeContextManager(): RuntimeContextManager
+    {
+        $client = Mockery::mock(ClientInterface::class);
+        $client->shouldReceive('getOptions')->andReturn(new Options());
+        $client->shouldReceive('flush')->andReturn(new Result(ResultStatus::success()));
+
+        $hub = Mockery::mock(HubInterface::class);
+        $hub->shouldReceive('getClient')->andReturn($client);
+
+        return new RuntimeContextManager($hub);
+    }
+}


### PR DESCRIPTION
## 问题

- `startContext()` 在主协程（非协程环境，`Hyperf\Engine\Coroutine::id()` 返回 -1）执行时，条目会写入进程级 context 存储；若 `endContext()` 未执行则永久残留，存在内存溢出/条目残留风险。
- `getExecutionContextKey()` 返回固定常量 `PROCESS_EXECUTION_CONTEXT_KEY`（`sentry.process.execution_context`），key 不含协程信息，存在跨协程/主协程映射残留风险。

## 修改

- `startContext()` 开头增加守卫：当前不在协程环境（`\Hyperf\Engine\Coroutine::id() <= 0`）时直接 `return`。主协程的 context 存储是进程级，start 后无法随协程回收，回退 global context 更安全。
- `getExecutionContextKey()` 改为包含协程 id：`sprintf('%s.%d', self::PROCESS_EXECUTION_CONTEXT_KEY, \Hyperf\Engine\Coroutine::id())`。key 按协程隔离，防止跨协程/主协程映射残留；`CoArrayObject` 本就按当前协程取存储，正常行为不变。
- 类 docblock 的 Lifecycle model 段落补充说明：`startContext()` 仅在协程内生效，非协程环境使用 global fallback。
- 其它行为（`createHubFromBaseHub`、`flush`、`removeContextById`、`generateRuntimeContextId`、global context 逻辑）一律未改动。

## 测试

新增 `tests/Sentry/RuntimeContextLifecycleTest.php`（直接 `new RuntimeContextManager` + mock `HubInterface`/`ClientInterface`，避免容器 make；class_map 注入仅在 Hyperf 运行时生效，测试进程不生效，故测试文件显式加载该 class_map 文件以验证被测实现）：

- 协程内 `startContext()` 后 `hasActiveContext()` 为 true，`endContext()` 后为 false；
- 主协程（`#[NonCoroutine]`，非 `Swoole\Coroutine\run` 内）`startContext()` 后 `hasActiveContext()` 为 false，`getCurrentContext()` 回退 global；
- 两个不同协程各自 `startContext()`，`getCurrentContext()->getId()` 不同且互不影响（一个 `endContext()` 后另一个 `hasActiveContext()` 仍为 true）；
- 同协程连续两次 `startContext()` 幂等，`endContext()` 一次即清理。

## 验证

- `vendor/bin/pest tests/Sentry`：**47 passed**（基线 43 + 新增 4），覆盖本组件全部 sentry 测试（`tests/Pest.php` 中 `uses()->group('sentry')->in('Sentry')`，该目录全部用例即 sentry group 成员）。注：本开发 worktree 的 `vendor` 为指向主 checkout 的符号链接，`vendor/bin/pest --group=sentry` 会在收集阶段先后加载主 checkout 与 worktree 两份 `tests/Helpers/HelpersTest.php`（顶层均声明 `enum TestEnum`），纯 main 无任何改动时同样触发该 fatal，属环境问题，故以完整 sentry 测试目录运行验证。
- `vendor/bin/php-cs-fixer fix --dry-run --diff`：0 个文件需修复。
- `git diff --check`：通过。
- `composer analyse src/sentry`：No errors。
