### PR TITLE
fix(sentry): move cross-request static state into coroutine context

### DIFF
--- a/src/sentry/src/Constants.php
+++ b/src/sentry/src/Constants.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Sentry;
 
+use Hyperf\Context\Context;
+
 class Constants
 {
     public const TRACE_CARRIER = 'sentry.tracing.trace_carrier';
@@ -21,5 +23,15 @@ class Constants
 
     public const TRACEPARENT = 'traceparent';
 
-    public static bool $runningInCommand = false;
+    public const CTX_RUNNING_IN_COMMAND = 'sentry.constants.running_in_command';
+
+    public static function runningInCommand(): bool
+    {
+        return (bool) Context::get(self::CTX_RUNNING_IN_COMMAND, false);
+    }
+
+    public static function setRunningInCommand(bool $running = true): void
+    {
+        Context::set(self::CTX_RUNNING_IN_COMMAND, $running);
+    }
 }

--- a/src/sentry/src/Integration.php
+++ b/src/sentry/src/Integration.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfHyperf\Sentry;
 
+use Hyperf\Context\Context;
 use Sentry\Breadcrumb;
 use Sentry\Event;
 use Sentry\Integration\IntegrationInterface;
@@ -28,7 +29,7 @@ use const SWOOLE_VERSION;
 
 class Integration implements IntegrationInterface
 {
-    private static ?string $transaction = null;
+    public const CONTEXT_TRANSACTION = 'sentry.integration.transaction';
 
     public function setupOnce(): void
     {
@@ -90,12 +91,12 @@ class Integration implements IntegrationInterface
 
     public static function getTransaction(): ?string
     {
-        return self::$transaction;
+        return Context::get(self::CONTEXT_TRANSACTION);
     }
 
     public static function setTransaction(?string $transaction): void
     {
-        self::$transaction = $transaction;
+        Context::set(self::CONTEXT_TRANSACTION, $transaction);
     }
 
     /**

--- a/src/sentry/src/Metrics/Listener/OnBeforeHandle.php
+++ b/src/sentry/src/Metrics/Listener/OnBeforeHandle.php
@@ -58,7 +58,7 @@ class OnBeforeHandle implements ListenerInterface
             return;
         }
 
-        Constants::$runningInCommand = true;
+        Constants::setRunningInCommand();
 
         if ($this->feature->isCommandMetricsEnabled() && $this->container->has(EventDispatcherInterface::class)) {
             $this->container->get(EventDispatcherInterface::class)->dispatch(new MetricFactoryReady());

--- a/src/sentry/src/Metrics/Listener/OnMetricFactoryReady.php
+++ b/src/sentry/src/Metrics/Listener/OnMetricFactoryReady.php
@@ -83,7 +83,7 @@ class OnMetricFactoryReady implements ListenerInterface
 
         $serverStatsFactory = null;
 
-        if (! SentryConstants::$runningInCommand) {
+        if (! SentryConstants::runningInCommand()) {
             if ($this->container->has(SwooleServer::class) && $server = $this->container->get(SwooleServer::class)) {
                 if ($server instanceof SwooleServer) {
                     $serverStatsFactory = fn (): array => $server->stats();

--- a/tests/Sentry/CoroutineScopedStateTest.php
+++ b/tests/Sentry/CoroutineScopedStateTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of friendsofhyperf/components.
+ *
+ * @link     https://github.com/friendsofhyperf/components
+ * @document https://github.com/friendsofhyperf/components/blob/main/README.md
+ * @contact  huangdijia@gmail.com
+ */
+
+namespace FriendsOfHyperf\Tests\Sentry;
+
+use FriendsOfHyperf\Sentry\Constants;
+use FriendsOfHyperf\Sentry\Integration;
+use FriendsOfHyperf\Tests\TestCase;
+use Swoole\Coroutine;
+use Swoole\Coroutine\Channel;
+
+/**
+ * Verifies that process-level static state previously shared between requests
+ * is now stored in the coroutine scoped Hyperf\Context\Context.
+ *
+ * Every test method runs inside `Swoole\Coroutine::run()` (see
+ * FriendsOfHyperf\CoPHPUnit\Concerns\RunTestsInCoroutine), so Hyperf
+ * Context values are isolated per coroutine.
+ *
+ * @internal
+ */
+class CoroutineScopedStateTest extends TestCase
+{
+    public function testTransactionCanBeSetAndClearedWithinCoroutine(): void
+    {
+        $this->assertGreaterThan(0, Coroutine::getCid());
+
+        Integration::setTransaction('A');
+        $this->assertSame('A', Integration::getTransaction());
+
+        Integration::setTransaction(null);
+        $this->assertNull(Integration::getTransaction());
+    }
+
+    public function testTransactionIsIsolatedBetweenCoroutines(): void
+    {
+        $values = [];
+        $firstSet = new Channel(1);
+        $secondChecked = new Channel(1);
+        $finished = new Channel(2);
+
+        Coroutine::create(function () use ($firstSet, $secondChecked, $finished, &$values): void {
+            Integration::setTransaction('A');
+            $firstSet->push(true); // Signal that 'A' has been set.
+            $secondChecked->pop(); // Wait until the second coroutine verified its own value.
+            $values['first'] = Integration::getTransaction();
+            $finished->push(true);
+        });
+
+        Coroutine::create(function () use ($firstSet, $secondChecked, $finished, &$values): void {
+            $firstSet->pop(); // Wait until the first coroutine set 'A'.
+            Integration::setTransaction('B');
+            $values['second'] = Integration::getTransaction();
+            $secondChecked->push(true); // Resume the first coroutine.
+            $finished->push(true);
+        });
+
+        $finished->pop();
+        $finished->pop();
+
+        $this->assertSame('A', $values['first']);
+        $this->assertSame('B', $values['second']);
+    }
+
+    public function testRunningInCommandDefaultsToFalseAndCanBeEnabledWithinCoroutine(): void
+    {
+        $this->assertFalse(Constants::runningInCommand());
+
+        Constants::setRunningInCommand();
+        $this->assertTrue(Constants::runningInCommand());
+
+        Constants::setRunningInCommand(false);
+        $this->assertFalse(Constants::runningInCommand());
+    }
+
+    public function testRunningInCommandIsIsolatedBetweenCoroutines(): void
+    {
+        $values = [];
+        $firstSet = new Channel(1);
+        $secondChecked = new Channel(1);
+        $finished = new Channel(2);
+
+        Coroutine::create(function () use ($firstSet, $secondChecked, $finished, &$values): void {
+            Constants::setRunningInCommand();
+            $firstSet->push(true); // Signal that the flag has been set.
+            $secondChecked->pop(); // Wait until the second coroutine verified its own value.
+            $values['first'] = Constants::runningInCommand();
+            $finished->push(true);
+        });
+
+        Coroutine::create(function () use ($firstSet, $secondChecked, $finished, &$values): void {
+            $firstSet->pop(); // Wait until the first coroutine set the flag.
+            $values['second'] = Constants::runningInCommand(); // Unset in this coroutine.
+            $secondChecked->push(true); // Resume the first coroutine.
+            $finished->push(true);
+        });
+
+        $finished->pop();
+        $finished->pop();
+
+        $this->assertTrue($values['first']);
+        $this->assertFalse($values['second']);
+    }
+}


### PR DESCRIPTION
## 问题

`src/sentry` 中存在两处进程级静态可变状态,在 Swoole 协程并发下会互相覆盖并跨请求残留:

1. `Integration::$transaction`(私有静态属性)——`getTransaction()` 在 `setupOnce()` 注册的事件处理器中被读取,决定事件上的 transaction 名;协程 A 写入后协程 B 覆盖,导致事件携带错误的 transaction,且值在请求结束后仍驻留进程。
2. `Constants::$runningInCommand`(公共静态属性)——被 `OnBeforeHandle` 写入、`OnMetricFactoryReady` 读取,同样为进程级共享,协程/请求间相互污染。

## 修改

将两处静态属性改为基于 `Hyperf\Context\Context` 的协程级存储(随协程生命周期自动回收):

- `Integration.php`:删除 `private static ?string $transaction`,新增 `CONTEXT_TRANSACTION` 常量;`getTransaction()`/`setTransaction()` 方法签名与可见性不变,内部改为读写 Context。
- `Constants.php`:删除公共静态属性 `public static bool $runningInCommand`,新增 `CTX_RUNNING_IN_COMMAND` 常量及静态方法 `runningInCommand(): bool`、`setRunningInCommand(bool $running = true): void`。
- `OnBeforeHandle.php`:`Constants::$runningInCommand = true` → `Constants::setRunningInCommand()`。
- `OnMetricFactoryReady.php`:`! SentryConstants::$runningInCommand` → `! SentryConstants::runningInCommand()`。

> ⚠️ BC:公共静态属性 `Constants::$runningInCommand` 被同名静态方法 `Constants::runningInCommand()` 替代,直接读写该属性的外部代码需要改用方法调用(读取 → `runningInCommand()`,写入 → `setRunningInCommand()`)。`Integration::$transaction` 原为私有属性,无外部 BC。

## 测试

新增 `tests/Sentry/CoroutineScopedStateTest.php`(PHPUnit 风格类,经 `FriendsOfHyperf\Tests\TestCase` 的 `RunTestsInCoroutine` trait 在 `Swoole\Coroutine::run()` 内执行),共 4 个用例:

- 协程内 `setTransaction('A')` → `getTransaction() === 'A'`,`setTransaction(null)` → `null`;
- 两个协程通过 Channel 同步:各自读写互不干扰(协程 1 仍读到 'A');
- `runningInCommand()` 默认 `false`,`setRunningInCommand()` 后为 `true`,可再次关闭;
- `runningInCommand` 两个协程间隔离(协程 2 未设置时为 `false`)。

## 验证

- `vendor/bin/pest --group=sentry`(sentry 组全部用例,含新增 4 例):通过(47 passed / 83 assertions);
- `php-cs-fixer fix --dry-run --diff` 改动文件:0 处需修复;
- `git diff --check`:无空白错误;
- `phpstan analyse src/sentry`:No errors;
- 新增测试在旧实现(静态属性)下会失败(`setRunningInCommand()` 不存在 / 协程间互相读到对方值),可有效防止回归。
