### PR TITLE
fix(sentry): 兼容无效的 Redis 集群槽位响应

### DIFF
--- a/src/sentry/src/Tracing/Aspect/RedisConnectionAspect.php
+++ b/src/sentry/src/Tracing/Aspect/RedisConnectionAspect.php
@@ -66,14 +66,15 @@ class RedisConnectionAspect extends AbstractAspect
 
     private function getClusterNodeBySlot(RedisCluster $rc, string $key)
     {
-        // $slot = $rc->cluster('CLUSTER', 'KEYSLOT', $key);
         $slot = RedisClusterKeySlot::get($key);
-        $slots = ($this->slotNodeCache[$rc] ??= $rc->cluster('CLUSTER', 'SLOTS')); // @phpstan-ignore-line
+        $slots = (array) ($this->slotNodeCache[$rc] ??= $rc->cluster('CLUSTER', 'SLOTS')); // @phpstan-ignore-line
 
         foreach ($slots as $range) {
+            if (! is_array($range) || count($range) < 3) {
+                continue;
+            }
             [$start, $end, $master] = $range;
             if ($slot >= $start && $slot <= $end) {
-                // $master = [host, port, nodeId]
                 return [
                     'host' => $master[0],
                     'port' => $master[1],


### PR DESCRIPTION
## Summary
- 安全处理 Redis 集群槽位查询返回的非数组结果
- 跳过结构不完整的槽位范围，避免解构异常

## Background
- `RedisCluster::cluster()` 返回类型为 mixed，槽位查询失败或返回异常结构时，现有遍历和解构逻辑可能产生运行时告警

## Changes
- 将槽位查询结果归一为数组后再遍历
- 在解构前校验槽位范围为数组且至少包含三个元素
- 移除已失效的注释代码

## Test Plan
- `vendor/bin/pest --group sentry`（43 passed）
- `vendor/bin/phpstan analyse --memory-limit=-1 src/sentry/src/Tracing/Aspect/RedisConnectionAspect.php`
- `vendor/bin/php-cs-fixer fix --dry-run --diff --ansi src/sentry/src/Tracing/Aspect/RedisConnectionAspect.php`
- `git diff --check`

## Risks
- 仅影响 Sentry RedisCluster 节点地址追踪；合法的 `CLUSTER SLOTS` 响应处理保持不变
- 异常槽位数据将被跳过，追踪上下文可能不包含节点地址，但不会影响原 Redis 命令结果

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 改进 Redis 集群槽位信息的处理，避免因缓存数据格式异常导致解析错误。
  - 自动跳过无效或不完整的槽位范围数据，提升连接处理的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->