### PR TITLE
fix(sentry): make transport push non-blocking and resilient to consumer failure

### DIFF
--- a/src/sentry/publish/sentry.php
+++ b/src/sentry/publish/sentry.php
@@ -184,7 +184,10 @@ return [
     // Transport configuration
     'transport_channel_size' => (int) env('SENTRY_TRANSPORT_CHANNEL_SIZE', 512),
     'transport_concurrent_limit' => (int) env('SENTRY_TRANSPORT_CONCURRENT_LIMIT', 100),
-    'transport_timeout' => (float) env('SENTRY_TRANSPORT_TIMEOUT', 0),
+    // The max seconds to wait when pushing an event into the transport channel
+    // `<= 0` means non-blocking (skip the event immediately when the channel is full),
+    // `> 0` means wait at most N seconds for the channel to have capacity.
+    'transport_timeout' => (float) env('SENTRY_TRANSPORT_TIMEOUT', 1.0),
 
     'http_timeout' => (float) env('SENTRY_HTTP_TIMEOUT', 2.0),
 ];

--- a/src/sentry/src/Transport/CoHttpTransport.php
+++ b/src/sentry/src/Transport/CoHttpTransport.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace FriendsOfHyperf\Sentry\Transport;
 
 use Hyperf\Contract\ConfigInterface;
+use Hyperf\Contract\StdoutLoggerInterface;
 use Hyperf\Coordinator\Constants;
 use Hyperf\Coordinator\CoordinatorManager;
 use Hyperf\Coroutine\Concurrent;
@@ -42,7 +43,7 @@ class CoHttpTransport implements TransportInterface
 
     protected int $channelSize = 65535;
 
-    protected float $timeout = -1;
+    protected float $timeout = 0;
 
     public function __construct(
         protected ContainerInterface $container,
@@ -58,26 +59,100 @@ class CoHttpTransport implements TransportInterface
             $this->concurrent = new Concurrent($concurrentLimit);
         }
 
-        $timeout = (float) $config->get('sentry.transport_timeout', -1);
-        if ($timeout > 0) {
-            $this->timeout = $timeout;
-        }
+        $this->timeout = $this->resolvePushTimeout();
     }
 
     public function send(Event $event): Result
     {
         $this->loop();
 
-        $chan = $this->chan;
-        // push event to channel, if timeout is set, it will wait for the specified time
-        $result = $chan?->push($event, $this->timeout) ? ResultStatus::success() : ResultStatus::skipped();
+        if ($this->chan === null) {
+            $this->logWarning('Sentry transport channel is not available, the event will be skipped.');
 
-        return new Result($result, $event);
+            return new Result(ResultStatus::skipped(), $event);
+        }
+
+        if (! $this->pushEvent($event)) {
+            $this->logWarning('Sentry transport channel is full, the event will be skipped.');
+
+            return new Result(ResultStatus::skipped(), $event);
+        }
+
+        return new Result(ResultStatus::success(), $event);
     }
 
     public function close(?int $timeout = null): Result
     {
+        $timeout ??= 1;
+
+        $chan = $this->chan;
+
+        if ($chan === null) {
+            return new Result(ResultStatus::success());
+        }
+
+        $startedAt = microtime(true);
+
+        while (! $chan->isEmpty()) {
+            if ((microtime(true) - $startedAt) >= $timeout) {
+                break;
+            }
+
+            msleep(100);
+        }
+
+        $this->closeChannel();
+
         return new Result(ResultStatus::success());
+    }
+
+    /**
+     * Resolve the timeout used when pushing an event into the channel from
+     * the `sentry.transport_timeout` config.
+     *
+     * Swoole Channel::push() semantics: -1 (and any other non-positive
+     * value) blocks until space is available, while a positive value waits
+     * at most N seconds. We map a non-positive config to 0 so that
+     * pushEvent() takes the non-blocking path and senders can never be
+     * suspended indefinitely.
+     */
+    protected function resolvePushTimeout(): float
+    {
+        $timeout = (float) $this->container->get(ConfigInterface::class)->get('sentry.transport_timeout', 0);
+
+        // A non-positive timeout means non-blocking: when the channel is full,
+        // the push returns false immediately and the event is skipped.
+        return $timeout <= 0 ? 0.0 : $timeout;
+    }
+
+    /**
+     * Push an event into the channel.
+     *
+     * When the configured push timeout is not positive the push is
+     * non-blocking: if the channel is full the event is skipped without
+     * suspending the caller coroutine.
+     */
+    protected function pushEvent(Event $event): bool
+    {
+        $chan = $this->chan;
+
+        if ($chan === null) {
+            return false;
+        }
+
+        if ($this->timeout <= 0) {
+            if ($chan->isFull()) {
+                return false;
+            }
+
+            // Swoole Channel::push() treats a non-positive timeout as "block
+            // until space is available", so guard against a full channel and
+            // bound the push with a tiny timeout to cover the race where
+            // another producer fills the channel right after the check.
+            return $chan->push($event, 0.001);
+        }
+
+        return $chan->push($event, $this->timeout);
     }
 
     protected function loop(): void
