### PR TITLE
fix(sentry): flush global telemetry buffers periodically

### DIFF
--- a/src/sentry/publish/sentry.php
+++ b/src/sentry/publish/sentry.php
@@ -44,6 +44,9 @@ return [
     'enable_logs' => env('SENTRY_ENABLE_LOGS', true),
 
     // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#log_flush_threshold
+    // Reaching the threshold triggers an automatic flush, and the telemetry
+    // flush listener also periodically flushes as a fallback. Memory usage
+    // grows linearly with the threshold, so keep it <= 5000.
     'log_flush_threshold' => env('SENTRY_LOG_FLUSH_THRESHOLD') === null ? null : (int) env('SENTRY_LOG_FLUSH_THRESHOLD'),
 
     // @see: https://docs.sentry.io/platforms/php/configuration/options/#before_send_log

--- a/src/sentry/src/ConfigProvider.php
+++ b/src/sentry/src/ConfigProvider.php
@@ -64,6 +64,7 @@ class ConfigProvider
                 Metrics\Listener\OnCoroutineServerStart::class,
                 Metrics\Listener\OnMetricFactoryReady::class,
                 Metrics\Listener\OnWorkerStart::class,
+                Metrics\Listener\TelemetryFlushListener::class,
                 Metrics\Listener\QueueWatcher::class,
                 Metrics\Listener\RedisPoolWatcher::class,
                 Metrics\Listener\RequestWatcher::class,

--- a/src/sentry/src/Feature.php
+++ b/src/sentry/src/Feature.php
@@ -35,6 +35,11 @@ class Feature
         return (bool) $this->config->get('sentry.enable_metrics', $default);
     }
 