@@ -93,38 +168,44 @@ class CoHttpTransport implements TransportInterface
         $this->chan = new Channel($this->channelSize);
 
         Coroutine::create(function () {
-            while (true) {
-                $transport = $this->makeHttpTransport();
-                $logger = $this->clientBuilder?->getLogger();
-
+            try {
                 while (true) {
-                    /** @var null|Event|false $event */
-                    $event = $this->chan?->pop();
+                    $transport = $this->makeHttpTransport();
+                    $logger = $this->clientBuilder?->getLogger();
 
-                    if (! $event) {
-                        break 2;
-                    }
+                    while (true) {
+                        /** @var null|Event|false $event */
+                        $event = $this->chan?->pop();
 
-                    try {
-                        $callable = static fn () => $transport->send($event);
-                        if ($this->concurrent !== null) {
-                            $this->concurrent->create($callable);
-                        } else {
-                            Coroutine::create($callable);
+                        if (! $event) {
+                            break 2;
                         }
-                    } catch (Throwable $e) {
-                        $logger?->error('Failed to send event to Sentry: ' . $e->getMessage(), ['exception' => $e]);
-                        $transport->close();
 
-                        break;
-                    } finally {
-                        // Prevent memory leak
-                        $event = null;
+                        try {
+                            $callable = static fn () => $transport->send($event);
+                            if ($this->concurrent !== null) {
+                                $this->concurrent->create($callable);
+                            } else {
+                                Coroutine::create($callable);
+                            }
+                        } catch (Throwable $e) {
+                            $logger?->error('Failed to send event to Sentry: ' . $e->getMessage(), ['exception' => $e]);
+                            $transport->close();
+
+                            break;
+                        } finally {
+                            // Prevent memory leak
+                            $event = null;
+                        }
                     }
                 }
+            } catch (Throwable $e) {
+                // The consumer died (e.g. makeHttpTransport() failed), close the
+                // channel so that send() can rebuild it on the next call.
+                $this->clientBuilder?->getLogger()?->error('Failed to initialize Sentry transport: ' . $e->getMessage(), ['exception' => $e]);
+            } finally {
+                $this->closeChannel();
             }
-
-            $this->closeChannel();
         });
 
         $this->workerWatcher ??= Coroutine::create(function () {
@@ -163,5 +244,20 @@ class CoHttpTransport implements TransportInterface
         if ($this->chan === $chan) {
             $this->chan = null;
         }
+    }
+
+    protected function logWarning(string $message): void
+    {
+        $logger = $this->clientBuilder?->getLogger();
+
+        if ($logger === null) {
+            try {
+                $logger = $this->container->get(StdoutLoggerInterface::class);
+            } catch (Throwable) {
+                // Ignore, the logger is not available.
+            }
+        }
+
+        $logger?->warning($message);
     }
 }

--- a/tests/Sentry/CoHttpTransportTest.php
+++ b/tests/Sentry/CoHttpTransportTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of friendsofhyperf/components.
+ *
+ * @link     https://github.com/friendsofhyperf/components
+ * @document https://github.com/friendsofhyperf/components/blob/main/README.md
+ * @contact  huangdijia@gmail.com
+ */
+
+namespace FriendsOfHyperf\Tests\Sentry;
+
+use FriendsOfHyperf\Sentry\Transport\CoHttpTransport;
+use Hyperf\Config\Config;
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\Engine\Channel;
+use Hyperf\Engine\Coroutine;
+use Mockery;
+use Psr\Container\ContainerInterface;
+use Sentry\Event;
+use Sentry\Transport\ResultStatus;
+use Throwable;
+
+use function Hyperf\Support\msleep;
+
+// The shared vendor autoloader (symlinked to the main checkout) resolves
+// FriendsOfHyperf\Sentry\* to the main checkout's source, so load the
+// worktree's CoHttpTransport explicitly to test the local changes.
+require_once dirname(__DIR__, 2) . '/src/sentry/src/Transport/CoHttpTransport.php';
+
+class CoHttpTransportTestable extends CoHttpTransport
+{
+    public function resolvePushTimeoutForTest(): float
+    {
+        return $this->resolvePushTimeout();
+    }
+
+    public function getTimeoutForTest(): float
+    {
+        return $this->timeout;
+    }
+
+    public function pushEventForTest(Event $event): bool
+    {
+        return $this->pushEvent($event);
+    }
+
+    public function getChanForTest(): ?Channel
+    {
+        return $this->chan;
+    }
+
+    public function setChanForTest(?Channel $chan): void
+    {
+        $this->chan = $chan;
+    }
+
+    protected function loop(): void
+    {
+        // no-op: avoid spawning the consumer and worker watcher coroutines in tests
+    }
+}
+
+function createCoHttpTransportTestable(array $overrides = []): CoHttpTransportTestable
+{
+    $config = new Config([
+        'sentry' => array_merge([
+            'transport_channel_size' => 512,
+            'transport_concurrent_limit' => 100,
+            'transport_timeout' => 0,
+        ], $overrides),
+    ]);
+
+    $container = Mockery::mock(ContainerInterface::class);
+    $container->shouldReceive('get')->with(ConfigInterface::class)->andReturn($config);
+
+    return new CoHttpTransportTestable($container);
+}
+
+function runTestInCoroutine(callable $callback): void
+{
+    $exception = null;
+
+    \Swoole\Coroutine\run(function () use ($callback, &$exception) {
+        try {
+            $callback();
+        } catch (Throwable $e) {
+            $exception = $e;
+        }
+    });
+
+    if ($exception !== null) {
+        throw $exception;
+    }
+}
+
+test('resolvePushTimeout returns non-blocking timeout for non-positive values', function () {
+    runTestInCoroutine(function () {
+        $transport = createCoHttpTransportTestable(['transport_timeout' => 0]);
+        expect($transport->resolvePushTimeoutForTest())->toBe(0.0);
+
+        $transport = createCoHttpTransportTestable(['transport_timeout' => -1]);
+        expect($transport->resolvePushTimeoutForTest())->toBe(0.0);
+
+        $transport = createCoHttpTransportTestable(['transport_timeout' => 1.5]);
+        expect($transport->resolvePushTimeoutForTest())->toBe(1.5);
+    });
+});
+
+test('constructor maps non-positive transport_timeout to a non-blocking push timeout', function () {
+    runTestInCoroutine(function () {
+        $transport = createCoHttpTransportTestable(['transport_timeout' => -1]);
+        expect($transport->getTimeoutForTest())->toBe(0.0);
+
+        $transport = createCoHttpTransportTestable(['transport_timeout' => 2]);
+        expect($transport->getTimeoutForTest())->toBe(2.0);
+    });
+});
+
+test('send returns skipped without blocking when the channel is full', function () {
+    runTestInCoroutine(function () {
+        $transport = createCoHttpTransportTestable([
+            'transport_channel_size' => 1,
+            'transport_timeout' => 0,
+        ]);
+        $transport->setChanForTest(new Channel(1));
+
+        // Fill the channel first, the next push must not block and must fail.
+        expect($transport->pushEventForTest(Event::createEvent()))->toBeTrue();
+
+        $result = $transport->send(Event::createEvent());
+        expect($result->getStatus())->toBe(ResultStatus::skipped());
+    });
+});
+
+test('send returns skipped when the channel is missing', function () {
+    runTestInCoroutine(function () {
+        $transport = createCoHttpTransportTestable();
+        $transport->setChanForTest(null);
+
+        $result = $transport->send(Event::createEvent());
+        expect($result->getStatus())->toBe(ResultStatus::skipped());
+    });
+});
+
+test('send returns success when the channel has capacity', function () {
+    runTestInCoroutine(function () {
+        $transport = createCoHttpTransportTestable([
+            'transport_channel_size' => 2,
+            'transport_timeout' => 0,
+        ]);
+        $transport->setChanForTest(new Channel(2));
+
+        $result = $transport->send(Event::createEvent());
+        expect($result->getStatus())->toBe(ResultStatus::success());
+    });
+});
+
+test('close waits for the channel to drain and then closes it', function () {
+    runTestInCoroutine(function () {
+        $transport = createCoHttpTransportTestable([
+            'transport_channel_size' => 8,
+            'transport_timeout' => 0,
+        ]);
+        $chan = new Channel(8);
+        $transport->setChanForTest($chan);
+
+        $chan->push(Event::createEvent());
+        $chan->push(Event::createEvent());
+
+        // Drain the channel slowly in a background coroutine.
+        Coroutine::create(function () use ($chan) {
+            while ($chan->pop(1) !== false) {
+                msleep(50);
+            }
+        });
+
+        $startedAt = microtime(true);
+        $result = $transport->close(1);
+        $elapsed = microtime(true) - $startedAt;
+
+        expect($result->getStatus())->toBe(ResultStatus::success());
+        // It waited for the backlog to be drained instead of closing immediately.
+        expect($elapsed)->toBeGreaterThanOrEqual(0.04);
+        // It did not block beyond the given timeout.
+        expect($elapsed)->toBeLessThan(2.0);
+        expect($transport->getChanForTest())->toBeNull();
+    });
+});
+
+test('close returns success when the channel does not exist', function () {
+    runTestInCoroutine(function () {
+        $transport = createCoHttpTransportTestable();
+        $transport->setChanForTest(null);
+
+        $result = $transport->close(1);
+        expect($result->getStatus())->toBe(ResultStatus::success());
+    });
+});


### PR DESCRIPTION
## 问题

`CoHttpTransport` 通过有限容量 Channel(发布配置默认 512)缓冲事件,但存在两类永久阻塞风险,会导致请求协程无法结束、协程数量无界堆积 → OOM:

1. **push 超时语义错误**:`send()` 中 `$chan?->push($event, $this->timeout)` 在通道满时,若 `transport_timeout <= 0`,内部超时保持 `-1`(永久阻塞)。请求协程在协程结束时 flush 会卡死,协程数无界增长。
2. **消费协程异常死亡无兜底**:`loop()` 里 `makeHttpTransport()` 在 try 之外,一旦抛异常消费协程直接死亡,channel 永远无人消费,所有后续 `send()` 永久阻塞。
3. `close()` 为空实现,不会等待通道排空。

## 修改

- **push 超时改为安全默认**:构造函数解析 `sentry.transport_timeout`,`<= 0` 时内部超时为 `0`(非阻塞,通道满立即跳过事件),`> 0` 时最多等待 N 秒。超时计算提取为 protected 方法 `resolvePushTimeout()`。
  - 注:Swoole 6.x 中 `Channel::push($data, 0)` 实际会被当作"无限等待"(源码 `wait_push` 仅在 `timeout > 0` 时注册定时器),因此 `pushEvent()` 在非阻塞模式下先用 `isFull()` 短路跳过,并以极小正超时(`0.001s`)兜底竞态,保证调用方协程绝不挂起。
- **消费协程异常兜底**:`loop()` 消费协程主体(`makeHttpTransport`、pop、派发)包进 `try/catch(Throwable)`,catch 中通过 `$this->clientBuilder?->getLogger()` 记录日志,`finally` 中 `closeChannel()`;`closeChannel()` 幂等,通道关闭后 `send()` 自愈(`loop()` 检测 chan 为 null 时重建)。
- **`close()` 支持排空**:等待通道排空(最多 `$timeout` 秒,默认 1 秒,`while (! $chan->isEmpty()) msleep(...)` + 超时判断,与 workerWatcher 风格一致),然后 `closeChannel()` 返回 success;通道不存在时直接 success。
- **send() 失败路径告警**:chan 为 null 或 push 失败时打 warning 日志(优先 `clientBuilder` 的 logger,否则通过容器解析 `StdoutLoggerInterface`,容器解析失败则忽略)。
- **发布配置**:`publish/sentry.php` 中 `transport_timeout` 默认值改为 `1.0`,并注释说明 `<= 0` 表示非阻塞、`> 0` 表示最多等待 N 秒;`channel_size`/`concurrent_limit` 及其余配置不变。

## 测试

新增 `tests/Sentry/CoHttpTransportTest.php`(Pest,`Swoole\Coroutine\run` 包裹,通过子类覆盖 `loop()` 避免真实协程与 HTTP 发送),覆盖:

- `resolvePushTimeout` 决策:`<= 0 → 0`、`> 0 → 原值`;
- 构造器把 `transport_timeout <= 0` 映射为非阻塞超时;
- 通道满时 `send()` 不阻塞并返回 `skipped`;
- 通道不存在时 `send()` 返回 `skipped`;
- 通道有空位时 `send()` 返回 `success`;
- `close()` 在通道有积压时等待排空后关闭,不阻塞超时;
- `close()` 在通道不存在时直接 success。

结果:

```bash
vendor/bin/pest tests/Sentry   # 50 passed (88 assertions),连续多次运行一致
```

说明:worktree 的 `vendor` 是指向主 checkout 的符号链接,其 composer autoloader 会把 `FriendsOfHyperf\Sentry\*` 解析到主 checkout 源码,且全量加载时存在预置的 `TestEnum` 重复声明问题(与本次改动无关),故以 `tests/Sentry` 目录方式运行(与 `--group=sentry` 覆盖相同的 43 个既有用例 + 7 个新增)。测试文件顶部显式 `require_once` worktree 的 `CoHttpTransport.php` 以测试本地改动。

## 验证

- `vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --dry-run --diff`(仅本次 3 个文件):0 处待修复。
- `git diff --check`:无错误。
- `composer analyse src/sentry`(PHPStan):按要求未运行。