+    public function isLogsEnabled(bool $default = true): bool
+    {
+        return (bool) $this->config->get('sentry.enable_logs', $default);
+    }
+
     public function isDefaultMetricsEnabled(bool $default = true): bool
     {
         if (! $this->isMetricsEnabled()) {

--- a/src/sentry/src/Metrics/Listener/TelemetryFlushListener.php
+++ b/src/sentry/src/Metrics/Listener/TelemetryFlushListener.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of friendsofhyperf/components.
+ *
+ * @link     https://github.com/friendsofhyperf/components
+ * @document https://github.com/friendsofhyperf/components/blob/main/README.md
+ * @contact  huangdijia@gmail.com
+ */
+
+namespace FriendsOfHyperf\Sentry\Metrics\Listener;
+
+use FriendsOfHyperf\Sentry\Feature;
+use FriendsOfHyperf\Sentry\Metrics\Event\MetricFactoryReady;
+use Hyperf\Coordinator\Timer;
+use Hyperf\Event\Contract\ListenerInterface;
+use Psr\Container\ContainerInterface;
+use Sentry\Logs\Logs;
+use Sentry\Metrics\TraceMetrics;
+use Sentry\SentrySdk;
+use Throwable;
+
+class TelemetryFlushListener implements ListenerInterface
+{
+    private Timer $timer;
+
+    private bool $ticking = false;
+
+    public function __construct(
+        protected ContainerInterface $container,
+        protected Feature $feature,
+        ?Timer $timer = null,
+    ) {
+        $this->timer = $timer ?? new Timer();
+    }
+
+    public function listen(): array
+    {
+        return [
+            MetricFactoryReady::class,
+        ];
+    }
+
+    /**
+     * @param object|MetricFactoryReady $event
+     */
+    public function process(object $event): void
+    {
+        if ($this->ticking) {
+            return;
+        }
+
+        if (! $this->feature->isMetricsEnabled() && ! $this->feature->isLogsEnabled()) {
+            return;
+        }
+
+        $this->ticking = true;
+
+        $this->timer->tick(
+            $this->feature->getMetricsInterval(),
+            function (): void {
+                // End this tick coroutine's own runtime context (if any), so the
+                // following flush operations target the global context aggregators.
+                SentrySdk::endContext();
+
+                try {
+                    Logs::getInstance()->flush();
+                } catch (Throwable) {
+                }
+
+                try {
+                    TraceMetrics::getInstance()->flush();
+                } catch (Throwable) {
+                }
+            }
+        );
+    }
+}

--- a/tests/Sentry/Metrics/Listener/TelemetryFlushListenerTest.php
+++ b/tests/Sentry/Metrics/Listener/TelemetryFlushListenerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of friendsofhyperf/components.
+ *
+ * @link     https://github.com/friendsofhyperf/components
+ * @document https://github.com/friendsofhyperf/components/blob/main/README.md
+ * @contact  huangdijia@gmail.com
+ */
+
+namespace FriendsOfHyperf\Tests\Sentry\Metrics\Listener;
+
+use FriendsOfHyperf\Sentry\Feature;
+use FriendsOfHyperf\Sentry\Metrics\Event\MetricFactoryReady;
+use FriendsOfHyperf\Sentry\Metrics\Listener\TelemetryFlushListener;
+use Hyperf\Coordinator\Constants;
+use Hyperf\Coordinator\Timer;
+use Mockery as m;
+use Psr\Container\ContainerInterface;
+
+class FakeTimer extends Timer
+{
+    public int $tickCount = 0;
+
+    /**
+     * @var array<int, callable>
+     */
+    public array $closures = [];
+
+    public function tick(float $timeout, callable $closure, string $identifier = Constants::WORKER_EXIT): int
+    {
+        ++$this->tickCount;
+        $this->closures[$this->tickCount] = $closure;
+
+        return $this->tickCount;
+    }
+}
+
+beforeEach(function () {
+    $this->feature = m::mock(Feature::class);
+    $this->feature->shouldReceive('getMetricsInterval')->andReturn(10);
+
+    $this->container = m::mock(ContainerInterface::class);
+    $this->timer = new FakeTimer();
+});
+
+afterEach(function () {
+    m::close();
+});
+
+test('process schedules a single tick for repeated calls', function () {
+    $this->feature->shouldReceive('isMetricsEnabled')->andReturn(true);
+    $this->feature->shouldReceive('isLogsEnabled')->andReturn(true);
+
+    $listener = new TelemetryFlushListener($this->container, $this->feature, $this->timer);
+
+    $listener->process(new MetricFactoryReady());
+    $listener->process(new MetricFactoryReady());
+
+    expect($this->timer->tickCount)->toBe(1);
+});
+
+test('saved tick closure can be invoked without throwing', function () {
+    $this->feature->shouldReceive('isMetricsEnabled')->andReturn(true);
+    $this->feature->shouldReceive('isLogsEnabled')->andReturn(true);
+
+    $listener = new TelemetryFlushListener($this->container, $this->feature, $this->timer);
+    $listener->process(new MetricFactoryReady());
+
+    $closure = $this->timer->closures[1];
+
+    $closure(false);
+
+    expect(true)->toBeTrue();
+});
+
+test('no tick is scheduled when logs and metrics are disabled', function () {
+    $this->feature->shouldReceive('isMetricsEnabled')->andReturn(false);
+    $this->feature->shouldReceive('isLogsEnabled')->andReturn(false);
+
+    $listener = new TelemetryFlushListener($this->container, $this->feature, $this->timer);
+
+    $listener->process(new MetricFactoryReady());
+
+    expect($this->timer->tickCount)->toBe(0);
+});


### PR DESCRIPTION
## 问题

Sentry SDK 的 Logs/Metrics 聚合器归属"当前 runtime context"(见 `vendor/sentry/sentry/src/Logs/Logs.php`、`Metrics/TraceMetrics.php`)。没有 active context 的协程(引擎协程、主进程等)写入 **global context** 的聚合器:

- 默认配置下聚合器是有界环形缓冲(1000 条,`LogsAggregator::LOGS_BUFFER_SIZE`),不会 OOM 但会静默丢弃日志。
- 用户设置 `log_flush_threshold`/`metric_flush_threshold` 后,存储变为无界数组(`Util/TelemetryStorage::unbounded()`),仅在达到阈值时 flush —— 阈值过大时存在内存溢出风险。

## 修改

- 新增 `Metrics\Listener\TelemetryFlushListener`:监听 `MetricFactoryReady`,按 `metrics_interval` 周期 tick,对 global context 的日志/指标聚合器执行 flush 兜底(用 `SentrySdk::endContext()` 结束 tick 协程自身 context 后再 flush,确保落在 global context;每个 flush 独立 try/catch,幂等无副作用)。
- `ConfigProvider` 注册新 listener(默认优先级)。
- `Feature` 新增 `isLogsEnabled(bool $default = true)` 读取 `sentry.enable_logs`,与 `isMetricsEnabled` 保持一致;二者任一开启即启动周期 flush。
- `publish/sentry.php` 为 `log_flush_threshold` 补充注释:达到阈值自动 flush、telemetry flush listener 周期兜底、内存占用与阈值成正比建议 <= 5000(默认值不变)。
- 新增测试 `tests/Sentry/Metrics/Listener/TelemetryFlushListenerTest.php`(FakeTimer 不 spawn 协程):重复 process 只 tick 一次;tick 闭包可安全调用(空聚合器 flush 返回 null);logs/metrics 均关闭时零 tick。

## 测试

- `vendor/bin/pest --group=sentry`:46 passed(基线 43 + 新增 3)。
- `vendor/bin/php-cs-fixer fix --dry-run --diff`:改动文件 0 处可修复。
- `vendor/bin/phpstan analyse src/sentry`:No errors。

## 验证

- `git diff --check` 通过;commit `f848978b`;分支 `sentry-pr/r5` 已推送。
- 未改动其它 listener/transport、默认配置数值及 docs。
